### PR TITLE
Handle corrupted saves with recovery prompt

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import TopBar from './components/TopBar.jsx';
 import BottomDock from './components/BottomDock.jsx';
 import Drawer from './components/Drawer.jsx';
 import OfflineProgressModal from './components/OfflineProgressModal.jsx';
+import CorruptSaveModal from './components/CorruptSaveModal.jsx';
 import BaseView from './views/BaseView.jsx';
 import PopulationView from './views/PopulationView.jsx';
 import ResearchView from './views/ResearchView.jsx';
@@ -34,6 +35,7 @@ export default function App() {
         <BottomDock />
         <Drawer />
         <OfflineProgressModal />
+        <CorruptSaveModal />
       </div>
     </GameProvider>
   );

--- a/src/components/CorruptSaveModal.jsx
+++ b/src/components/CorruptSaveModal.jsx
@@ -1,0 +1,28 @@
+import { useGame } from '../state/useGame.js';
+
+export default function CorruptSaveModal() {
+  const { loadError, retryLoad, resetGame } = useGame();
+  if (!loadError) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-bg2 p-4 rounded border border-stroke max-w-sm w-full space-y-4">
+        <h2 className="font-semibold text-lg">Save Load Failed</h2>
+        <p>Your save data appears corrupted.</p>
+        <div className="flex justify-end gap-2">
+          <button
+            className="px-4 py-2 rounded border border-stroke"
+            onClick={retryLoad}
+          >
+            Retry
+          </button>
+          <button
+            className="px-4 py-2 rounded border border-stroke"
+            onClick={resetGame}
+          >
+            Reset
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/engine/persistence.js
+++ b/src/engine/persistence.js
@@ -89,14 +89,14 @@ export function saveGame(state) {
 }
 
 export function loadGame() {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return { state: null, error: null };
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return null;
     const { state } = load(raw);
-    return state;
+    return { state, error: null };
   } catch (err) {
     console.error('Load failed', err);
-    return null;
+    return { state: null, error: err };
   }
 }
 


### PR DESCRIPTION
## Summary
- surface load errors from persistence so GameProvider knows when a save fails to load
- add retry/reset logic and modal to let users recover from corrupted saves
- render the corrupted-save modal in the app shell

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a66502418833198067095ff5619aa