### PR TITLE
Synchronize survivor aging with season days

### DIFF
--- a/src/data/names.js
+++ b/src/data/names.js
@@ -70,13 +70,15 @@ export const LAST_NAMES = [
 
 import { DAYS_PER_YEAR } from '../engine/time.js';
 
-export function makeRandomSettler({ sex } = {}) {
+export function makeRandomSettler({ sex, randomizeAge = false } = {}) {
   const chosenSex = sex || (Math.random() < 0.5 ? 'M' : 'F');
   const firstPool = FIRST_NAMES[chosenSex];
   const firstName = firstPool[Math.floor(Math.random() * firstPool.length)];
   const lastName = LAST_NAMES[Math.floor(Math.random() * LAST_NAMES.length)];
   const baseAge = 18 * DAYS_PER_YEAR;
-  const randomDays = Math.floor(Math.random() * DAYS_PER_YEAR);
+  const randomDays = randomizeAge
+    ? Math.floor(Math.random() * DAYS_PER_YEAR)
+    : 0;
   return {
     id: globalThis.crypto?.randomUUID
       ? globalThis.crypto.randomUUID()

--- a/src/engine/time.js
+++ b/src/engine/time.js
@@ -43,7 +43,7 @@ export function getTimeBreakdown(state) {
   const yearDuration = SEASON_DURATION * SEASONS.length;
   const year = Math.floor(seconds / yearDuration) + 1;
   const secondsInSeason = seconds % SEASON_DURATION;
-  const day = Math.floor(secondsInSeason / SECONDS_PER_DAY) + 1;
+  const day = Math.floor(secondsInSeason / SECONDS_PER_DAY);
   return { year, day, season, secondsInSeason };
 }
 

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -25,5 +25,5 @@ export function formatAge(ageDays = 0) {
   const totalDays = Math.floor(ageDays || 0);
   const years = Math.floor(totalDays / DAYS_PER_YEAR);
   const day = totalDays % DAYS_PER_YEAR;
-  return { years, days: day + 1 };
+  return { years, days: day };
 }


### PR DESCRIPTION
## Summary
- Start new settlers at exactly 18 years without extra days
- Calculate season and age days from zero to keep counters aligned

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a784529808331bf04fbddaa54b99b