### PR TITLE
Add year tracking and season tooltip

### DIFF
--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -1,30 +1,48 @@
-import { getSeasonModifiers } from '../engine/time.js'
+import { useState } from 'react'
+import { getSeasonModifiers, getTimeBreakdown } from '../engine/time.js'
 import { useGame } from '../state/useGame.js'
 
 export default function TopBar() {
-  const { state, toggleDrawer, selectSeason, selectSeasonDay } = useGame()
-  const season = selectSeason()
-  const day = selectSeasonDay()
+  const { state, toggleDrawer } = useGame()
+  const time = getTimeBreakdown(state)
   const modifiers = getSeasonModifiers(state)
+  const [open, setOpen] = useState(false)
+
+  const labels = { farmingSpeed: 'Growth', farmingYield: 'Yield' }
 
   return (
     <header className="flex items-center justify-between px-4 py-2 border-b border-stroke bg-bg2">
-      <div className="flex flex-col items-start leading-tight">
-        <span className="text-xl">
-          {season.icon} {season.label}: Day {day}
-        </span>
-        <span className="text-xs opacity-80">
-          Growth x{modifiers.farmingSpeed.toFixed(1)} • Yield x
-          {modifiers.farmingYield.toFixed(1)}
-        </span>
-      </div>
+      <span className="tabular-nums text-xl">Year {time.year}</span>
       <h1 className="font-semibold">Apocalypse Idle</h1>
-      <button
-        className="text-xl px-2 py-1 rounded border border-stroke"
-        onClick={toggleDrawer}
-      >
-        ☰
-      </button>
+      <div className="relative flex items-center gap-2">
+        <button
+          className="text-xl tabular-nums"
+          onClick={() => setOpen((o) => !o)}
+          onMouseEnter={() => setOpen(true)}
+          onMouseLeave={() => setOpen(false)}
+        >
+          {time.season.icon} {time.season.label}, Day {time.dayInSeason}
+        </button>
+        {open && (
+          <div
+            className="absolute top-full right-0 mt-1 p-2 bg-bg2 border border-stroke rounded text-xs shadow-lg"
+            onMouseEnter={() => setOpen(true)}
+            onMouseLeave={() => setOpen(false)}
+          >
+            {Object.entries(modifiers).map(([key, val]) => (
+              <div key={key} className="whitespace-nowrap">
+                {(labels[key] || key)} x{val.toFixed(1)}
+              </div>
+            ))}
+          </div>
+        )}
+        <button
+          className="text-xl px-2 py-1 rounded border border-stroke"
+          onClick={toggleDrawer}
+        >
+          ☰
+        </button>
+      </div>
     </header>
   )
 }

--- a/src/state/defaultState.js
+++ b/src/state/defaultState.js
@@ -2,7 +2,7 @@ import { makeRandomSettler } from '../data/names.js'
 import { initSeasons } from '../engine/time.js'
 
 export const defaultState = {
-  gameTime: { seconds: 0 },
+  gameTime: { seconds: 0, year: 1 },
   meta: { seasons: initSeasons() },
   ui: { activeTab: 'base', drawerOpen: false, offlineProgress: null },
   resources: {


### PR DESCRIPTION
## Summary
- track game year derived from season durations
- age settlers each time a year passes
- show current year and season tooltip in top bar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899e95981b08331862838d7cf84a344