### PR TITLE
Refactor season modifiers for resource-key overrides

### DIFF
--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -8,7 +8,8 @@ export default function TopBar() {
   const modifiers = getSeasonModifiers(state)
   const [open, setOpen] = useState(false)
 
-  const labels = { farmingSpeed: 'Growth', farmingYield: 'Yield' }
+  const first = Object.values(modifiers)[0] || { speed: 1, yield: 1 }
+  const labels = { speed: 'Growth', yield: 'Yield' }
 
   return (
     <header className="flex items-center justify-between px-4 py-2 border-b border-stroke bg-bg2">
@@ -29,7 +30,7 @@ export default function TopBar() {
             onMouseEnter={() => setOpen(true)}
             onMouseLeave={() => setOpen(false)}
           >
-            {Object.entries(modifiers).map(([key, val]) => (
+            {Object.entries(first).map(([key, val]) => (
               <div key={key} className="whitespace-nowrap">
                 {(labels[key] || key)} x{val.toFixed(1)}
               </div>

--- a/src/engine/__tests__/persistence.test.js
+++ b/src/engine/__tests__/persistence.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeEach } from 'vitest'
-import { saveGame, loadGame, deleteSave, SCHEMA_VERSION } from '../persistence.js'
+import { saveGame, loadGame, SCHEMA_VERSION } from '../persistence.js'
 
 describe('persistence engine', () => {
   beforeEach(() => {

--- a/src/engine/__tests__/production.test.js
+++ b/src/engine/__tests__/production.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi, beforeEach } from 'vitest'
 import * as prod from '../production.js'
 import * as time from '../time.js'
+import { BUILDINGS } from '../../data/buildings.js'
 
 const baseState = {
   resources: {
@@ -29,12 +30,35 @@ describe('production engine', () => {
       buildings: { potatoField: { count: 1 } },
       timers: { food: { potatoField: 0 } },
     }
-    vi.spyOn(time, 'getSeasonModifiers').mockReturnValue({
-      farmingSpeed: 0.5,
-      farmingYield: 2,
+    vi.spyOn(time, 'getSeason').mockReturnValue({
+      id: 'test',
+      modifiers: { food: { speed: 0.5, yield: 2 } },
     })
     const next = prod.processTick(state, 1)
     expect(next.resources.food.amount).toBe(20)
+  })
+
+  test('parity for existing buildings across seasons', () => {
+    const seasons = [
+      { id: 'spring', modifiers: { food: { speed: 0.8, yield: 1.1 }, wood: { speed: 0.8, yield: 1.1 } } },
+      { id: 'summer', modifiers: { food: { speed: 1.0, yield: 1.0 }, wood: { speed: 1.0, yield: 1.0 } } },
+      { id: 'autumn', modifiers: { food: { speed: 1.1, yield: 1.0 }, wood: { speed: 1.1, yield: 1.0 } } },
+      { id: 'winter', modifiers: { food: { speed: 2.0, yield: 0.0 }, wood: { speed: 2.0, yield: 0.0 } } },
+    ]
+    const building = BUILDINGS.find((b) => b.id === 'potatoField')
+    const base = {
+      ...makeState(),
+      buildings: { potatoField: { count: 1 } },
+      timers: { food: { potatoField: 0 } },
+    }
+    const getSeasonSpy = vi.spyOn(time, 'getSeason')
+    seasons.forEach((season) => {
+      getSeasonSpy.mockReturnValue(season)
+      const next = prod.processTick(base, 1)
+      const mods = season.modifiers.food
+      const expected = building.harvestAmount * mods.yield * building.yieldValue
+      expect(next.resources.food.amount).toBe(expected)
+    })
   })
 
   test('clamps resources to capacity', () => {
@@ -72,5 +96,44 @@ describe('production engine', () => {
     const next = prod.demolishBuilding(state, 'potatoField')
     expect(next.buildings.potatoField.count).toBe(0)
     expect(next.resources.wood.amount).toBe(5)
+  })
+
+  test('seasonal mode ignore removes winter penalty', () => {
+    const farm = BUILDINGS.find((b) => b.id === 'potatoField')
+    const original = farm.seasonal
+    farm.seasonal = { mode: 'ignore' }
+    const season = { id: 'winter', modifiers: { food: { speed: 2, yield: 0 } } }
+    vi.spyOn(time, 'getSeason').mockReturnValue(season)
+    const state = {
+      ...makeState(),
+      buildings: { potatoField: { count: 1 } },
+      timers: { food: { potatoField: 0 } },
+    }
+    const next = prod.processTick(state, 1)
+    expect(next.resources.food.amount).toBe(
+      farm.harvestAmount * farm.yieldValue,
+    )
+    farm.seasonal = original
+  })
+
+  test('seasonal mode custom overrides global modifier', () => {
+    const farm = BUILDINGS.find((b) => b.id === 'potatoField')
+    const original = farm.seasonal
+    farm.seasonal = {
+      mode: 'custom',
+      modifiers: { winter: { food: 1.0 } },
+    }
+    const season = { id: 'winter', modifiers: { food: { speed: 2, yield: 0 } } }
+    vi.spyOn(time, 'getSeason').mockReturnValue(season)
+    const state = {
+      ...makeState(),
+      buildings: { potatoField: { count: 1 } },
+      timers: { food: { potatoField: 0 } },
+    }
+    const next = prod.processTick(state, 1)
+    expect(next.resources.food.amount).toBe(
+      farm.harvestAmount * farm.yieldValue,
+    )
+    farm.seasonal = original
   })
 })

--- a/src/engine/production.js
+++ b/src/engine/production.js
@@ -1,5 +1,5 @@
 import { BUILDINGS } from '../data/buildings.js'
-import { getSeasonModifiers } from './time.js'
+import { getSeason, getSeasonMultiplier } from './time.js'
 import { getCapacity } from '../state/selectors.js'
 
 export function getProductionRates(state) {
@@ -38,7 +38,7 @@ export function processTick(state, seconds = 1) {
     resources[res] = { amount: nextAmount, capacity, stocks }
   })
 
-  const mods = getSeasonModifiers(state)
+  const season = getSeason(state)
   const timers = { ...state.timers }
 
   BUILDINGS.forEach((b) => {
@@ -46,8 +46,9 @@ export function processTick(state, seconds = 1) {
     if (count <= 0 || !b.growthTime) return
     const resId = b.resource
     const type = b.type
-    const effectiveGrowth = b.growthTime * mods.farmingSpeed
-    const effectiveHarvest = b.harvestAmount * mods.farmingYield * b.yieldValue
+    const mods = getSeasonMultiplier(season, resId, b)
+    const effectiveGrowth = b.growthTime * mods.speed
+    const effectiveHarvest = b.harvestAmount * mods.yield * b.yieldValue
     const group = { ...(timers[resId] || {}) }
     let timer = (group[b.id] ?? effectiveGrowth) - seconds
     let cycles = 0

--- a/src/engine/time.js
+++ b/src/engine/time.js
@@ -6,28 +6,40 @@ const DEFAULT_SEASONS = [
     label: 'Spring',
     icon: '🌱',
     days: 90,
-    modifiers: { farmingSpeed: 0.8, farmingYield: 1.1 },
+    modifiers: {
+      food: { speed: 0.8, yield: 1.1 },
+      wood: { speed: 0.8, yield: 1.1 },
+    },
   },
   {
     id: 'summer',
     label: 'Summer',
     icon: '☀️',
     days: 90,
-    modifiers: { farmingSpeed: 1.0, farmingYield: 1.0 },
+    modifiers: {
+      food: { speed: 1.0, yield: 1.0 },
+      wood: { speed: 1.0, yield: 1.0 },
+    },
   },
   {
     id: 'autumn',
     label: 'Autumn',
     icon: '🍂',
     days: 90,
-    modifiers: { farmingSpeed: 1.1, farmingYield: 1.0 },
+    modifiers: {
+      food: { speed: 1.1, yield: 1.0 },
+      wood: { speed: 1.1, yield: 1.0 },
+    },
   },
   {
     id: 'winter',
     label: 'Winter',
     icon: '❄️',
     days: 90,
-    modifiers: { farmingSpeed: 2.0, farmingYield: 0.0 },
+    modifiers: {
+      food: { speed: 2.0, yield: 0.0 },
+      wood: { speed: 2.0, yield: 0.0 },
+    },
   },
 ]
 
@@ -90,9 +102,23 @@ export function getDayInSeason(state) {
 export const getSeasonDay = getDayInSeason
 
 export function getSeasonModifiers(state) {
-  return getTimeBreakdown(state).season.modifiers || {
-    farmingSpeed: 1,
-    farmingYield: 1,
+  return getTimeBreakdown(state).season.modifiers || {}
+}
+
+export function getSeasonMultiplier(season, resourceKey, building) {
+  const base = season?.modifiers?.[resourceKey] || { speed: 1, yield: 1 }
+  let { speed = 1, yield: yieldMult = 1 } = base
+  const seasonal = building?.seasonal
+  if (seasonal?.mode === 'ignore') {
+    speed = 1
+    yieldMult = 1
+  } else if (seasonal?.mode === 'custom') {
+    const custom = seasonal?.modifiers?.[season.id]?.[resourceKey]
+    if (typeof custom === 'number') {
+      speed = custom
+      yieldMult = custom
+    }
   }
+  return { speed, yield: yieldMult }
 }
 

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -1,5 +1,5 @@
 import { BUILDINGS } from '../data/buildings.js'
-import { getSeasonModifiers } from '../engine/time.js'
+import { getSeason, getSeasonMultiplier } from '../engine/time.js'
 import { formatRate } from '../utils/format.js'
 
 export function getCapacity(state, resourceId) {
@@ -8,15 +8,16 @@ export function getCapacity(state, resourceId) {
 }
 
 export function getResourceProductionSummary(state) {
-  const mods = getSeasonModifiers(state)
+  const season = getSeason(state)
   const groupedCategories = {}
   const groupedTypes = {}
   BUILDINGS.forEach((b) => {
     const count = state.buildings?.[b.id]?.count || 0
     if (count > 0 && b.growthTime) {
-      const effectiveGrowth = b.growthTime * mods.farmingSpeed
+      const mods = getSeasonMultiplier(season, b.resource, b)
+      const effectiveGrowth = b.growthTime * mods.speed
       const effectiveHarvest =
-        b.harvestAmount * mods.farmingYield * b.yieldValue
+        b.harvestAmount * mods.yield * b.yieldValue
       const res = b.resource
       groupedCategories[res] = groupedCategories[res] || []
       groupedCategories[res].push({

--- a/src/views/BaseView.jsx
+++ b/src/views/BaseView.jsx
@@ -3,7 +3,7 @@ import { useGame } from '../state/useGame.js'
 import EventLog from '../components/EventLog.jsx'
 import ResourceSidebar from '../components/ResourceSidebar.jsx'
 import { FOOD_BUILDINGS, RESOURCE_BUILDINGS } from '../data/buildings.js'
-import { getSeasonModifiers } from '../engine/time.js'
+import { getSeason, getSeasonMultiplier } from '../engine/time.js'
 import { getCapacity } from '../state/selectors.js'
 import { formatRate } from '../utils/format.js'
 
@@ -26,10 +26,11 @@ function AccordionItem({ title, children, defaultOpen = false }) {
 function BuildingRow({ building }) {
   const { state, setState } = useGame()
   const count = state.buildings[building.id]?.count || 0
-  const mods = getSeasonModifiers(state)
-  const effectiveGrowth = building.growthTime * mods.farmingSpeed
+  const season = getSeason(state)
+  const mods = getSeasonMultiplier(season, building.resource, building)
+  const effectiveGrowth = building.growthTime * mods.speed
   const effectiveHarvest =
-    building.harvestAmount * mods.farmingYield * building.yieldValue
+    building.harvestAmount * mods.yield * building.yieldValue
   const costEntries = Object.entries(building.cost || {})
   const canAfford = costEntries.every(
     ([res, amt]) => (state.resources[res]?.amount || 0) >= amt,


### PR DESCRIPTION
## Summary
- store season modifiers by resource and add `getSeasonMultiplier` for per-building seasonal overrides
- apply new seasonal multipliers in production, selectors, UI, and building views
- add parity and override tests for seasonal behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899fcbbfb7c8331a52f55e4015a9bfd