### PR TITLE
docs: add economy report generator

### DIFF
--- a/docs/ECONOMY_REPORT.md
+++ b/docs/ECONOMY_REPORT.md
@@ -1,0 +1,79 @@
+# Economy Report
+
+## 1) Overview
+Economy generated from commit **bbcec0abfb9fbb25d8a5b49d06f567ef68ca3f94** on 2025-08-11 17:35:30 +0200. Save version: **2**.
+Each tick represents 1 second. For each building: base production is modified by season multipliers, summed, then clamped to capacity. Offline progress processes in 60-second chunks.
+
+## 2) Resources
+| key | displayName | category | startingAmount | startingCapacity | unit |
+| - | - | - | - | - | - |
+| food | Food | food | 0 | 300 |  |
+| wood | Wood | resources | 0 | 100 |  |
+| plank | Planks | resources | 0 | 0 |  |
+| scrap | Scrap | resources | 0 | 100 |  |
+| metal | Metal Bars | resources | 0 | 0 |  |
+| water | Water | food | 0 | 100 |  |
+
+Global rules: resources cannot go negative; amounts are clamped to capacity.
+
+## 3) Seasons and Global Modifiers
+| season | duration (sec) | food | wood | plank | scrap | metal | water |
+| - | - | - | - | - | - | - | - |
+| spring | 270 | 1.375 | 1.375 | 1.375 | 1.375 | 1.000 | 1.250 |
+| summer | 270 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
+| autumn | 270 | 0.909 | 0.909 | 0.909 | 0.909 | 1.000 | 0.909 |
+| winter | 270 | 0.000 | 0.000 | 0.000 | 0.000 | 1.000 | 0.500 |
+
+## 4) Buildings
+| id | name | type | cost | refund | storage | base prod/s | season mults |
+| - | - | - | - | - | - | - | - |
+| potatoField | Potato Field | production | wood: 20 | 0.5 | - | food: 0.375 | spring: 1.375, summer: 1, autumn: 0.909 |
+| cornField | Corn Field | production | wood: 30 | 0.5 | - | food: 0.4 | spring: 1.375, summer: 1, autumn: 0.909 |
+| ricePaddy | Rice Paddy | production | wood: 15 | 0.5 | - | food: 0.333 | spring: 1.375, summer: 1, autumn: 0.909 |
+| loggingCamp | Logging Camp | production | scrap: 50 | 0.5 | - | wood: 0.167 | spring: 1.375, summer: 1, autumn: 0.909 |
+| sawmill | Sawmill | production | scrap: 30, wood: 40, plank: 10 | 0.5 | - | plank: 0.25 | spring: 1.375, summer: 1, autumn: 0.909 |
+| scrapYard | Scrap Yard | production | - | 0.5 | - | scrap: 0.143 | spring: 1.375, summer: 1, autumn: 0.909 |
+| smelter | Smelter | production | scrap: 100, wood: 50, plank: 20 | 0.5 | - | metal: 0.1 | spring: 1, summer: 1, autumn: 1, winter: 1 |
+| granary | Granary | storage | scrap: 20, wood: 60, plank: 10 | 0.5 | food: 200 | - | - |
+| warehouse | Warehouse | storage | scrap: 30, wood: 80, plank: 20 | 0.5 | wood: 200, scrap: 200 | - | - |
+
+## 5) Population and Roles
+No role-based production modifiers in effect.
+
+## 6) Production Math (Exact Formula)
+Per building per tick:
+
+`effectiveCycle = cycleTimeSec * seasonSpeed`
+
+`effectiveHarvest = harvestAmount * outputValue * seasonYield`
+
+`cycles = floor((elapsed + timer) / effectiveCycle)`
+
+`production = effectiveHarvest * count * cycles`
+
+Sum production for each resource across buildings, then `clampResource(value, capacity)` where values below 0 become 0 and above capacity become capacity.
+
+Offline progress is applied in 60-second chunks.
+
+## 7) Costs, Refunds, and Edge Rules
+Building costs scale by `cost * 1.15^count`, rounded up. Demolition refunds 50% of the previous cost (floored) and adds back resources subject to capacity. Resource values are rounded to 6 decimals in clamping and cannot be negative.
+
+## 8) Starting State
+Starting season: spring, Year: 1.
+
+### Resources
+| resource | amount | capacity |
+| - | - | - |
+| food | 0 | 300 |
+| wood | 0 | 100 |
+| plank | 0 | 0 |
+| scrap | 0 | 100 |
+| metal | 0 | 0 |
+| water | 0 | 100 |
+
+### Buildings
+| building | count |
+| - | - |
+| potatoField | 1 |
+| loggingCamp | 1 |
+

--- a/docs/economy-snapshot.json
+++ b/docs/economy-snapshot.json
@@ -1,0 +1,338 @@
+{
+  "version": "bbcec0abfb9fbb25d8a5b49d06f567ef68ca3f94",
+  "saveVersion": 2,
+  "tickSeconds": 1,
+  "seasons": {
+    "spring": {
+      "durationSec": 270,
+      "multipliers": {
+        "food": 1.375,
+        "wood": 1.375,
+        "plank": 1.375,
+        "scrap": 1.375,
+        "metal": 1,
+        "water": 1.25
+      }
+    },
+    "summer": {
+      "durationSec": 270,
+      "multipliers": {
+        "food": 1,
+        "wood": 1,
+        "plank": 1,
+        "scrap": 1,
+        "metal": 1,
+        "water": 1
+      }
+    },
+    "autumn": {
+      "durationSec": 270,
+      "multipliers": {
+        "food": 0.9090909090909091,
+        "wood": 0.9090909090909091,
+        "plank": 0.9090909090909091,
+        "scrap": 0.9090909090909091,
+        "metal": 1,
+        "water": 0.9090909090909091
+      }
+    },
+    "winter": {
+      "durationSec": 270,
+      "multipliers": {
+        "food": 0,
+        "wood": 0,
+        "plank": 0,
+        "scrap": 0,
+        "metal": 1,
+        "water": 0.5
+      }
+    }
+  },
+  "resources": [
+    {
+      "key": "food",
+      "displayName": "Food",
+      "category": "food",
+      "startingAmount": 0,
+      "startingCapacity": 300,
+      "unit": null
+    },
+    {
+      "key": "wood",
+      "displayName": "Wood",
+      "category": "resources",
+      "startingAmount": 0,
+      "startingCapacity": 100,
+      "unit": null
+    },
+    {
+      "key": "plank",
+      "displayName": "Planks",
+      "category": "resources",
+      "startingAmount": 0,
+      "startingCapacity": 0,
+      "unit": null
+    },
+    {
+      "key": "scrap",
+      "displayName": "Scrap",
+      "category": "resources",
+      "startingAmount": 0,
+      "startingCapacity": 100,
+      "unit": null
+    },
+    {
+      "key": "metal",
+      "displayName": "Metal Bars",
+      "category": "resources",
+      "startingAmount": 0,
+      "startingCapacity": 0,
+      "unit": null
+    },
+    {
+      "key": "water",
+      "displayName": "Water",
+      "category": "food",
+      "startingAmount": 0,
+      "startingCapacity": 100,
+      "unit": null
+    }
+  ],
+  "buildings": [
+    {
+      "id": "potatoField",
+      "name": "Potato Field",
+      "type": "production",
+      "constructionCost": {
+        "scrap": 0,
+        "wood": 20,
+        "plank": 0,
+        "metal": 0
+      },
+      "demolitionRefund": 0.5,
+      "storageProvided": {},
+      "baseProductionPerSec": {
+        "food": 0.375
+      },
+      "seasonalMode": "default",
+      "seasonalCustom": null,
+      "seasonalMultipliers": {
+        "spring": 1.375,
+        "summer": 1,
+        "autumn": 0.9090909090909091,
+        "winter": 0
+      }
+    },
+    {
+      "id": "cornField",
+      "name": "Corn Field",
+      "type": "production",
+      "constructionCost": {
+        "scrap": 0,
+        "wood": 30,
+        "plank": 0,
+        "metal": 0
+      },
+      "demolitionRefund": 0.5,
+      "storageProvided": {},
+      "baseProductionPerSec": {
+        "food": 0.4
+      },
+      "seasonalMode": "default",
+      "seasonalCustom": null,
+      "seasonalMultipliers": {
+        "spring": 1.375,
+        "summer": 1,
+        "autumn": 0.9090909090909091,
+        "winter": 0
+      }
+    },
+    {
+      "id": "ricePaddy",
+      "name": "Rice Paddy",
+      "type": "production",
+      "constructionCost": {
+        "scrap": 0,
+        "wood": 15,
+        "plank": 0,
+        "metal": 0
+      },
+      "demolitionRefund": 0.5,
+      "storageProvided": {},
+      "baseProductionPerSec": {
+        "food": 0.3333333333333333
+      },
+      "seasonalMode": "default",
+      "seasonalCustom": null,
+      "seasonalMultipliers": {
+        "spring": 1.375,
+        "summer": 1,
+        "autumn": 0.9090909090909091,
+        "winter": 0
+      }
+    },
+    {
+      "id": "loggingCamp",
+      "name": "Logging Camp",
+      "type": "production",
+      "constructionCost": {
+        "scrap": 50,
+        "wood": 0,
+        "plank": 0,
+        "metal": 0
+      },
+      "demolitionRefund": 0.5,
+      "storageProvided": {},
+      "baseProductionPerSec": {
+        "wood": 0.16666666666666666
+      },
+      "seasonalMode": "default",
+      "seasonalCustom": null,
+      "seasonalMultipliers": {
+        "spring": 1.375,
+        "summer": 1,
+        "autumn": 0.9090909090909091,
+        "winter": 0
+      }
+    },
+    {
+      "id": "sawmill",
+      "name": "Sawmill",
+      "type": "production",
+      "constructionCost": {
+        "scrap": 30,
+        "wood": 40,
+        "plank": 10,
+        "metal": 0
+      },
+      "demolitionRefund": 0.5,
+      "storageProvided": {},
+      "baseProductionPerSec": {
+        "plank": 0.25
+      },
+      "seasonalMode": "default",
+      "seasonalCustom": null,
+      "seasonalMultipliers": {
+        "spring": 1.375,
+        "summer": 1,
+        "autumn": 0.9090909090909091,
+        "winter": 0
+      }
+    },
+    {
+      "id": "scrapYard",
+      "name": "Scrap Yard",
+      "type": "production",
+      "constructionCost": {
+        "scrap": 0,
+        "wood": 0,
+        "plank": 0,
+        "metal": 0
+      },
+      "demolitionRefund": 0.5,
+      "storageProvided": {},
+      "baseProductionPerSec": {
+        "scrap": 0.14285714285714285
+      },
+      "seasonalMode": "default",
+      "seasonalCustom": null,
+      "seasonalMultipliers": {
+        "spring": 1.375,
+        "summer": 1,
+        "autumn": 0.9090909090909091,
+        "winter": 0
+      }
+    },
+    {
+      "id": "smelter",
+      "name": "Smelter",
+      "type": "production",
+      "constructionCost": {
+        "scrap": 100,
+        "wood": 50,
+        "plank": 20,
+        "metal": 0
+      },
+      "demolitionRefund": 0.5,
+      "storageProvided": {},
+      "baseProductionPerSec": {
+        "metal": 0.1
+      },
+      "seasonalMode": "default",
+      "seasonalCustom": null,
+      "seasonalMultipliers": {
+        "spring": 1,
+        "summer": 1,
+        "autumn": 1,
+        "winter": 1
+      }
+    },
+    {
+      "id": "granary",
+      "name": "Granary",
+      "type": "storage",
+      "constructionCost": {
+        "scrap": 20,
+        "wood": 60,
+        "plank": 10,
+        "metal": 0
+      },
+      "demolitionRefund": 0.5,
+      "storageProvided": {
+        "food": 200
+      },
+      "baseProductionPerSec": {},
+      "seasonalMode": "ignore",
+      "seasonalCustom": null,
+      "seasonalMultipliers": {}
+    },
+    {
+      "id": "warehouse",
+      "name": "Warehouse",
+      "type": "storage",
+      "constructionCost": {
+        "scrap": 30,
+        "wood": 80,
+        "plank": 20,
+        "metal": 0
+      },
+      "demolitionRefund": 0.5,
+      "storageProvided": {
+        "wood": 200,
+        "scrap": 200
+      },
+      "baseProductionPerSec": {},
+      "seasonalMode": "ignore",
+      "seasonalCustom": null,
+      "seasonalMultipliers": {}
+    }
+  ],
+  "roles": [],
+  "formula": {
+    "order": [
+      "base",
+      "season",
+      "roles",
+      "sum",
+      "clamp"
+    ],
+    "demolitionRefund": 0.5,
+    "clampRule": "min(value, capacity) and never negative"
+  },
+  "startingState": {
+    "season": "spring",
+    "year": 1,
+    "resources": {
+      "food": 0,
+      "wood": 0,
+      "plank": 0,
+      "scrap": 0,
+      "metal": 0,
+      "water": 0
+    },
+    "buildings": {
+      "potatoField": 1,
+      "loggingCamp": 1
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "coverage": "vitest run --coverage"
+    "coverage": "vitest run --coverage",
+    "report:economy": "node scripts/generate-economy-report.mjs"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.11",

--- a/scripts/generate-economy-report.mjs
+++ b/scripts/generate-economy-report.mjs
@@ -1,0 +1,215 @@
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { execSync } from 'child_process'
+
+import { BUILDINGS } from '../src/data/buildings.js'
+import { RESOURCES } from '../src/data/resources.js'
+import { initSeasons, SECONDS_PER_DAY, getSeasonMultiplier } from '../src/engine/time.js'
+import { CURRENT_SAVE_VERSION } from '../src/engine/persistence.js'
+import { defaultState } from '../src/state/defaultState.js'
+import { getCapacity } from '../src/state/selectors.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const repoRoot = path.resolve(__dirname, '..')
+
+function getCommitInfo() {
+  try {
+    const hash = execSync('git rev-parse HEAD').toString().trim()
+    const date = execSync('git show -s --format=%ci HEAD').toString().trim()
+    return { hash, date }
+  } catch {
+    return { hash: 'unknown', date: 'unknown' }
+  }
+}
+
+const { hash: commitHash, date: commitDate } = getCommitInfo()
+
+const seasons = initSeasons()
+const resourceKeys = Object.keys(RESOURCES)
+
+function computeResourceMultiplier(resId, season) {
+  const building = BUILDINGS.find((b) => b.outputResource === resId)
+  let speedKey
+  let yieldKey
+  if (building) {
+    speedKey = building.seasonSpeedKey
+    yieldKey = building.seasonYieldKey
+  } else {
+    const keys = RESOURCES[resId]?.seasonalKeys || []
+    speedKey = keys[0]
+    yieldKey = keys[1]
+  }
+  const speed = season.modifiers?.[speedKey] ?? 1
+  const yieldMult = yieldKey ? season.modifiers?.[yieldKey] ?? 1 : 1
+  return yieldMult / speed
+}
+
+const seasonData = {}
+seasons.forEach((s) => {
+  const multipliers = {}
+  resourceKeys.forEach((r) => {
+    multipliers[r] = computeResourceMultiplier(r, s)
+  })
+  seasonData[s.id] = { durationSec: s.days * SECONDS_PER_DAY, multipliers }
+})
+
+const resources = resourceKeys.map((id) => {
+  const r = RESOURCES[id]
+  return {
+    key: id,
+    displayName: r.name,
+    category: r.category,
+    startingAmount: defaultState.resources[id]?.amount ?? 0,
+    startingCapacity: getCapacity(defaultState, id),
+    unit: null,
+  }
+})
+
+function buildingType(b) {
+  if (b.addsCapacity) return 'storage'
+  if (b.cycleTimeSec) return 'production'
+  return 'other'
+}
+
+function baseProductionPerSec(b) {
+  if (!b.cycleTimeSec || !b.outputResource) return {}
+  const rate = (b.harvestAmount * b.outputValue) / b.cycleTimeSec
+  return { [b.outputResource]: rate }
+}
+
+function buildingSeasonMultipliers(b) {
+  if (!b.cycleTimeSec) return {}
+  const result = {}
+  seasons.forEach((s) => {
+    const mods = getSeasonMultiplier(s, b)
+    result[s.id] = (mods.yield ?? 1) / (mods.speed ?? 1)
+  })
+  return result
+}
+
+const buildings = BUILDINGS.map((b) => ({
+  id: b.id,
+  name: b.name,
+  type: buildingType(b),
+  constructionCost: { ...b.cost },
+  demolitionRefund: 0.5,
+  storageProvided: { ...(b.addsCapacity || {}) },
+  baseProductionPerSec: baseProductionPerSec(b),
+  seasonalMode: b.cycleTimeSec ? 'default' : 'ignore',
+  seasonalCustom: null,
+  seasonalMultipliers: buildingSeasonMultipliers(b),
+}))
+
+const roles = []
+
+const snapshot = {
+  version: commitHash,
+  saveVersion: CURRENT_SAVE_VERSION,
+  tickSeconds: 1,
+  seasons: seasonData,
+  resources,
+  buildings,
+  roles,
+  formula: {
+    order: ['base', 'season', 'roles', 'sum', 'clamp'],
+    demolitionRefund: 0.5,
+    clampRule: 'min(value, capacity) and never negative',
+  },
+  startingState: {
+    season: seasons[0].id,
+    year: 1,
+    resources: Object.fromEntries(resources.map((r) => [r.key, r.startingAmount])),
+    buildings: Object.fromEntries(
+      BUILDINGS.filter((b) => b.startsWithCount > 0).map((b) => [b.id, b.startsWithCount])
+    ),
+  },
+}
+
+fs.mkdirSync(path.join(repoRoot, 'docs'), { recursive: true })
+fs.writeFileSync(
+  path.join(repoRoot, 'docs/economy-snapshot.json'),
+  JSON.stringify(snapshot, null, 2) + '\n'
+)
+
+function formatCost(obj) {
+  const entries = Object.entries(obj || {}).filter(([, v]) => v)
+  return entries.length ? entries.map(([k, v]) => `${k}: ${v}`).join(', ') : '-'
+}
+
+function formatObj(obj) {
+  const entries = Object.entries(obj || {}).filter(([, v]) => v)
+  return entries.length
+    ? entries.map(([k, v]) => `${k}: ${Number(v.toFixed ? v.toFixed(3) : v)}`).join(', ')
+    : '-'
+}
+
+let md = ''
+md += '# Economy Report\n\n'
+md += '## 1) Overview\n'
+md += `Economy generated from commit **${commitHash}** on ${commitDate}. Save version: **${CURRENT_SAVE_VERSION}**.\n`
+md += 'Each tick represents 1 second. For each building: base production is modified by season multipliers, summed, then clamped to capacity. Offline progress processes in 60-second chunks.\n\n'
+
+md += '## 2) Resources\n'
+md += '| key | displayName | category | startingAmount | startingCapacity | unit |\n'
+md += '| - | - | - | - | - | - |\n'
+resources.forEach((r) => {
+  md += `| ${r.key} | ${r.displayName} | ${r.category} | ${r.startingAmount} | ${r.startingCapacity} | ${r.unit ?? ''} |\n`
+})
+md += '\nGlobal rules: resources cannot go negative; amounts are clamped to capacity.\n\n'
+
+md += '## 3) Seasons and Global Modifiers\n'
+md += '| season | duration (sec) |'
+resourceKeys.forEach((r) => (md += ` ${r} |`))
+md += '\n| - | - |'
+resourceKeys.forEach(() => (md += ' - |'))
+md += '\n'
+seasons.forEach((s) => {
+  md += `| ${s.id} | ${seasonData[s.id].durationSec} |`
+  resourceKeys.forEach((r) => {
+    md += ` ${seasonData[s.id].multipliers[r].toFixed(3)} |`
+  })
+  md += '\n'
+})
+md += '\n'
+
+md += '## 4) Buildings\n'
+md += '| id | name | type | cost | refund | storage | base prod/s | season mults |\n'
+md += '| - | - | - | - | - | - | - | - |\n'
+BUILDINGS.forEach((b, idx) => {
+  const row = buildings[idx]
+  md += `| ${row.id} | ${row.name} | ${row.type} | ${formatCost(row.constructionCost)} | ${row.demolitionRefund} | ${formatObj(row.storageProvided)} | ${formatObj(row.baseProductionPerSec)} | ${formatObj(row.seasonalMultipliers)} |\n`
+})
+md += '\n'
+
+md += '## 5) Population and Roles\n'
+md += 'No role-based production modifiers in effect.\n\n'
+
+md += '## 6) Production Math (Exact Formula)\n'
+md += 'Per building per tick:\n\n'
+md += '`effectiveCycle = cycleTimeSec * seasonSpeed`\n\n'
+md += '`effectiveHarvest = harvestAmount * outputValue * seasonYield`\n\n'
+md += '`cycles = floor((elapsed + timer) / effectiveCycle)`\n\n'
+md += '`production = effectiveHarvest * count * cycles`\n\n'
+md += 'Sum production for each resource across buildings, then `clampResource(value, capacity)` where values below 0 become 0 and above capacity become capacity.\n\n'
+md += 'Offline progress is applied in 60-second chunks.\n\n'
+
+md += '## 7) Costs, Refunds, and Edge Rules\n'
+md += 'Building costs scale by `cost * 1.15^count`, rounded up. Demolition refunds 50% of the previous cost (floored) and adds back resources subject to capacity. Resource values are rounded to 6 decimals in clamping and cannot be negative.\n\n'
+
+md += '## 8) Starting State\n'
+md += `Starting season: ${seasons[0].id}, Year: 1.\n\n`
+md += '### Resources\n'
+md += '| resource | amount | capacity |\n| - | - | - |\n'
+resources.forEach((r) => {
+  md += `| ${r.key} | ${r.startingAmount} | ${r.startingCapacity} |\n`
+})
+md += '\n### Buildings\n'
+md += '| building | count |\n| - | - |\n'
+BUILDINGS.filter((b) => b.startsWithCount > 0).forEach((b) => {
+  md += `| ${b.id} | ${b.startsWithCount} |\n`
+})
+md += '\n'
+
+fs.writeFileSync(path.join(repoRoot, 'docs/ECONOMY_REPORT.md'), md)


### PR DESCRIPTION
## Summary
- add `report:economy` script to generate snapshot and markdown summary
- document current resources, seasons, buildings, and production math

## Testing
- `npm run report:economy`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a0ea0cb408331a571fb27da7e4d29