### PR TITLE
feat: add age formatter

### DIFF
--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -17,3 +17,10 @@ export function formatRate(perSec) {
   if (!Number.isFinite(perSec)) perSec = 0;
   return `+${formatAmount(perSec)}/s`;
 }
+
+export function formatAge(ageSeconds = 0) {
+  const totalDays = Math.floor((ageSeconds || 0) / 86400);
+  const years = Math.floor(totalDays / 365);
+  const days = totalDays % 365;
+  return { years, days };
+}

--- a/src/views/PopulationView.jsx
+++ b/src/views/PopulationView.jsx
@@ -1,4 +1,5 @@
 import { useGame } from '../state/useGame.js'
+import { formatAge } from '../utils/format.js'
 
 export default function PopulationView() {
   const { state, setSettlerRole } = useGame()
@@ -7,44 +8,46 @@ export default function PopulationView() {
   return (
     <div className="p-4 space-y-4 pb-20">
       {settlers.length > 0 ? (
-        settlers.map((s) => (
-          <div
-            key={s.id}
-            className="border border-stroke rounded p-3 bg-bg2/50 flex flex-col gap-2"
-          >
-          <div className="font-semibold">
-            {s.firstName} {s.lastName}
-          </div>
-          <div className="flex flex-wrap items-center gap-2 text-sm text-muted">
-            <span
-              className={`px-2 py-0.5 rounded text-xs text-white ${
-                s.sex === 'M' ? 'bg-blue-700' : 'bg-pink-700'
-              }`}
+        settlers.map((s) => {
+          const { years, days } = formatAge(s.ageSeconds)
+          return (
+            <div
+              key={s.id}
+              className="border border-stroke rounded p-3 bg-bg2/50 flex flex-col gap-2"
             >
-              {s.sex}
-            </span>
-            <span>Age {Math.floor((s.ageSeconds || 0) / 86400)}</span>
-          </div>
-          <div className="relative inline-block w-36">
-            <select
-              value={s.role}
-              onChange={(e) => setSettlerRole(s.id, e.target.value)}
-              className="appearance-none w-full rounded bg-gray-800 text-white px-3 py-2 pr-8 hover:bg-gray-700 focus:outline-none"
-            >
-              <option value="idle">idle</option>
-              <option value="farming">farming</option>
-              <option value="scavenging">scavenging</option>
-            </select>
-            <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
-              <span className="w-2 h-2 border-r-2 border-b-2 border-white rotate-45" />
-            </span>
-          </div>
-        </div>
-        ))
+              <div className="font-semibold">
+                {s.firstName} {s.lastName}
+              </div>
+              <div className="flex flex-wrap items-center gap-2 text-sm text-muted">
+                <span
+                  className={`px-2 py-0.5 rounded text-xs text-white ${
+                    s.sex === 'M' ? 'bg-blue-700' : 'bg-pink-700'
+                  }`}
+                >
+                  {s.sex}
+                </span>
+                <span>Age: {years}y {days}d</span>
+              </div>
+              <div className="relative inline-block w-36">
+                <select
+                  value={s.role}
+                  onChange={(e) => setSettlerRole(s.id, e.target.value)}
+                  className="appearance-none w-full rounded bg-gray-800 text-white px-3 py-2 pr-8 hover:bg-gray-700 focus:outline-none"
+                >
+                  <option value="idle">idle</option>
+                  <option value="farming">farming</option>
+                  <option value="scavenging">scavenging</option>
+                </select>
+                <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+                  <span className="w-2 h-2 border-r-2 border-b-2 border-white rotate-45" />
+                </span>
+              </div>
+            </div>
+          )
+        })
       ) : (
         <div className="text-center text-muted">No survivors</div>
       )}
     </div>
   )
 }
-


### PR DESCRIPTION
## Summary
- format age seconds into years and days
- show settler age in years and days in population view

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a1af86c1c8331b0911f50bcb6ad74