### PR TITLE
feat: add save migrations and manual export

### DIFF
--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -1,8 +1,35 @@
+import { useRef } from 'react'
 import { useGame } from '../state/useGame.js'
-import { saveGame, loadGame } from '../engine/persistence.js'
+import { exportSaveFile, load } from '../engine/persistence.js'
 
 export default function Drawer() {
-  const { state, toggleDrawer, setState, resetGame } = useGame()
+    const { state, toggleDrawer, setState, resetGame } = useGame()
+    const fileInput = useRef(null)
+
+    const handleFile = (e) => {
+      const file = e.target.files?.[0]
+      if (!file) return
+      const reader = new FileReader()
+      reader.onload = (ev) => {
+        try {
+          const text = ev.target?.result
+          const { state: loaded, migratedFrom } = load(text)
+          const note = migratedFrom
+            ? `Save loaded (migrated from v${migratedFrom})`
+            : 'Save loaded'
+          const log = [note, ...(loaded.log || [])].slice(0, 100)
+          setState({ ...loaded, log })
+        } catch (err) {
+          console.error(err)
+          setState((prev) => ({
+            ...prev,
+            log: [`Failed to load save: ${err.message}`, ...prev.log].slice(0, 100),
+          }))
+        }
+      }
+      reader.readAsText(file)
+      e.target.value = ''
+    }
 
   return (
     <>
@@ -25,23 +52,33 @@ export default function Drawer() {
           <section>
             <h2 className="font-semibold mb-2">💾 Save/Load</h2>
             <div className="flex gap-2">
-              <button
-                className="px-2 py-1 rounded border border-stroke"
-                onClick={() => setState(saveGame(state))}
-              >
-                Save
-              </button>
-              <button
-                className="px-2 py-1 rounded border border-stroke"
-                onClick={() => {
-                  const loaded = loadGame()
-                  if (loaded) setState(loaded)
-                }}
-              >
-                Load
-              </button>
-            </div>
-          </section>
+                <button
+                  className="px-2 py-1 rounded border border-stroke"
+                  onClick={() => {
+                    exportSaveFile(state)
+                    setState((prev) => ({
+                      ...prev,
+                      log: ['Save exported', ...prev.log].slice(0, 100),
+                    }))
+                  }}
+                >
+                  Save
+                </button>
+                <button
+                  className="px-2 py-1 rounded border border-stroke"
+                  onClick={() => fileInput.current?.click()}
+                >
+                  Load
+                </button>
+                <input
+                  ref={fileInput}
+                  type="file"
+                  accept="application/json"
+                  className="hidden"
+                  onChange={handleFile}
+                />
+              </div>
+            </section>
           <section>
             <h2 className="font-semibold mb-2">🧹 Reset</h2>
             <button

--- a/src/engine/__tests__/persistence.test.js
+++ b/src/engine/__tests__/persistence.test.js
@@ -1,25 +1,76 @@
-import { describe, expect, test, beforeEach } from 'vitest'
-import { saveGame, loadGame, SCHEMA_VERSION } from '../persistence.js'
+import { describe, expect, test } from 'vitest'
+import {
+  applyMigrations,
+  validateSave,
+  load,
+  save,
+  CURRENT_SAVE_VERSION,
+} from '../persistence.js'
 
-describe('persistence engine', () => {
-  beforeEach(() => {
-    localStorage.clear()
-  })
-
-  test('saves and loads game state', () => {
-    const state = { foo: 'bar' }
-    const saved = saveGame(state)
-    expect(saved.schemaVersion).toBe(SCHEMA_VERSION)
-    const loaded = loadGame()
-    expect(loaded.foo).toBe('bar')
-    expect(loaded.schemaVersion).toBe(SCHEMA_VERSION)
-  })
-
-  test('returns null when schema version mismatches', () => {
-    localStorage.setItem(
-      'apocalypse-idle-save',
-      JSON.stringify({ schemaVersion: SCHEMA_VERSION + 1 }),
-    )
-    expect(loadGame()).toBeNull()
+describe('persistence migrations', () => {
+  test('upgrades v1 saves to v2', () => {
+    const v1 = {
+      version: 1,
+      gameTime: 5,
+      resources: {},
+      buildings: {},
+      population: {},
+    }
+    const migrated = applyMigrations({ ...v1 })
+    expect(migrated.version).toBe(2)
+    expect(migrated.gameTime).toEqual({ seconds: 5 })
   })
 })
+
+describe('validateSave', () => {
+  test('throws when required keys missing', () => {
+    expect(() =>
+      validateSave({ version: 2, buildings: {}, population: {} }),
+    ).toThrow(/resources/)
+  })
+
+  test('throws when types invalid', () => {
+    expect(() =>
+      validateSave({
+        version: 2,
+        resources: [],
+        buildings: {},
+        population: {},
+      }),
+    ).toThrow(/resources must be object/)
+  })
+})
+
+describe('load', () => {
+  test('migrates v1 save to current version', () => {
+    const v1 = {
+      version: 1,
+      gameTime: 7,
+      resources: {},
+      buildings: {},
+      population: {},
+    }
+    const { state, migratedFrom } = load(v1)
+    expect(state.version).toBe(CURRENT_SAVE_VERSION)
+    expect(state.gameTime).toEqual({ seconds: 7 })
+    expect(migratedFrom).toBe(1)
+  })
+
+  test('throws on bad input', () => {
+    expect(() => load('{')).toThrow()
+  })
+})
+
+describe('export/import helpers', () => {
+  test('save produces JSON-friendly object', () => {
+    const saved = save({
+      resources: {},
+      buildings: {},
+      population: {},
+      gameTime: { seconds: 0 },
+    })
+    expect(saved.version).toBe(CURRENT_SAVE_VERSION)
+    expect(() => JSON.stringify(saved)).not.toThrow()
+  })
+})
+

--- a/src/engine/persistence.js
+++ b/src/engine/persistence.js
@@ -1,9 +1,90 @@
 const STORAGE_KEY = 'apocalypse-idle-save'
-export const SCHEMA_VERSION = 1
+
+export const CURRENT_SAVE_VERSION = 2
+
+export const migrations = [
+  {
+    from: 1,
+    to: 2,
+    up(save) {
+      if (typeof save.gameTime === 'number') {
+        save.gameTime = { seconds: save.gameTime }
+      } else if (!save.gameTime) {
+        save.gameTime = { seconds: 0 }
+      }
+      if ('schemaVersion' in save) delete save.schemaVersion
+      return save
+    },
+  },
+]
+
+export function applyMigrations(save) {
+  while (save.version < CURRENT_SAVE_VERSION) {
+    const migration = migrations.find((m) => m.from === save.version)
+    if (!migration)
+      throw new Error(`Missing migration from v${save.version}`)
+    save = migration.up(save) || save
+    save.version = migration.to
+  }
+  return save
+}
+
+export function validateSave(obj) {
+  if (!obj || typeof obj !== 'object')
+    throw new Error('Invalid save: not an object')
+  if (!('resources' in obj))
+    throw new Error('Invalid save: missing resources')
+  if (
+    typeof obj.resources !== 'object' ||
+    obj.resources === null ||
+    Array.isArray(obj.resources)
+  )
+    throw new Error('Invalid save: resources must be object')
+  if (!('buildings' in obj))
+    throw new Error('Invalid save: missing buildings')
+  if (
+    typeof obj.buildings !== 'object' ||
+    obj.buildings === null ||
+    Array.isArray(obj.buildings)
+  )
+    throw new Error('Invalid save: buildings must be object')
+  if (!('population' in obj))
+    throw new Error('Invalid save: missing population')
+  if (
+    typeof obj.population !== 'object' ||
+    obj.population === null ||
+    Array.isArray(obj.population)
+  )
+    throw new Error('Invalid save: population must be object')
+  if (
+    'gameTime' in obj &&
+    typeof obj.gameTime !== 'number' &&
+    typeof obj.gameTime !== 'object'
+  )
+    throw new Error('Invalid save: gameTime must be number or object')
+  return true
+}
+
+export function save(state) {
+  return { ...state, version: CURRENT_SAVE_VERSION, lastSaved: Date.now() }
+}
+
+export function load(raw) {
+  const save =
+    typeof raw === 'string'
+      ? JSON.parse(raw)
+      : JSON.parse(JSON.stringify(raw))
+  save.version = save.version ?? save.schemaVersion ?? 1
+  validateSave(save)
+  const start = save.version
+  applyMigrations(save)
+  validateSave(save)
+  return { state: save, migratedFrom: start < save.version ? start : null }
+}
 
 export function saveGame(state) {
   try {
-    const data = { ...state, schemaVersion: SCHEMA_VERSION, lastSaved: Date.now() }
+    const data = save(state)
     localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
     return data
   } catch (err) {
@@ -16,8 +97,8 @@ export function loadGame() {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
     if (!raw) return null
-    const parsed = JSON.parse(raw)
-    return parsed.schemaVersion === SCHEMA_VERSION ? parsed : null
+    const { state } = load(raw)
+    return state
   } catch (err) {
     console.error('Load failed', err)
     return null
@@ -30,5 +111,20 @@ export function deleteSave() {
   } catch (err) {
     console.error('Delete failed', err)
   }
+}
+
+export function exportSaveFile(state) {
+  const data = save(state)
+  const json = JSON.stringify(data, null, 2)
+  const blob = new Blob([json], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = 'apocalypse-idle-save.json'
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+  return data
 }
 

--- a/src/state/defaultState.js
+++ b/src/state/defaultState.js
@@ -1,9 +1,9 @@
 import { makeRandomSettler } from '../data/names.js'
 import { initSeasons } from '../engine/time.js'
-import { SCHEMA_VERSION } from '../engine/persistence.js'
+import { CURRENT_SAVE_VERSION } from '../engine/persistence.js'
 
 export const defaultState = {
-  schemaVersion: SCHEMA_VERSION,
+  version: CURRENT_SAVE_VERSION,
   gameTime: { seconds: 0, year: 1 },
   meta: { seasons: initSeasons() },
   ui: { activeTab: 'base', drawerOpen: false, offlineProgress: null },


### PR DESCRIPTION
## Summary
- add migration framework and validation for save data
- wire drawer save/load buttons to download and import JSON save files
- cover migrations, validation, and helpers with tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899ff8622d48331b5bd3edbdc3d3613