### PR TITLE
Restrict survivor roles to available buildings

### DIFF
--- a/src/data/roles.js
+++ b/src/data/roles.js
@@ -4,30 +4,35 @@ export const ROLES = {
     name: 'Farmer',
     skill: 'Farming',
     resource: 'potatoes',
+    building: 'potatoField',
   },
   woodcutter: {
     id: 'woodcutter',
     name: 'Woodcutter',
     skill: 'Woodcutting',
     resource: 'wood',
+    building: 'loggingCamp',
   },
   scavenger: {
     id: 'scavenger',
     name: 'Scavenger',
     skill: 'Scavenging',
     resource: 'scrap',
+    building: 'scrapyard',
   },
   quarryWorker: {
     id: 'quarryWorker',
     name: 'Quarry Worker',
     skill: 'Quarrying',
     resource: 'stone',
+    building: 'quarry',
   },
   scientist: {
     id: 'scientist',
     name: 'Scientist',
     skill: 'Scientist',
     resource: 'science',
+    building: 'school',
   },
 };
 
@@ -37,4 +42,11 @@ export const ROLE_BY_RESOURCE = Object.fromEntries(
 );
 export const SKILL_LABELS = Object.fromEntries(
   ROLE_LIST.map((r) => [r.id, r.skill]),
+);
+
+export const ROLE_BUILDINGS = Object.fromEntries(
+  ROLE_LIST.map((r) => [r.id, r.building]),
+);
+export const BUILDING_ROLES = Object.fromEntries(
+  ROLE_LIST.map((r) => [r.building, r.id]),
 );

--- a/src/engine/__tests__/economy.test.js
+++ b/src/engine/__tests__/economy.test.js
@@ -25,4 +25,25 @@ describe('economy basics', () => {
       Math.floor(prevCost.wood * blueprint.refund),
     );
   });
+
+  test('removing last required building unassigns settlers', () => {
+    const state = clone(defaultState);
+    state.buildings.potatoField.count = 1;
+    state.population = {
+      settlers: [
+        {
+          id: 's1',
+          firstName: 'A',
+          lastName: 'B',
+          role: 'farmer',
+          skills: { farmer: { level: 3, xp: 0 } },
+        },
+      ],
+    };
+    const after = demolishBuilding(state, 'potatoField');
+    expect(after.buildings.potatoField.count).toBe(0);
+    const settler = after.population.settlers[0];
+    expect(settler.role).toBe(null);
+    expect(settler.skills.farmer.level).toBe(3);
+  });
 });

--- a/src/engine/production.js
+++ b/src/engine/production.js
@@ -4,7 +4,7 @@ import {
   getBuildingCost,
 } from '../data/buildings.js';
 import { RESOURCES } from '../data/resources.js';
-import { ROLE_BY_RESOURCE } from '../data/roles.js';
+import { ROLE_BY_RESOURCE, BUILDING_ROLES } from '../data/roles.js';
 import { getSeason, getSeasonMultiplier } from './time.js';
 import { getCapacity, getResearchOutputBonus } from '../state/selectors.js';
 import { BALANCE } from '../data/balance.js';
@@ -113,5 +113,19 @@ export function demolishBuilding(state, buildingId) {
     entry.amount = clampResource(entry.amount, capacity);
     if (entry.amount > 0) entry.discovered = true;
   });
-  return { ...state, resources, buildings };
+  let settlers = state.population?.settlers || [];
+  if ((buildings[buildingId]?.count || 0) <= 0) {
+    const role = BUILDING_ROLES[buildingId];
+    if (role) {
+      settlers = settlers.map((s) =>
+        s.role === role ? { ...s, role: null } : s,
+      );
+    }
+  }
+  return {
+    ...state,
+    resources,
+    buildings,
+    population: { ...state.population, settlers },
+  };
 }

--- a/src/state/GameContext.jsx
+++ b/src/state/GameContext.jsx
@@ -18,6 +18,7 @@ import {
 } from '../engine/time.js';
 import { getResourceRates } from './selectors.js';
 import { RESOURCES } from '../data/resources.js';
+import { ROLE_BUILDINGS } from '../data/roles.js';
 
 export function GameProvider({ children }) {
   const [state, setState] = useState(() => {
@@ -154,6 +155,11 @@ export function GameProvider({ children }) {
       const settler = prev.population.settlers.find((s) => s.id === id);
       if (!settler) return prev;
       const normalized = role === 'idle' ? null : role;
+      if (normalized) {
+        const building = ROLE_BUILDINGS[normalized];
+        const count = prev.buildings?.[building]?.count || 0;
+        if (count <= 0) return prev;
+      }
       const settlers = prev.population.settlers.map((s) =>
         s.id === id ? { ...s, role: normalized } : s,
       );

--- a/src/views/PopulationView.jsx
+++ b/src/views/PopulationView.jsx
@@ -11,6 +11,9 @@ export default function PopulationView() {
   const [onlyLiving, setOnlyLiving] = useState(true);
   const [unassignedOnly, setUnassignedOnly] = useState(false);
   const settlers = state.population?.settlers ?? [];
+  const availableRoles = ROLE_LIST.filter(
+    (r) => (state.buildings?.[r.building]?.count || 0) > 0,
+  );
   const filtered = settlers
     .filter((s) => !onlyLiving || !s.isDead)
     .filter((s) => !unassignedOnly || s.role == null);
@@ -100,7 +103,7 @@ export default function PopulationView() {
                   className="appearance-none w-full rounded bg-gray-800 text-white px-3 py-2 pr-8 hover:bg-gray-700 focus:outline-none"
                 >
                   <option value="idle">Idle</option>
-                  {ROLE_LIST.map((r) => (
+                  {availableRoles.map((r) => (
                     <option key={r.id} value={r.id}>
                       {r.name}
                     </option>

--- a/src/views/__tests__/PopulationView.test.jsx
+++ b/src/views/__tests__/PopulationView.test.jsx
@@ -17,7 +17,10 @@ describe('PopulationView', () => {
       skills: {},
     };
     const setSettlerRole = vi.fn();
-    const state = { population: { settlers: [settler] } };
+    const state = {
+      population: { settlers: [settler] },
+      buildings: { potatoField: { count: 1 } },
+    };
 
     render(
       <GameContext.Provider value={{ state, setSettlerRole }}>


### PR DESCRIPTION
## Summary
- Link each role to a required building and expose mappings
- Prevent assigning roles when the required building is missing
- Auto-unassign settlers when their building is demolished and keep their skills
- Only show assignable roles in the population view

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a6610225883319fa2ccb21f5c3101