### PR TITLE
Introduce science resource and research groundwork

### DIFF
--- a/src/components/ResourceSidebar.jsx
+++ b/src/components/ResourceSidebar.jsx
@@ -1,6 +1,7 @@
 import { useGame } from '../state/useGame.js';
 import Accordion from './Accordion.jsx';
 import { getCapacity, getResourceRates } from '../state/selectors.js';
+import { computeRoleBonuses } from '../engine/settlers.js';
 import { formatAmount } from '../utils/format.js';
 import { RESOURCE_LIST } from '../data/resources.js';
 
@@ -23,14 +24,21 @@ function ResourceRow({ icon, name, amount, capacity, rate }) {
 
 export default function ResourceSidebar() {
   const { state } = useGame();
-  const rates = getResourceRates(state, true);
-  const groups = { FOOD: [], RAW: [] };
+  const roleBonuses = computeRoleBonuses(state.population?.settlers || []);
+  const rates = getResourceRates(state, true, roleBonuses);
+  const groups = {};
+  const CATEGORY_LABELS = {
+    FOOD: 'Food',
+    RAW: 'Raw Materials',
+    SOCIETY: 'Society',
+  };
   RESOURCE_LIST.forEach((r) => {
     const amount = state.resources[r.id]?.amount || 0;
     const capacity = getCapacity(state, r.id);
     const rateInfo = rates[r.id];
     const discovered = state.resources[r.id]?.discovered;
     if (rateInfo.perSec !== 0 || amount > 0 || discovered) {
+      if (!groups[r.category]) groups[r.category] = [];
       groups[r.category].push({
         id: r.id,
         name: r.name,
@@ -41,17 +49,11 @@ export default function ResourceSidebar() {
       });
     }
   });
-  const entries = [];
-  if (groups.FOOD.length > 0) {
-    entries.push({ title: 'Food', items: groups.FOOD, defaultOpen: true });
-  }
-  if (groups.RAW.length > 0) {
-    entries.push({
-      title: 'Raw Materials',
-      items: groups.RAW,
-      defaultOpen: true,
-    });
-  }
+  const entries = Object.entries(groups).map(([cat, items]) => ({
+    title: CATEGORY_LABELS[cat] || cat,
+    items,
+    defaultOpen: true,
+  }));
 
   return (
     <div className="border border-stroke rounded overflow-hidden bg-bg2">

--- a/src/data/buildings.js
+++ b/src/data/buildings.js
@@ -40,6 +40,16 @@ export const BUILDINGS = [
     description: 'Extracts stone slowly but steadily.',
   },
   {
+    id: 'school',
+    name: 'School',
+    type: 'production',
+    outputsPerSecBase: { science: 0.5 },
+    costBase: { wood: 25, scrap: 10, stone: 10 },
+    costGrowth: 1.15,
+    refund: 0.5,
+    description: 'Provides basic education and generates science.',
+  },
+  {
     id: 'foodStorage',
     name: 'Granary',
     type: 'storage',

--- a/src/data/resources.js
+++ b/src/data/resources.js
@@ -31,6 +31,14 @@ export const RESOURCES = {
     startingAmount: 0,
     startingCapacity: 100,
   },
+  science: {
+    id: 'science',
+    name: 'Science',
+    icon: '🔬',
+    category: 'SOCIETY',
+    startingAmount: 0,
+    startingCapacity: 400,
+  },
 };
 
 export const RESOURCE_LIST = Object.values(RESOURCES);

--- a/src/data/roles.js
+++ b/src/data/roles.js
@@ -23,6 +23,12 @@ export const ROLES = {
     skill: 'Quarrying',
     resource: 'stone',
   },
+  scientist: {
+    id: 'scientist',
+    name: 'Scientist',
+    skill: 'Scientist',
+    resource: 'science',
+  },
 };
 
 export const ROLE_LIST = Object.values(ROLES);

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -3,6 +3,7 @@ import { RESOURCES } from '../data/resources.js';
 import { getSeason, getSeasonMultiplier } from '../engine/time.js';
 import { formatRate } from '../utils/format.js';
 import { BALANCE } from '../data/balance.js';
+import { ROLE_BY_RESOURCE } from '../data/roles.js';
 
 export function getCapacity(state, resourceId) {
   const base = RESOURCES[resourceId]?.startingCapacity || 0;
@@ -16,7 +17,11 @@ export function getCapacity(state, resourceId) {
   return base + fromBuildings;
 }
 
-export function getResourceRates(state, includeConsumption = false) {
+export function getResourceRates(
+  state,
+  includeConsumption = false,
+  roleBonuses = {},
+) {
   const season = getSeason(state);
   const rates = {};
   PRODUCTION_BUILDINGS.forEach((b) => {
@@ -25,7 +30,9 @@ export function getResourceRates(state, includeConsumption = false) {
     Object.entries(b.outputsPerSecBase).forEach(([res, base]) => {
       const category = RESOURCES[res].category;
       const mult = getSeasonMultiplier(season, category);
-      const perSec = base * mult * count;
+      const role = ROLE_BY_RESOURCE[res];
+      const bonusPercent = roleBonuses[role] || 0;
+      const perSec = base * mult * count * (1 + bonusPercent / 100);
       rates[res] = (rates[res] || 0) + perSec;
     });
   });

--- a/src/views/ResearchView.jsx
+++ b/src/views/ResearchView.jsx
@@ -1,3 +1,7 @@
 export default function ResearchView() {
-  return <div className="p-4 pb-20">Coming soon</div>;
+  return (
+    <div className="p-4 pb-20">
+      <h1 className="font-semibold text-lg">Research (WIP)</h1>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add configurable Science resource under new Society sidebar group
- implement School building and Scientist role with level-scaled bonuses
- scaffold Research view for future tech tree

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a5e4eab6883319979b139b08b8eec