### PR TITLE
Use global randomUUID for settler IDs

### DIFF
--- a/src/data/names.js
+++ b/src/data/names.js
@@ -28,7 +28,9 @@ export function makeRandomSettler({ sex } = {}) {
   const baseAge = 18 * 365 * 86400
   const randomDays = Math.floor(Math.random() * 365) * 86400
   return {
-    id: crypto.randomUUID ? crypto.randomUUID() : Date.now().toString(),
+    id: globalThis.crypto?.randomUUID
+      ? globalThis.crypto.randomUUID()
+      : Date.now().toString(),
     firstName,
     lastName,
     sex: chosenSex,


### PR DESCRIPTION
## Summary
- use `globalThis.crypto.randomUUID` if available when generating settler IDs
- fall back to `Date.now().toString()` when `crypto.randomUUID` is unavailable

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a440f79248331852c99b41b694ac5