### PR TITLE
Fix settler aging and restrict roles

### DIFF
--- a/src/data/names.js
+++ b/src/data/names.js
@@ -1,3 +1,5 @@
+import { DAYS_PER_YEAR, SECONDS_PER_DAY } from '../engine/time.js'
+
 export const FIRST_NAMES = {
   M: [
     'James', 'John', 'Robert', 'Michael', 'William',
@@ -25,8 +27,8 @@ export function makeRandomSettler({ sex } = {}) {
   const firstPool = FIRST_NAMES[chosenSex]
   const firstName = firstPool[Math.floor(Math.random() * firstPool.length)]
   const lastName = LAST_NAMES[Math.floor(Math.random() * LAST_NAMES.length)]
-  const baseAge = 18 * 365 * 86400
-  const randomDays = Math.floor(Math.random() * 365) * 86400
+  const baseAge = 18 * DAYS_PER_YEAR * SECONDS_PER_DAY
+  const randomDays = Math.floor(Math.random() * DAYS_PER_YEAR) * SECONDS_PER_DAY
   return {
     id: globalThis.crypto?.randomUUID
       ? globalThis.crypto.randomUUID()

--- a/src/data/roles.js
+++ b/src/data/roles.js
@@ -1,0 +1,6 @@
+export const SETTLER_ROLES = [
+  { id: 'farming', label: 'Food' },
+  { id: 'scavenging', label: 'Raw' },
+]
+
+export const SETTLER_ROLE_IDS = SETTLER_ROLES.map((r) => r.id)

--- a/src/state/GameContext.jsx
+++ b/src/state/GameContext.jsx
@@ -5,9 +5,10 @@ import { saveGame, loadGame, deleteSave } from '../engine/persistence.js'
 import { processTick, applyOfflineProgress } from '../engine/production.js'
 import { processSettlersTick } from '../engine/settlers.js'
 import { defaultState } from './defaultState.js'
-import { getYear, initSeasons } from '../engine/time.js'
+import { DAYS_PER_YEAR, SECONDS_PER_DAY, getYear, initSeasons } from '../engine/time.js'
 import { getResourceRates } from './selectors.js'
 import { RESOURCES } from '../data/resources.js'
+import { SETTLER_ROLE_IDS } from '../data/roles.js'
 
 export function GameProvider({ children }) {
   const [state, setState] = useState(() => {
@@ -30,9 +31,10 @@ export function GameProvider({ children }) {
         let settlers = progressed.population.settlers
         if (yearAfter > prevYear) {
           const diff = yearAfter - prevYear
+          const secondsPerYear = DAYS_PER_YEAR * SECONDS_PER_DAY
           settlers = settlers.map((s) => ({
             ...s,
-            ageSeconds: (s.ageSeconds || 0) + diff * 365 * 86400,
+            ageSeconds: (s.ageSeconds || 0) + diff * secondsPerYear,
           }))
         }
         const show = Object.keys(gains).length > 0
@@ -82,9 +84,10 @@ export function GameProvider({ children }) {
       if (computedYear > year) {
         const diff = computedYear - year
         year = computedYear
+        const secondsPerYear = DAYS_PER_YEAR * SECONDS_PER_DAY
         settlers = settlers.map((s) => ({
           ...s,
-          ageSeconds: (s.ageSeconds || 0) + diff * 365 * 86400,
+          ageSeconds: (s.ageSeconds || 0) + diff * secondsPerYear,
         }))
       }
       return {
@@ -133,6 +136,7 @@ export function GameProvider({ children }) {
       const settler = prev.population.settlers.find((s) => s.id === id)
       if (!settler) return prev
       const normalized = role === 'idle' ? null : role
+      if (normalized && !SETTLER_ROLE_IDS.includes(normalized)) return prev
       const settlers = prev.population.settlers.map((s) =>
         s.id === id ? { ...s, role: normalized } : s,
       )

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -1,3 +1,5 @@
+import { DAYS_PER_YEAR, SECONDS_PER_DAY } from '../engine/time.js';
+
 export function formatAmount(n) {
   const abs = Math.abs(n || 0);
   const sign = n < 0 ? '-' : '';
@@ -20,8 +22,8 @@ export function formatRate(perSec) {
 }
 
 export function formatAge(ageSeconds = 0) {
-  const totalDays = Math.floor((ageSeconds || 0) / 86400);
-  const years = Math.floor(totalDays / 365);
-  const days = totalDays % 365;
+  const totalDays = Math.floor((ageSeconds || 0) / SECONDS_PER_DAY);
+  const years = Math.floor(totalDays / DAYS_PER_YEAR);
+  const days = totalDays % DAYS_PER_YEAR;
   return { years, days };
 }

--- a/src/views/PopulationView.jsx
+++ b/src/views/PopulationView.jsx
@@ -6,6 +6,7 @@ import {
   computeRoleBonuses,
 } from '../engine/settlers.js'
 import { XP_TIME_TO_NEXT_LEVEL_SECONDS } from '../data/balance.js'
+import { SETTLER_ROLES } from '../data/roles.js'
 
 export default function PopulationView() {
   const { state, setSettlerRole } = useGame()
@@ -17,10 +18,9 @@ export default function PopulationView() {
     .filter((s) => (!unassignedOnly || s.role == null))
   const { assigned, living } = assignmentsSummary(settlers)
   const bonuses = computeRoleBonuses(settlers)
-  const bonusLabels = {
-    farming: 'Food',
-    scavenging: 'Raw',
-  }
+  const bonusLabels = Object.fromEntries(
+    SETTLER_ROLES.map((r) => [r.id, r.label]),
+  )
 
   return (
     <div className="p-4 space-y-4 pb-20">
@@ -95,8 +95,11 @@ export default function PopulationView() {
                   className="appearance-none w-full rounded bg-gray-800 text-white px-3 py-2 pr-8 hover:bg-gray-700 focus:outline-none"
                 >
                   <option value="idle">idle</option>
-                  <option value="farming">farming</option>
-                  <option value="scavenging">scavenging</option>
+                  {SETTLER_ROLES.map((r) => (
+                    <option key={r.id} value={r.id}>
+                      {r.id}
+                    </option>
+                  ))}
                 </select>
                 <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
                   <span className="w-2 h-2 border-r-2 border-b-2 border-white rotate-45" />

--- a/src/views/__tests__/PopulationView.test.jsx
+++ b/src/views/__tests__/PopulationView.test.jsx
@@ -3,6 +3,7 @@ import { describe, expect, test, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import PopulationView from '../PopulationView.jsx'
 import { GameContext } from '../../state/useGame.js'
+import { SETTLER_ROLES } from '../../data/roles.js'
 
 describe('PopulationView', () => {
   test('shows idle settlers and propagates role changes', () => {
@@ -28,8 +29,9 @@ describe('PopulationView', () => {
     const select = screen.getByRole('combobox')
     expect(select.value).toBe('idle')
 
-    fireEvent.change(select, { target: { value: 'farming' } })
-    expect(setSettlerRole).toHaveBeenCalledWith('s1', 'farming')
+    const role = SETTLER_ROLES[0].id
+    fireEvent.change(select, { target: { value: role } })
+    expect(setSettlerRole).toHaveBeenCalledWith('s1', role)
   })
 })
 


### PR DESCRIPTION
## Summary
- align age calculation with game time constants so settlers age correctly
- restrict settler role assignments to a defined list and generate UI options from that list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a4583d300833197be0968da3d529b