### PR TITLE
Add autosave, offline progress, and reset colony option

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { GameProvider } from './state/GameContext.jsx'
 import TopBar from './components/TopBar.jsx'
 import BottomDock from './components/BottomDock.jsx'
 import Drawer from './components/Drawer.jsx'
+import OfflineProgressModal from './components/OfflineProgressModal.jsx'
 import BaseView from './views/BaseView.jsx'
 import PopulationView from './views/PopulationView.jsx'
 import ResearchView from './views/ResearchView.jsx'
@@ -32,6 +33,7 @@ export default function App() {
         </div>
         <BottomDock />
         <Drawer />
+        <OfflineProgressModal />
       </div>
     </GameProvider>
   )

--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -2,7 +2,7 @@ import { useGame } from '../state/useGame.js'
 import { saveGame, loadGame } from '../engine/persistence.js'
 
 export default function Drawer() {
-  const { state, toggleDrawer, setState } = useGame()
+  const { state, toggleDrawer, setState, resetGame } = useGame()
 
   return (
     <>
@@ -27,7 +27,7 @@ export default function Drawer() {
             <div className="flex gap-2">
               <button
                 className="px-2 py-1 rounded border border-stroke"
-                onClick={() => saveGame(state)}
+                onClick={() => setState(saveGame(state))}
               >
                 Save
               </button>
@@ -41,6 +41,15 @@ export default function Drawer() {
                 Load
               </button>
             </div>
+          </section>
+          <section>
+            <h2 className="font-semibold mb-2">🧹 Reset</h2>
+            <button
+              className="px-2 py-1 rounded border border-stroke"
+              onClick={resetGame}
+            >
+              Reset colony
+            </button>
           </section>
         </div>
       </aside>

--- a/src/components/OfflineProgressModal.jsx
+++ b/src/components/OfflineProgressModal.jsx
@@ -1,0 +1,41 @@
+import { useGame } from '../state/useGame.js'
+
+function formatTime(seconds) {
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  const s = seconds % 60
+  const parts = []
+  if (h) parts.push(`${h}h`)
+  if (m) parts.push(`${m}m`)
+  if (s || parts.length === 0) parts.push(`${s}s`)
+  return parts.join(' ')
+}
+
+export default function OfflineProgressModal() {
+  const { state, dismissOfflineModal } = useGame()
+  const info = state.ui.offlineProgress
+  if (!info) return null
+
+  const { elapsed, gains } = info
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-bg2 p-4 rounded border border-stroke max-w-sm w-full space-y-4">
+        <h2 className="font-semibold text-lg">While you were away...</h2>
+        <p>You were gone for {formatTime(elapsed)}</p>
+        <div className="space-y-1">
+          {Object.entries(gains).map(([res, amt]) => (
+            <div key={res}>
+              {res}: {Math.floor(amt)}
+            </div>
+          ))}
+        </div>
+        <button
+          className="px-4 py-2 rounded border border-stroke"
+          onClick={dismissOfflineModal}
+        >
+          Continue
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/engine/persistence.js
+++ b/src/engine/persistence.js
@@ -2,9 +2,12 @@ const STORAGE_KEY = 'apocalypse-idle-save'
 
 export function saveGame(state) {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+    const data = { ...state, lastSaved: Date.now() }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+    return data
   } catch (err) {
     console.error('Save failed', err)
+    return state
   }
 }
 
@@ -15,6 +18,14 @@ export function loadGame() {
   } catch (err) {
     console.error('Load failed', err)
     return null
+  }
+}
+
+export function deleteSave() {
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch (err) {
+    console.error('Delete failed', err)
   }
 }
 

--- a/src/engine/production.js
+++ b/src/engine/production.js
@@ -1,6 +1,35 @@
-// Stub for future resource production/consumption system
-export function processTick(state) {
-  // Production logic will go here later
-  return state
+export function getProductionRates(state) {
+  const rates = { food: 0, scrap: 0 }
+  const settlers = state.population?.settlers ?? []
+  settlers.forEach((s) => {
+    if (s.role === 'farming') rates.food += 1 + s.skills.farming * 0.1
+    if (s.role === 'scavenging') rates.scrap += 1 + s.skills.scavenging * 0.1
+  })
+  const buildings = state.buildings || {}
+  Object.values(buildings).forEach((b) => {
+    if (b.resource && b.rate) {
+      rates[b.resource] = (rates[b.resource] || 0) + b.rate * (b.count || 1)
+    }
+  })
+  return rates
 }
 
+export function processTick(state, seconds = 1) {
+  const rates = getProductionRates(state)
+  const resources = { ...state.resources }
+  Object.entries(rates).forEach(([res, rate]) => {
+    resources[res] = (resources[res] || 0) + rate * seconds
+  })
+  return { ...state, resources }
+}
+
+export function applyOfflineProgress(state, elapsedSeconds) {
+  if (elapsedSeconds <= 0) return { state, gains: {} }
+  const nextState = processTick(state, elapsedSeconds)
+  const gains = {}
+  Object.keys(nextState.resources).forEach((res) => {
+    const gain = nextState.resources[res] - (state.resources[res] || 0)
+    if (gain > 0) gains[res] = gain
+  })
+  return { state: nextState, gains }
+}

--- a/src/state/defaultState.js
+++ b/src/state/defaultState.js
@@ -1,0 +1,11 @@
+import { makeRandomSettler } from '../data/names.js'
+
+export const defaultState = {
+  gameTime: 0,
+  ui: { activeTab: 'base', drawerOpen: false, offlineProgress: null },
+  resources: { scrap: 0, food: 0 },
+  population: { settlers: [makeRandomSettler()] },
+  buildings: {},
+  log: [],
+  lastSaved: Date.now(),
+}


### PR DESCRIPTION
## Summary
- Persist game state with timestamped autosaves and deletion support
- Track resource generation and apply offline progress on load
- Provide modal feedback for offline gains and reset option via menu

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6899d2ec27608331a6780d8b9f30514c