### PR TITLE
Add day tracking to top bar

### DIFF
--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -11,7 +11,7 @@ export default function TopBar() {
 
   return (
     <header className="flex items-center justify-between px-4 py-2 border-b border-stroke bg-bg2">
-      <span className="tabular-nums text-xl">Year {time.year}</span>
+      <span className="tabular-nums text-xl">Year {time.year}, Day {time.day}</span>
       <h1 className="font-semibold">Apocalypse Idle</h1>
       <div className="relative flex items-center gap-2">
         <button

--- a/src/engine/time.js
+++ b/src/engine/time.js
@@ -7,6 +7,11 @@ export const SEASONS = [
   { id: 'winter', label: 'Winter', icon: '❄️', multipliers: { FOOD: 0.0, RAW: 0.8 } },
 ];
 
+// Each season lasts 90 days for a 360-day year
+export const DAYS_PER_SEASON = 90;
+export const DAYS_PER_YEAR = DAYS_PER_SEASON * SEASONS.length;
+export const SECONDS_PER_DAY = SEASON_DURATION / DAYS_PER_SEASON;
+
 export function initSeasons() {
   return SEASONS.map((s) => ({ ...s }));
 }
@@ -15,9 +20,12 @@ export function getTimeBreakdown(state) {
   const seconds = state?.gameTime?.seconds || 0;
   const seasonIndex = Math.floor(seconds / SEASON_DURATION) % SEASONS.length;
   const season = SEASONS[seasonIndex];
-  const year = Math.floor(seconds / (SEASON_DURATION * SEASONS.length)) + 1;
+  const yearDuration = SEASON_DURATION * SEASONS.length;
+  const year = Math.floor(seconds / yearDuration) + 1;
+  const secondsInYear = seconds % yearDuration;
+  const day = Math.floor(secondsInYear / SECONDS_PER_DAY) + 1;
   const secondsInSeason = seconds % SEASON_DURATION;
-  return { year, season, secondsInSeason };
+  return { year, day, season, secondsInSeason };
 }
 
 export function getYear(state) {


### PR DESCRIPTION
## Summary
- derive day of year from game time
- show day and year in the top bar

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a2041bbd08331810a94d0ea9ab972