### PR TITLE
feat: round and abbreviate resource amounts

### DIFF
--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -4,7 +4,9 @@ export function formatRate({ amountPerHarvest, intervalSec }) {
 }
 
 export function formatAmount(n) {
-  if (n >= 1000000) return `${(n / 1000000).toFixed(1)}m`
-  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`
-  return `${n}`
+  const rounded = Math.round(n)
+  if (rounded >= 1000000)
+    return `${parseFloat((rounded / 1000000).toFixed(1))}m`
+  if (rounded >= 1000) return `${parseFloat((rounded / 1000).toFixed(1))}k`
+  return `${rounded}`
 }


### PR DESCRIPTION
## Summary
- Round resource amounts to whole numbers before formatting
- Show large resource values in shorthand (2k, 2.2k, etc.)

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899f55306a08331b23cbe5db9b1592e