### PR TITLE
refactor: share accordion component

### DIFF
--- a/src/components/Accordion.jsx
+++ b/src/components/Accordion.jsx
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+
+export default function Accordion({ title, children, defaultOpen = false }) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="border-b border-stroke">
+      <button
+        className="w-full flex items-center justify-between p-2"
+        onClick={() => setOpen(!open)}
+      >
+        <span>{title}</span>
+        <span>{open ? '-' : '+'}</span>
+      </button>
+      {open && <div className="p-2 space-y-2">{children}</div>}
+    </div>
+  );
+}

--- a/src/components/ResourceSidebar.jsx
+++ b/src/components/ResourceSidebar.jsx
@@ -1,24 +1,8 @@
-import { useState } from 'react';
 import { useGame } from '../state/useGame.js';
+import Accordion from './Accordion.jsx';
 import { getCapacity, getResourceRates } from '../state/selectors.js';
 import { formatAmount } from '../utils/format.js';
 import { RESOURCE_LIST } from '../data/resources.js';
-
-function Accordion({ title, children, defaultOpen = false }) {
-  const [open, setOpen] = useState(defaultOpen);
-  return (
-    <div className="border-b border-stroke">
-      <button
-        className="w-full flex items-center justify-between p-2"
-        onClick={() => setOpen(!open)}
-      >
-        <span>{title}</span>
-        <span>{open ? '-' : '+'}</span>
-      </button>
-      {open && <div className="p-2 space-y-2">{children}</div>}
-    </div>
-  );
-}
 
 function ResourceRow({ icon, name, amount, capacity, rate }) {
   return (

--- a/src/views/BaseView.jsx
+++ b/src/views/BaseView.jsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
 import { useGame } from '../state/useGame.js';
 import EventLog from '../components/EventLog.jsx';
 import ResourceSidebar from '../components/ResourceSidebar.jsx';
+import Accordion from '../components/Accordion.jsx';
 import {
   PRODUCTION_BUILDINGS,
   STORAGE_BUILDINGS,
@@ -12,22 +12,6 @@ import { getSeason, getSeasonMultiplier } from '../engine/time.js';
 import { getCapacity } from '../state/selectors.js';
 import { formatAmount, formatRate } from '../utils/format.js';
 import { demolishBuilding } from '../engine/production.js';
-
-function AccordionItem({ title, children, defaultOpen = false }) {
-  const [open, setOpen] = useState(defaultOpen);
-  return (
-    <div className="border-b border-stroke">
-      <button
-        className="w-full flex items-center justify-between p-2"
-        onClick={() => setOpen(!open)}
-      >
-        <span>{title}</span>
-        <span>{open ? '-' : '+'}</span>
-      </button>
-      {open && <div className="p-2 space-y-2">{children}</div>}
-    </div>
-  );
-}
 
 function BuildingRow({ building }) {
   const { state, setState } = useGame();
@@ -137,16 +121,16 @@ export default function BaseView() {
       </div>
       <div className="flex-1 space-y-6">
         <div className="border border-stroke rounded">
-          <AccordionItem title="Production" defaultOpen>
+          <Accordion title="Production" defaultOpen>
             {PRODUCTION_BUILDINGS.map((b) => (
               <BuildingRow key={b.id} building={b} />
             ))}
-          </AccordionItem>
-          <AccordionItem title="Storage">
+          </Accordion>
+          <Accordion title="Storage">
             {STORAGE_BUILDINGS.map((b) => (
               <BuildingRow key={b.id} building={b} />
             ))}
-          </AccordionItem>
+          </Accordion>
         </div>
         <div>
           <h2 className="font-semibold mb-2">Event Log</h2>


### PR DESCRIPTION
## Summary
- add reusable Accordion component
- reuse Accordion in ResourceSidebar and BaseView

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a42c3099c833197e9bf909eb1d72a