### PR TITLE
Use stable IDs for event log entries

### DIFF
--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import { useGame } from '../state/useGame.js';
 import { exportSaveFile, load } from '../engine/persistence.js';
+import { createLogEntry } from '../utils/log.js';
 
 export default function Drawer() {
   const { state, toggleDrawer, setState, resetGame } = useGame();
@@ -13,10 +14,10 @@ export default function Drawer() {
     if (file.type !== 'application/json') {
       setState((prev) => ({
         ...prev,
-        log: ['Failed to load save: Invalid file type', ...prev.log].slice(
-          0,
-          100,
-        ),
+        log: [
+          createLogEntry('Failed to load save: Invalid file type'),
+          ...prev.log,
+        ].slice(0, 100),
       }));
       e.target.value = '';
       return;
@@ -30,16 +31,16 @@ export default function Drawer() {
         const note = migratedFrom
           ? `Save loaded (migrated from v${migratedFrom})`
           : 'Save loaded';
-        const log = [note, ...(loaded.log || [])].slice(0, 100);
+        const log = [createLogEntry(note), ...(loaded.log || [])].slice(0, 100);
         setState({ ...loaded, log });
       } catch (err) {
         console.error(err);
         setState((prev) => ({
           ...prev,
-          log: [`Failed to load save: ${err.message}`, ...prev.log].slice(
-            0,
-            100,
-          ),
+          log: [
+            createLogEntry(`Failed to load save: ${err.message}`),
+            ...prev.log,
+          ].slice(0, 100),
         }));
       }
     };
@@ -74,7 +75,10 @@ export default function Drawer() {
                   exportSaveFile(state);
                   setState((prev) => ({
                     ...prev,
-                    log: ['Save exported', ...prev.log].slice(0, 100),
+                    log: [createLogEntry('Save exported'), ...prev.log].slice(
+                      0,
+                      100,
+                    ),
                   }));
                 }}
               >

--- a/src/components/EventLog.jsx
+++ b/src/components/EventLog.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 export default function EventLog({ log = [] }) {
   return (
     <ul className="text-sm space-y-1">
-      {log.map((entry, i) => (
-        <li key={i}>{entry}</li>
+      {log.map((entry) => (
+        <li key={entry.id}>{entry.text}</li>
       ))}
     </ul>
   );

--- a/src/components/EventLog.test.jsx
+++ b/src/components/EventLog.test.jsx
@@ -9,4 +9,19 @@ describe('EventLog', () => {
     expect(screen.getByRole('list')).toBeTruthy();
     expect(screen.queryAllByRole('listitem')).toHaveLength(0);
   });
+
+  it('renders and updates entries', () => {
+    const initial = [
+      { id: 'a', text: 'First entry' },
+      { id: 'b', text: 'Second entry' },
+    ];
+    const { rerender } = render(<EventLog log={initial} />);
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+    expect(screen.getByText('First entry')).toBeTruthy();
+
+    rerender(<EventLog log={[initial[1]]} />);
+    expect(screen.queryByText('First entry')).toBeNull();
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+    expect(screen.getByText('Second entry')).toBeTruthy();
+  });
 });

--- a/src/engine/__tests__/persistence.test.js
+++ b/src/engine/__tests__/persistence.test.js
@@ -29,7 +29,7 @@ describe('persistence migrations and validation', () => {
 
   it('fails validation when essential data is missing', () => {
     const base = {
-      version: 3,
+      version: CURRENT_SAVE_VERSION,
       resources: {},
       buildings: {},
       ui: { activeTab: 'base', drawerOpen: false, offlineProgress: null },
@@ -51,5 +51,24 @@ describe('persistence migrations and validation', () => {
 
     const missingSettlers = { ...base, population: {} };
     expect(() => validateSave(missingSettlers)).toThrow();
+  });
+
+  it('converts string log entries to objects', () => {
+    const oldSave = {
+      version: 3,
+      resources: {},
+      buildings: {},
+      ui: { activeTab: 'base', drawerOpen: false, offlineProgress: null },
+      log: ['hello world'],
+      research: { current: null, completed: [], progress: {} },
+      population: { settlers: [] },
+    };
+
+    const { state, migratedFrom } = load(JSON.stringify(oldSave));
+    expect(migratedFrom).toBe(3);
+    expect(state.version).toBe(CURRENT_SAVE_VERSION);
+    expect(state.log).toHaveLength(1);
+    expect(state.log[0].text).toBe('hello world');
+    expect(typeof state.log[0].id).toBe('string');
   });
 });

--- a/src/state/GameContext.jsx
+++ b/src/state/GameContext.jsx
@@ -25,6 +25,7 @@ import {
 import { getResourceRates } from './selectors.js';
 import { RESOURCES } from '../data/resources.js';
 import { ROLE_BUILDINGS } from '../data/roles.js';
+import { createLogEntry } from '../utils/log.js';
 
 function mergeDeep(target, source) {
   const out = { ...target };
@@ -252,7 +253,9 @@ if (loaded) {
         s.id === id ? { ...s, role: normalized } : s,
       );
       const roleName = normalized ?? 'idle';
-      const entry = `${settler.firstName} ${settler.lastName} is now ${roleName}`;
+      const entry = createLogEntry(
+        `${settler.firstName} ${settler.lastName} is now ${roleName}`,
+      );
       const log = [entry, ...prev.log].slice(0, 100);
       return { ...prev, population: { ...prev.population, settlers }, log };
     });

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -1,0 +1,8 @@
+export function createLogEntry(text) {
+  return {
+    id: globalThis.crypto?.randomUUID
+      ? globalThis.crypto.randomUUID()
+      : Date.now().toString(36) + Math.random().toString(36).slice(2),
+    text,
+  };
+}


### PR DESCRIPTION
## Summary
- represent event log entries with stable ids
- update persistence to migrate and validate new log structure
- cover event log rendering and migration in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a70588b348331bfcf0082e3e6d844