### PR TITLE
Default EventLog log prop to empty array

### DIFF
--- a/src/components/EventLog.jsx
+++ b/src/components/EventLog.jsx
@@ -1,4 +1,6 @@
-export default function EventLog({ log }) {
+import React from 'react';
+
+export default function EventLog({ log = [] }) {
   return (
     <ul className="text-sm space-y-1">
       {log.map((entry, i) => (

--- a/src/components/EventLog.test.jsx
+++ b/src/components/EventLog.test.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import EventLog from './EventLog.jsx';
+
+describe('EventLog', () => {
+  it('renders without log prop', () => {
+    render(<EventLog />);
+    expect(screen.getByRole('list')).toBeTruthy();
+    expect(screen.queryAllByRole('listitem')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Default `EventLog`'s `log` prop to an empty array
- Add unit test ensuring `EventLog` renders without a `log`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a664e9f748331bc33956398ee9da5