### PR TITLE
Use clampResource in BaseView resource updates

### DIFF
--- a/src/components/Accordion.jsx
+++ b/src/components/Accordion.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 
 export default function Accordion({ title, children, defaultOpen = false }) {
   const [open, setOpen] = useState(defaultOpen);

--- a/src/components/ResourceSidebar.jsx
+++ b/src/components/ResourceSidebar.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useGame } from '../state/useGame.js';
 import Accordion from './Accordion.jsx';
 import { getCapacity, getResourceRates } from '../state/selectors.js';

--- a/src/views/BaseView.jsx
+++ b/src/views/BaseView.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useGame } from '../state/useGame.js';
 import EventLog from '../components/EventLog.jsx';
 import ResourceSidebar from '../components/ResourceSidebar.jsx';
@@ -11,7 +12,7 @@ import { RESOURCES } from '../data/resources.js';
 import { getSeason, getSeasonMultiplier } from '../engine/time.js';
 import { getCapacity } from '../state/selectors.js';
 import { formatAmount, formatRate } from '../utils/format.js';
-import { demolishBuilding } from '../engine/production.js';
+import { clampResource, demolishBuilding } from '../engine/production.js';
 
 function BuildingRow({ building }) {
   const { state, setState } = useGame();
@@ -49,7 +50,7 @@ function BuildingRow({ building }) {
       Object.keys(resources).forEach((res) => {
         const cap = getCapacity({ ...prev, buildings }, res);
         const entry = resources[res];
-        entry.amount = Math.min(cap, entry.amount);
+        entry.amount = clampResource(entry.amount, cap);
         if (entry.amount > 0) entry.discovered = true;
       });
       return { ...prev, resources, buildings };

--- a/src/views/__tests__/BaseView.test.jsx
+++ b/src/views/__tests__/BaseView.test.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { describe, expect, test } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import BaseView from '../BaseView.jsx';
+import { GameContext } from '../../state/useGame.js';
+
+describe('BaseView', () => {
+  test('build clamps negative resource amounts to zero', () => {
+    let gameState = {
+      resources: {
+        wood: { amount: 100, discovered: true },
+        potatoes: { amount: -5, discovered: true },
+      },
+      buildings: { potatoField: { count: 0 } },
+      research: { completed: [] },
+      gameTime: { seconds: 0 },
+      population: { settlers: [] },
+      log: [],
+    };
+    const setState = (fn) => {
+      gameState = fn(gameState);
+    };
+
+    render(
+      <GameContext.Provider value={{ state: gameState, setState }}>
+        <BaseView />
+      </GameContext.Provider>,
+    );
+
+    const buildButton = screen.getAllByRole('button', { name: 'Build' })[0];
+    fireEvent.click(buildButton);
+
+    expect(gameState.resources.potatoes.amount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Clamp resources with `clampResource` when constructing buildings in BaseView
- Add missing React imports for BaseView and supporting components
- Test that building a structure clamps negative resources to zero

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a776bcde88331ac98dad8d013e66f