### PR TITLE
feat: highlight active bottom tab

### DIFF
--- a/src/components/BottomDock.jsx
+++ b/src/components/BottomDock.jsx
@@ -18,8 +18,11 @@ export default function BottomDock() {
           key={t.id}
           onClick={() => setActiveTab(t.id)}
           aria-label={t.label}
+          aria-current={state.ui.activeTab === t.id ? 'page' : undefined}
           className={`flex-1 py-2 text-xl ${
-            state.ui.activeTab === t.id ? 'text-ink' : 'text-muted'
+            state.ui.activeTab === t.id
+              ? 'text-ink bg-panel font-semibold'
+              : 'text-muted'
           }`}
         >
           {t.icon}

--- a/src/components/BottomDock.test.jsx
+++ b/src/components/BottomDock.test.jsx
@@ -20,5 +20,11 @@ describe('BottomDock accessibility', () => {
     labels.forEach((name) => {
       expect(screen.getByRole('button', { name })).toBeTruthy();
     });
+
+    const baseButton = screen.getByRole('button', { name: 'Base' });
+    expect(baseButton.getAttribute('aria-current')).toBe('page');
+
+    const popButton = screen.getByRole('button', { name: 'Population' });
+    expect(popButton.hasAttribute('aria-current')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- improve bottom tab bar with visual active state
- mark active button with `aria-current` for accessibility
- test active state

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a78859b9083318fadcb6a2615fb85