### PR TITLE
Add scientist research speed bonus

### DIFF
--- a/src/engine/__tests__/research.test.js
+++ b/src/engine/__tests__/research.test.js
@@ -6,6 +6,7 @@ import {
 } from '../research.js';
 import { defaultState } from '../../state/defaultState.js';
 import { getResearchOutputBonus } from '../../state/selectors.js';
+import { computeRoleBonuses } from '../settlers.js';
 
 function clone(obj) {
   return JSON.parse(JSON.stringify(obj));
@@ -39,5 +40,22 @@ describe('research engine', () => {
     state.research.completed = ['woodworking1', 'woodworking2'];
     const bonus = getResearchOutputBonus(state, 'wood');
     expect(bonus).toBeCloseTo(0.1, 5);
+  });
+
+  it('scientists speed up research', () => {
+    const state = clone(defaultState);
+    state.resources.science.amount = 50;
+    state.population.settlers = Array.from({ length: 4 }).map((_, i) => ({
+      id: i,
+      role: 'scientist',
+      isDead: false,
+      skills: { scientist: { level: 20 } },
+    }));
+    let s = startResearch(state, 'industry1');
+    const bonuses = computeRoleBonuses(state.population.settlers);
+    s = processResearchTick(s, 56, bonuses);
+    expect(s.research.current).not.toBe(null);
+    s = processResearchTick(s, 1, bonuses);
+    expect(s.research.current).toBe(null);
   });
 });

--- a/src/engine/research.js
+++ b/src/engine/research.js
@@ -41,12 +41,13 @@ export function cancelResearch(state) {
   };
 }
 
-export function processResearchTick(state, seconds = 1) {
+export function processResearchTick(state, seconds = 1, roleBonuses = {}) {
   const current = state.research.current;
   if (!current) return state;
   const node = RESEARCH_MAP[current.id];
   const prev = state.research.progress[current.id] || 0;
-  const next = prev + seconds;
+  const bonusPercent = roleBonuses['scientist'] || 0;
+  const next = prev + seconds * (1 + bonusPercent / 100);
   const progress = { ...state.research.progress, [current.id]: next };
   if (next >= node.timeSec) {
     const completed = [...state.research.completed, current.id];

--- a/src/state/GameContext.jsx
+++ b/src/state/GameContext.jsx
@@ -105,7 +105,7 @@ export function GameProvider({ children }) {
     setState((prev) => {
       const roleBonuses = computeRoleBonuses(prev.population?.settlers || []);
       const afterTick = processTick(prev, dt, roleBonuses);
-      const withResearch = processResearchTick(afterTick, dt);
+      const withResearch = processResearchTick(afterTick, dt, roleBonuses);
       const rates = getResourceRates(withResearch);
       let totalFoodProdBase = 0;
       Object.keys(RESOURCES).forEach((id) => {


### PR DESCRIPTION
## Summary
- allow scientists to accelerate research progress, reducing required time
- propagate role bonuses to research tick
- test scientist-driven research speed boost

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a807d8fb08331abbb3078b465e38d