### PR TITLE
fix: correct seasonal multipliers in economy report

### DIFF
--- a/docs/ECONOMY_REPORT.md
+++ b/docs/ECONOMY_REPORT.md
@@ -1,52 +1,45 @@
 # Economy Report
 
 ## 1) Overview
-
-Economy generated from commit **bbcec0abfb9fbb25d8a5b49d06f567ef68ca3f94** on 2025-08-11 17:35:30 +0200. Save version: **2**.
+Economy generated from commit **d569ef1fc8d61e5b00e36debd246dfcdfd144d7b** on 2025-08-12 00:19:16 +0200. Save version: **3**.
 Each tick represents 1 second. For each building: base production is modified by season multipliers, summed, then clamped to capacity. Offline progress processes in 60-second chunks.
 
 ## 2) Resources
-
-| key   | displayName | category  | startingAmount | startingCapacity | unit |
-| ----- | ----------- | --------- | -------------- | ---------------- | ---- |
-| food  | Food        | food      | 0              | 300              |      |
-| wood  | Wood        | resources | 0              | 100              |      |
-| plank | Planks      | resources | 0              | 0                |      |
-| scrap | Scrap       | resources | 0              | 100              |      |
-| metal | Metal Bars  | resources | 0              | 0                |      |
-| water | Water       | food      | 0              | 100              |      |
+| key | displayName | category | startingAmount | startingCapacity | unit |
+| - | - | - | - | - | - |
+| potatoes | Potatoes | FOOD | 0 | 300 |  |
+| wood | Wood | RAW | 0 | 100 |  |
+| stone | Stone | RAW | 0 | 100 |  |
+| scrap | Scrap | RAW | 0 | 100 |  |
+| planks | Planks | CONSTRUCTION_MATERIALS | 0 | 0 |  |
+| metalParts | Metal Parts | CONSTRUCTION_MATERIALS | 0 | 0 |  |
+| science | Science | SOCIETY | 0 | 400 |  |
 
 Global rules: resources cannot go negative; amounts are clamped to capacity.
 
 ## 3) Seasons and Global Modifiers
-
-| season | duration (sec) | food  | wood  | plank | scrap | metal | water |
-| ------ | -------------- | ----- | ----- | ----- | ----- | ----- | ----- |
-| spring | 270            | 1.375 | 1.375 | 1.375 | 1.375 | 1.000 | 1.250 |
-| summer | 270            | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
-| autumn | 270            | 0.909 | 0.909 | 0.909 | 0.909 | 1.000 | 0.909 |
-| winter | 270            | 0.000 | 0.000 | 0.000 | 0.000 | 1.000 | 0.500 |
+| season | duration (sec) | potatoes | wood | stone | scrap | planks | metalParts | science |
+| - | - | - | - | - | - | - | - | - |
+| spring | 270 | 1.250 | 1.100 | 1.100 | 1.100 | 1.000 | 1.000 | 1.000 |
+| summer | 270 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
+| autumn | 270 | 0.850 | 0.900 | 0.900 | 0.900 | 1.000 | 1.000 | 1.000 |
+| winter | 270 | 0.000 | 0.800 | 0.800 | 0.800 | 1.000 | 1.000 | 1.000 |
 
 ## 4) Buildings
-
-| id          | name         | type       | cost                            | refund | storage               | base prod/s  | season mults                               |
-| ----------- | ------------ | ---------- | ------------------------------- | ------ | --------------------- | ------------ | ------------------------------------------ |
-| potatoField | Potato Field | production | wood: 20                        | 0.5    | -                     | food: 0.375  | spring: 1.375, summer: 1, autumn: 0.909    |
-| cornField   | Corn Field   | production | wood: 30                        | 0.5    | -                     | food: 0.4    | spring: 1.375, summer: 1, autumn: 0.909    |
-| ricePaddy   | Rice Paddy   | production | wood: 15                        | 0.5    | -                     | food: 0.333  | spring: 1.375, summer: 1, autumn: 0.909    |
-| loggingCamp | Logging Camp | production | scrap: 50                       | 0.5    | -                     | wood: 0.167  | spring: 1.375, summer: 1, autumn: 0.909    |
-| sawmill     | Sawmill      | production | scrap: 30, wood: 40, plank: 10  | 0.5    | -                     | plank: 0.25  | spring: 1.375, summer: 1, autumn: 0.909    |
-| scrapYard   | Scrap Yard   | production | -                               | 0.5    | -                     | scrap: 0.143 | spring: 1.375, summer: 1, autumn: 0.909    |
-| smelter     | Smelter      | production | scrap: 100, wood: 50, plank: 20 | 0.5    | -                     | metal: 0.1   | spring: 1, summer: 1, autumn: 1, winter: 1 |
-| granary     | Granary      | storage    | scrap: 20, wood: 60, plank: 10  | 0.5    | food: 200             | -            | -                                          |
-| warehouse   | Warehouse    | storage    | scrap: 30, wood: 80, plank: 20  | 0.5    | wood: 200, scrap: 200 | -            | -                                          |
+| id | name | type | cost | refund | storage | base prod/s | season mults |
+| - | - | - | - | - | - | - | - |
+| potatoField | Potato Field | production | - | 0.5 | - | potatoes: 0.375 | spring: 1.25, summer: 1, autumn: 0.85 |
+| loggingCamp | Logging Camp | production | - | 0.5 | - | wood: 0.2 | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
+| scrapyard | Scrap Yard | production | - | 0.5 | - | scrap: 0.06 | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
+| quarry | Quarry | production | - | 0.5 | - | stone: 0.08 | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
+| school | School | production | - | 0.5 | - | science: 0.5 | spring: 1, summer: 1, autumn: 1, winter: 1 |
+| foodStorage | Granary | storage | - | 0.5 | - | - | - |
+| rawStorage | Warehouse | storage | - | 0.5 | - | - | - |
 
 ## 5) Population and Roles
-
 No role-based production modifiers in effect.
 
 ## 6) Production Math (Exact Formula)
-
 Per building per tick:
 
 `effectiveCycle = cycleTimeSec * seasonSpeed`
@@ -62,27 +55,23 @@ Sum production for each resource across buildings, then `clampResource(value, ca
 Offline progress is applied in 60-second chunks.
 
 ## 7) Costs, Refunds, and Edge Rules
-
 Building costs scale by `cost * 1.15^count`, rounded up. Demolition refunds 50% of the previous cost (floored) and adds back resources subject to capacity. Resource values are rounded to 6 decimals in clamping and cannot be negative.
 
 ## 8) Starting State
-
 Starting season: spring, Year: 1.
 
 ### Resources
-
 | resource | amount | capacity |
-| -------- | ------ | -------- |
-| food     | 0      | 300      |
-| wood     | 0      | 100      |
-| plank    | 0      | 0        |
-| scrap    | 0      | 100      |
-| metal    | 0      | 0        |
-| water    | 0      | 100      |
+| - | - | - |
+| potatoes | 0 | 300 |
+| wood | 0 | 100 |
+| stone | 0 | 100 |
+| scrap | 0 | 100 |
+| planks | 0 | 0 |
+| metalParts | 0 | 0 |
+| science | 0 | 400 |
 
 ### Buildings
+| building | count |
+| - | - |
 
-| building    | count |
-| ----------- | ----- |
-| potatoField | 1     |
-| loggingCamp | 1     |

--- a/docs/economy-snapshot.json
+++ b/docs/economy-snapshot.json
@@ -1,58 +1,62 @@
 {
-  "version": "bbcec0abfb9fbb25d8a5b49d06f567ef68ca3f94",
-  "saveVersion": 2,
+  "version": "d569ef1fc8d61e5b00e36debd246dfcdfd144d7b",
+  "saveVersion": 3,
   "tickSeconds": 1,
   "seasons": {
     "spring": {
       "durationSec": 270,
       "multipliers": {
-        "food": 1.375,
-        "wood": 1.375,
-        "plank": 1.375,
-        "scrap": 1.375,
-        "metal": 1,
-        "water": 1.25
+        "potatoes": 1.25,
+        "wood": 1.1,
+        "stone": 1.1,
+        "scrap": 1.1,
+        "planks": 1,
+        "metalParts": 1,
+        "science": 1
       }
     },
     "summer": {
       "durationSec": 270,
       "multipliers": {
-        "food": 1,
+        "potatoes": 1,
         "wood": 1,
-        "plank": 1,
+        "stone": 1,
         "scrap": 1,
-        "metal": 1,
-        "water": 1
+        "planks": 1,
+        "metalParts": 1,
+        "science": 1
       }
     },
     "autumn": {
       "durationSec": 270,
       "multipliers": {
-        "food": 0.9090909090909091,
-        "wood": 0.9090909090909091,
-        "plank": 0.9090909090909091,
-        "scrap": 0.9090909090909091,
-        "metal": 1,
-        "water": 0.9090909090909091
+        "potatoes": 0.85,
+        "wood": 0.9,
+        "stone": 0.9,
+        "scrap": 0.9,
+        "planks": 1,
+        "metalParts": 1,
+        "science": 1
       }
     },
     "winter": {
       "durationSec": 270,
       "multipliers": {
-        "food": 0,
-        "wood": 0,
-        "plank": 0,
-        "scrap": 0,
-        "metal": 1,
-        "water": 0.5
+        "potatoes": 0,
+        "wood": 0.8,
+        "stone": 0.8,
+        "scrap": 0.8,
+        "planks": 1,
+        "metalParts": 1,
+        "science": 1
       }
     }
   },
   "resources": [
     {
-      "key": "food",
-      "displayName": "Food",
-      "category": "food",
+      "key": "potatoes",
+      "displayName": "Potatoes",
+      "category": "FOOD",
       "startingAmount": 0,
       "startingCapacity": 300,
       "unit": null
@@ -60,41 +64,49 @@
     {
       "key": "wood",
       "displayName": "Wood",
-      "category": "resources",
+      "category": "RAW",
       "startingAmount": 0,
       "startingCapacity": 100,
       "unit": null
     },
     {
-      "key": "plank",
-      "displayName": "Planks",
-      "category": "resources",
+      "key": "stone",
+      "displayName": "Stone",
+      "category": "RAW",
       "startingAmount": 0,
-      "startingCapacity": 0,
+      "startingCapacity": 100,
       "unit": null
     },
     {
       "key": "scrap",
       "displayName": "Scrap",
-      "category": "resources",
+      "category": "RAW",
       "startingAmount": 0,
       "startingCapacity": 100,
       "unit": null
     },
     {
-      "key": "metal",
-      "displayName": "Metal Bars",
-      "category": "resources",
+      "key": "planks",
+      "displayName": "Planks",
+      "category": "CONSTRUCTION_MATERIALS",
       "startingAmount": 0,
       "startingCapacity": 0,
       "unit": null
     },
     {
-      "key": "water",
-      "displayName": "Water",
-      "category": "food",
+      "key": "metalParts",
+      "displayName": "Metal Parts",
+      "category": "CONSTRUCTION_MATERIALS",
       "startingAmount": 0,
-      "startingCapacity": 100,
+      "startingCapacity": 0,
+      "unit": null
+    },
+    {
+      "key": "science",
+      "displayName": "Science",
+      "category": "SOCIETY",
+      "startingAmount": 0,
+      "startingCapacity": 400,
       "unit": null
     }
   ],
@@ -103,71 +115,18 @@
       "id": "potatoField",
       "name": "Potato Field",
       "type": "production",
-      "constructionCost": {
-        "scrap": 0,
-        "wood": 20,
-        "plank": 0,
-        "metal": 0
-      },
+      "constructionCost": {},
       "demolitionRefund": 0.5,
       "storageProvided": {},
       "baseProductionPerSec": {
-        "food": 0.375
+        "potatoes": 0.375
       },
-      "seasonalMode": "default",
+      "seasonalMode": "ignore",
       "seasonalCustom": null,
       "seasonalMultipliers": {
-        "spring": 1.375,
+        "spring": 1.25,
         "summer": 1,
-        "autumn": 0.9090909090909091,
-        "winter": 0
-      }
-    },
-    {
-      "id": "cornField",
-      "name": "Corn Field",
-      "type": "production",
-      "constructionCost": {
-        "scrap": 0,
-        "wood": 30,
-        "plank": 0,
-        "metal": 0
-      },
-      "demolitionRefund": 0.5,
-      "storageProvided": {},
-      "baseProductionPerSec": {
-        "food": 0.4
-      },
-      "seasonalMode": "default",
-      "seasonalCustom": null,
-      "seasonalMultipliers": {
-        "spring": 1.375,
-        "summer": 1,
-        "autumn": 0.9090909090909091,
-        "winter": 0
-      }
-    },
-    {
-      "id": "ricePaddy",
-      "name": "Rice Paddy",
-      "type": "production",
-      "constructionCost": {
-        "scrap": 0,
-        "wood": 15,
-        "plank": 0,
-        "metal": 0
-      },
-      "demolitionRefund": 0.5,
-      "storageProvided": {},
-      "baseProductionPerSec": {
-        "food": 0.3333333333333333
-      },
-      "seasonalMode": "default",
-      "seasonalCustom": null,
-      "seasonalMultipliers": {
-        "spring": 1.375,
-        "summer": 1,
-        "autumn": 0.9090909090909091,
+        "autumn": 0.85,
         "winter": 0
       }
     },
@@ -175,90 +134,70 @@
       "id": "loggingCamp",
       "name": "Logging Camp",
       "type": "production",
-      "constructionCost": {
-        "scrap": 50,
-        "wood": 0,
-        "plank": 0,
-        "metal": 0
-      },
+      "constructionCost": {},
       "demolitionRefund": 0.5,
       "storageProvided": {},
       "baseProductionPerSec": {
-        "wood": 0.16666666666666666
+        "wood": 0.2
       },
-      "seasonalMode": "default",
+      "seasonalMode": "ignore",
       "seasonalCustom": null,
       "seasonalMultipliers": {
-        "spring": 1.375,
+        "spring": 1.1,
         "summer": 1,
-        "autumn": 0.9090909090909091,
-        "winter": 0
+        "autumn": 0.9,
+        "winter": 0.8
       }
     },
     {
-      "id": "sawmill",
-      "name": "Sawmill",
-      "type": "production",
-      "constructionCost": {
-        "scrap": 30,
-        "wood": 40,
-        "plank": 10,
-        "metal": 0
-      },
-      "demolitionRefund": 0.5,
-      "storageProvided": {},
-      "baseProductionPerSec": {
-        "plank": 0.25
-      },
-      "seasonalMode": "default",
-      "seasonalCustom": null,
-      "seasonalMultipliers": {
-        "spring": 1.375,
-        "summer": 1,
-        "autumn": 0.9090909090909091,
-        "winter": 0
-      }
-    },
-    {
-      "id": "scrapYard",
+      "id": "scrapyard",
       "name": "Scrap Yard",
       "type": "production",
-      "constructionCost": {
-        "scrap": 0,
-        "wood": 0,
-        "plank": 0,
-        "metal": 0
-      },
+      "constructionCost": {},
       "demolitionRefund": 0.5,
       "storageProvided": {},
       "baseProductionPerSec": {
-        "scrap": 0.14285714285714285
+        "scrap": 0.06
       },
-      "seasonalMode": "default",
+      "seasonalMode": "ignore",
       "seasonalCustom": null,
       "seasonalMultipliers": {
-        "spring": 1.375,
+        "spring": 1.1,
         "summer": 1,
-        "autumn": 0.9090909090909091,
-        "winter": 0
+        "autumn": 0.9,
+        "winter": 0.8
       }
     },
     {
-      "id": "smelter",
-      "name": "Smelter",
+      "id": "quarry",
+      "name": "Quarry",
       "type": "production",
-      "constructionCost": {
-        "scrap": 100,
-        "wood": 50,
-        "plank": 20,
-        "metal": 0
-      },
+      "constructionCost": {},
       "demolitionRefund": 0.5,
       "storageProvided": {},
       "baseProductionPerSec": {
-        "metal": 0.1
+        "stone": 0.08
       },
-      "seasonalMode": "default",
+      "seasonalMode": "ignore",
+      "seasonalCustom": null,
+      "seasonalMultipliers": {
+        "spring": 1.1,
+        "summer": 1,
+        "autumn": 0.9,
+        "winter": 0.8
+      }
+    },
+    {
+      "id": "school",
+      "name": "School",
+      "type": "production",
+      "constructionCost": {},
+      "demolitionRefund": 0.5,
+      "storageProvided": {},
+      "baseProductionPerSec": {
+        "science": 0.5
+      },
+      "seasonalMode": "ignore",
       "seasonalCustom": null,
       "seasonalMultipliers": {
         "spring": 1,
@@ -268,39 +207,24 @@
       }
     },
     {
-      "id": "granary",
+      "id": "foodStorage",
       "name": "Granary",
       "type": "storage",
-      "constructionCost": {
-        "scrap": 20,
-        "wood": 60,
-        "plank": 10,
-        "metal": 0
-      },
+      "constructionCost": {},
       "demolitionRefund": 0.5,
-      "storageProvided": {
-        "food": 200
-      },
+      "storageProvided": {},
       "baseProductionPerSec": {},
       "seasonalMode": "ignore",
       "seasonalCustom": null,
       "seasonalMultipliers": {}
     },
     {
-      "id": "warehouse",
+      "id": "rawStorage",
       "name": "Warehouse",
       "type": "storage",
-      "constructionCost": {
-        "scrap": 30,
-        "wood": 80,
-        "plank": 20,
-        "metal": 0
-      },
+      "constructionCost": {},
       "demolitionRefund": 0.5,
-      "storageProvided": {
-        "wood": 200,
-        "scrap": 200
-      },
+      "storageProvided": {},
       "baseProductionPerSec": {},
       "seasonalMode": "ignore",
       "seasonalCustom": null,
@@ -309,7 +233,13 @@
   ],
   "roles": [],
   "formula": {
-    "order": ["base", "season", "roles", "sum", "clamp"],
+    "order": [
+      "base",
+      "season",
+      "roles",
+      "sum",
+      "clamp"
+    ],
     "demolitionRefund": 0.5,
     "clampRule": "min(value, capacity) and never negative"
   },
@@ -317,16 +247,14 @@
     "season": "spring",
     "year": 1,
     "resources": {
-      "food": 0,
+      "potatoes": 0,
       "wood": 0,
-      "plank": 0,
+      "stone": 0,
       "scrap": 0,
-      "metal": 0,
-      "water": 0
+      "planks": 0,
+      "metalParts": 0,
+      "science": 0
     },
-    "buildings": {
-      "potatoField": 1,
-      "loggingCamp": 1
-    }
+    "buildings": {}
   }
 }


### PR DESCRIPTION
## Summary
- derive resource multipliers from season category data
- add helper to compute building season modifiers and use in report
- refresh generated economy snapshot and documentation

## Testing
- `npm run report:economy`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a6e78f1e48331b98d9ff00e920179