### PR TITLE
Integrate settlers tick and track ages in seconds

### DIFF
--- a/src/data/names.js
+++ b/src/data/names.js
@@ -25,13 +25,15 @@ export function makeRandomSettler({ sex } = {}) {
   const firstPool = FIRST_NAMES[chosenSex]
   const firstName = firstPool[Math.floor(Math.random() * firstPool.length)]
   const lastName = LAST_NAMES[Math.floor(Math.random() * LAST_NAMES.length)]
+  const baseAge = 18 * 365 * 86400
+  const randomDays = Math.floor(Math.random() * 365) * 86400
   return {
     id: crypto.randomUUID ? crypto.randomUUID() : Date.now().toString(),
     firstName,
     lastName,
     sex: chosenSex,
     isDead: false,
-    ageSeconds: 0,
+    ageSeconds: baseAge + randomDays,
     role: null,
     skills: {},
   }


### PR DESCRIPTION
## Summary
- Process settlers after each production tick to handle food, aging, and telemetry
- Track settler ages in seconds and ensure offline/annual increments update `ageSeconds`
- Initialize new settlers at 18+ years in seconds with random extra days

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a19a5fa08833180d85958ec6fa709