### PR TITLE
Align season counter left and lengthen day

### DIFF
--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -9,7 +9,7 @@ export default function TopBar() {
 
   return (
     <header className="flex items-center justify-between px-4 py-2 border-b border-stroke bg-bg2">
-      <div className="flex flex-col items-center leading-tight">
+      <div className="flex flex-col items-start leading-tight">
         <span className="text-xl">
           {season.icon} {season.label}: Day {day}
         </span>

--- a/src/engine/time.js
+++ b/src/engine/time.js
@@ -1,4 +1,4 @@
-export const SECONDS_PER_DAY = 1 // easy customization of day length
+export const SECONDS_PER_DAY = 3 // easy customization of day length
 
 const DEFAULT_SEASONS = [
   {


### PR DESCRIPTION
## Summary
- Align season/day counter with header's left edge
- Extend in-game day duration to three seconds

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899e5c36b508331b2c2170183f5fb27