### PR TITLE
Add random settler generation and population view styling

### DIFF
--- a/src/data/names.js
+++ b/src/data/names.js
@@ -1,22 +1,38 @@
-export const firstNames = [
-  'Alex',
-  'Maya',
-  'Jan',
-  'Anna',
-  'Piotr',
-  'Olga',
-  'John',
-  'Zoe',
+export const FIRST_NAMES = {
+  M: [
+    'James', 'John', 'Robert', 'Michael', 'William',
+    'David', 'Richard', 'Joseph', 'Thomas', 'Charles',
+    'Christopher', 'Daniel', 'Matthew', 'Anthony', 'Mark',
+    'Donald', 'Steven', 'Paul', 'Andrew', 'Joshua',
+  ],
+  F: [
+    'Mary', 'Patricia', 'Jennifer', 'Linda', 'Elizabeth',
+    'Barbara', 'Susan', 'Jessica', 'Sarah', 'Karen',
+    'Nancy', 'Lisa', 'Margaret', 'Betty', 'Sandra',
+    'Ashley', 'Kimberly', 'Emily', 'Donna', 'Michelle',
+  ],
+}
+
+export const LAST_NAMES = [
+  'Smith', 'Johnson', 'Williams', 'Brown', 'Jones',
+  'Garcia', 'Miller', 'Davis', 'Rodriguez', 'Martinez',
+  'Hernandez', 'Lopez', 'Gonzalez', 'Wilson', 'Anderson',
+  'Thomas', 'Taylor', 'Moore', 'Jackson', 'Martin',
 ]
 
-export const lastNames = [
-  'Smith',
-  'Kowalski',
-  'Nowak',
-  'Brown',
-  'Evans',
-  'Kaczmarek',
-  'Taylor',
-  'Wójcik',
-]
-
+export function makeRandomSettler({ sex } = {}) {
+  const chosenSex = sex || (Math.random() < 0.5 ? 'M' : 'F')
+  const firstPool = FIRST_NAMES[chosenSex]
+  const firstName = firstPool[Math.floor(Math.random() * firstPool.length)]
+  const lastName = LAST_NAMES[Math.floor(Math.random() * LAST_NAMES.length)]
+  return {
+    id: crypto.randomUUID ? crypto.randomUUID() : Date.now().toString(),
+    firstName,
+    lastName,
+    sex: chosenSex,
+    age: 18,
+    role: 'idle',
+    skills: { farming: 0, scavenging: 0 },
+    morale: 50,
+  }
+}

--- a/src/state/GameContext.jsx
+++ b/src/state/GameContext.jsx
@@ -2,29 +2,13 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { GameContext } from './useGame.js'
 import useGameLoop from '../engine/useGameLoop.js'
 import { saveGame, loadGame } from '../engine/persistence.js'
-import { firstNames, lastNames } from '../data/names.js'
-
-function createSettler() {
-  const first = firstNames[Math.floor(Math.random() * firstNames.length)]
-  const last = lastNames[Math.floor(Math.random() * lastNames.length)]
-  const gender = Math.random() < 0.5 ? 'male' : 'female'
-  return {
-    id: crypto.randomUUID ? crypto.randomUUID() : Date.now().toString(),
-    firstName: first,
-    lastName: last,
-    gender,
-    age: 18,
-    role: 'idle',
-    morale: 50,
-    skills: {},
-  }
-}
+import { makeRandomSettler } from '../data/names.js'
 
 const defaultState = {
   gameTime: 0,
   ui: { activeTab: 'base', drawerOpen: false },
   resources: { scrap: 0, food: 0 },
-  population: [createSettler()],
+  population: { settlers: [makeRandomSettler()] },
   buildings: {},
   log: [],
 }
@@ -53,13 +37,13 @@ export function GameProvider({ children }) {
 
   const setSettlerRole = useCallback((id, role) => {
     setState((prev) => {
-      const population = prev.population.map((s) =>
+      const settlers = prev.population.settlers.map((s) =>
         s.id === id ? { ...s, role } : s,
       )
-      const settler = prev.population.find((s) => s.id === id)
+      const settler = prev.population.settlers.find((s) => s.id === id)
       const entry = `${settler.firstName} ${settler.lastName} is now ${role}`
       const log = [entry, ...prev.log].slice(0, 100)
-      return { ...prev, population, log }
+      return { ...prev, population: { ...prev.population, settlers }, log }
     })
   }, [])
 

--- a/src/views/PopulationView.jsx
+++ b/src/views/PopulationView.jsx
@@ -5,26 +5,45 @@ export default function PopulationView() {
 
   return (
     <div className="p-4 space-y-4 pb-20">
-      {state.population.map((s) => (
+      {state.population.settlers.map((s) => (
         <div
           key={s.id}
-          className="border border-stroke rounded p-2 space-y-1"
+          className="border border-stroke rounded p-3 bg-bg2/50 flex flex-col gap-2"
         >
           <div className="font-semibold">
             {s.firstName} {s.lastName}
           </div>
-          <div className="text-sm text-muted">
-            {s.gender}, {s.age}
+          <div className="flex flex-wrap items-center gap-2 text-sm text-muted">
+            <span
+              className={`px-2 py-0.5 rounded text-xs text-white ${
+                s.sex === 'M' ? 'bg-blue-700' : 'bg-pink-700'
+              }`}
+            >
+              {s.sex}
+            </span>
+            <span>Age {s.age}</span>
+            <span className="px-2 py-0.5 rounded bg-green-700 text-white text-xs">
+              Farm {s.skills.farming}
+            </span>
+            <span className="px-2 py-0.5 rounded bg-yellow-700 text-white text-xs">
+              Scav {s.skills.scavenging}
+            </span>
+            <span>Morale {s.morale}%</span>
           </div>
-          <select
-            value={s.role}
-            onChange={(e) => setSettlerRole(s.id, e.target.value)}
-            className="mt-1 p-1 rounded bg-bg2 border border-stroke"
-          >
-            <option value="idle">idle</option>
-            <option value="food">food</option>
-            <option value="scrap">scrap</option>
-          </select>
+          <div className="relative inline-block w-36">
+            <select
+              value={s.role}
+              onChange={(e) => setSettlerRole(s.id, e.target.value)}
+              className="appearance-none w-full rounded bg-gray-800 text-white px-3 py-2 pr-8 hover:bg-gray-700 focus:outline-none"
+            >
+              <option value="idle">idle</option>
+              <option value="farming">farming</option>
+              <option value="scavenging">scavenging</option>
+            </select>
+            <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+              <span className="w-2 h-2 border-r-2 border-b-2 border-white rotate-45" />
+            </span>
+          </div>
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- generate settlers using gender-specific first and last name lists
- initialize game with one random settler and support role changes
- show detailed settler info with styled role dropdown in Population view

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899cd23f87883318dfc1c09b597cb75