### PR TITLE
feat: validate save file type before loading

### DIFF
--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -9,6 +9,16 @@ export default function Drawer() {
     const handleFile = (e) => {
       const file = e.target.files?.[0]
       if (!file) return
+
+      if (file.type !== 'application/json') {
+        setState((prev) => ({
+          ...prev,
+          log: ['Failed to load save: Invalid file type', ...prev.log].slice(0, 100),
+        }))
+        e.target.value = ''
+        return
+      }
+
       const reader = new FileReader()
       reader.onload = (ev) => {
         try {


### PR DESCRIPTION
## Summary
- ensure Drawer only reads JSON save files
- log error and skip reading when file type is invalid

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a441910b48331b1e134195d5e1a33