### PR TITLE
Handle missing colony state

### DIFF
--- a/src/engine/__tests__/economy.test.js
+++ b/src/engine/__tests__/economy.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { processTick, demolishBuilding } from '../production.js';
+import { processSettlersTick } from '../settlers.js';
 import { defaultState } from '../../state/defaultState.js';
 import { BUILDING_MAP, getBuildingCost } from '../../data/buildings.js';
 
@@ -23,5 +24,10 @@ describe('economy basics', () => {
     expect(after.resources.wood.amount).toBe(
       Math.floor(prevCost.wood * blueprint.refund),
     );
+  });
+
+  test('processSettlersTick handles default state', () => {
+    const state = clone(defaultState);
+    expect(() => processSettlersTick(state)).not.toThrow();
   });
 });

--- a/src/engine/settlers.js
+++ b/src/engine/settlers.js
@@ -26,7 +26,8 @@ export function assignmentsSummary(settlers) {
 
 export function processSettlersTick(state, seconds = BALANCE.TICK_SECONDS, totalFoodProdBase = 0, rng = Math.random) {
   const settlers = state.population?.settlers ? [...state.population.settlers] : []
-  const colony = { ...state.colony }
+  const starvationTimer = state.colony?.starvationTimerSeconds || 0
+  const colony = { ...(state.colony || {}), starvationTimerSeconds: starvationTimer }
 
   const living = settlers.filter((s) => !s.isDead)
 

--- a/src/state/defaultState.js
+++ b/src/state/defaultState.js
@@ -23,6 +23,7 @@ export const defaultState = {
   ui: { activeTab: 'base', drawerOpen: false, offlineProgress: null },
   resources: initResources(),
   buildings: initBuildings(),
+  colony: { starvationTimerSeconds: 0 },
   population: { settlers: [makeRandomSettler()] },
   log: [],
   lastSaved: Date.now(),


### PR DESCRIPTION
## Summary
- Ensure `processSettlersTick` handles undefined colony state by providing a fallback and carrying over starvation timer
- Add default colony state with `starvationTimerSeconds` for new saves
- Test `processSettlersTick` with `defaultState` to confirm no crash

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a3f1967d48331ac84daf9ea8df8c1