### PR TITLE
feat(report): show inputs per sec

### DIFF
--- a/docs/ECONOMY_REPORT.md
+++ b/docs/ECONOMY_REPORT.md
@@ -1,48 +1,54 @@
 # Economy Report
 
 ## 1) Overview
-Economy generated from commit **d4192363b46dcaabac75aaa417bc4a8a8766c279** on 2025-08-12 01:59:03 +0200. Save version: **4**.
+
+Economy generated from commit **965f8303e7488ace47c19773059d713a040dfacc** on 2025-08-12 02:07:02 +0200. Save version: **4**.
 Each tick represents 1 second. For each building: base production is modified by season multipliers, summed, then clamped to capacity. Offline progress processes in 60-second chunks.
 
 ## 2) Resources
-| key | displayName | category | startingAmount | startingCapacity | unit |
-| - | - | - | - | - | - |
-| potatoes | Potatoes | FOOD | 0 | 300 |  |
-| wood | Wood | RAW | 0 | 100 |  |
-| stone | Stone | RAW | 0 | 100 |  |
-| scrap | Scrap | RAW | 0 | 100 |  |
-| planks | Planks | CONSTRUCTION_MATERIALS | 0 | 0 |  |
-| metalParts | Metal Parts | CONSTRUCTION_MATERIALS | 0 | 0 |  |
-| science | Science | SOCIETY | 0 | 400 |  |
-| power | Power | ENERGY | 0 | 2 |  |
+
+| key        | displayName | category               | startingAmount | startingCapacity | unit |
+| ---------- | ----------- | ---------------------- | -------------- | ---------------- | ---- |
+| potatoes   | Potatoes    | FOOD                   | 0              | 300              |      |
+| wood       | Wood        | RAW                    | 0              | 100              |      |
+| stone      | Stone       | RAW                    | 0              | 100              |      |
+| scrap      | Scrap       | RAW                    | 0              | 100              |      |
+| planks     | Planks      | CONSTRUCTION_MATERIALS | 0              | 0                |      |
+| metalParts | Metal Parts | CONSTRUCTION_MATERIALS | 0              | 0                |      |
+| science    | Science     | SOCIETY                | 0              | 400              |      |
+| power      | Power       | ENERGY                 | 0              | 2                |      |
 
 Global rules: resources cannot go negative; amounts are clamped to capacity.
 
 ## 3) Seasons and Global Modifiers
-| season | duration (sec) | potatoes | wood | stone | scrap | planks | metalParts | science | power |
-| - | - | - | - | - | - | - | - | - | - |
-| spring | 270 | 1.250 | 1.100 | 1.100 | 1.100 | 1.000 | 1.000 | 1.000 | 1.000 |
-| summer | 270 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
-| autumn | 270 | 0.850 | 0.900 | 0.900 | 0.900 | 1.000 | 1.000 | 1.000 | 1.000 |
-| winter | 270 | 0.000 | 0.800 | 0.800 | 0.800 | 1.000 | 1.000 | 1.000 | 1.000 |
+
+| season | duration (sec) | potatoes | wood  | stone | scrap | planks | metalParts | science | power |
+| ------ | -------------- | -------- | ----- | ----- | ----- | ------ | ---------- | ------- | ----- |
+| spring | 270            | 1.250    | 1.100 | 1.100 | 1.100 | 1.000  | 1.000      | 1.000   | 1.000 |
+| summer | 270            | 1.000    | 1.000 | 1.000 | 1.000 | 1.000  | 1.000      | 1.000   | 1.000 |
+| autumn | 270            | 0.850    | 0.900 | 0.900 | 0.900 | 1.000  | 1.000      | 1.000   | 1.000 |
+| winter | 270            | 0.000    | 0.800 | 0.800 | 0.800 | 1.000  | 1.000      | 1.000   | 1.000 |
 
 ## 4) Buildings
-| id | name | type | cost | refund | storage | base prod/s | season mults |
-| - | - | - | - | - | - | - | - |
-| potatoField | Potato Field | production | wood: 15 | 0.5 | - | potatoes: 0.375 | spring: 1.25, summer: 1, autumn: 0.85 |
-| loggingCamp | Logging Camp | production | scrap: 15 | 0.5 | - | wood: 0.2 | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
-| scrapyard | Scrap Yard | production | wood: 12 | 0.5 | - | scrap: 0.06 | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
-| quarry | Quarry | production | wood: 20, scrap: 5 | 0.5 | - | stone: 0.08 | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
-| school | School | production | wood: 25, scrap: 10, stone: 10 | 0.5 | - | science: 0.5 | spring: 1, summer: 1, autumn: 1, winter: 1 |
-| woodGenerator | Wood Generator | production | wood: 50, stone: 10 | 0.5 | - | power: 1 | spring: 1, summer: 1, autumn: 1, winter: 1 |
-| foodStorage | Granary | storage | wood: 20, scrap: 5, stone: 5 | 0.5 | - | - | - |
-| rawStorage | Warehouse | storage | wood: 25, scrap: 10, stone: 10 | 0.5 | - | - | - |
-| battery | Battery | storage | wood: 40, stone: 20 | 0.5 | - | - | - |
+
+| id            | name           | type       | cost                           | refund | storage | base prod/s     | inputs per sec | season mults                                     |
+| ------------- | -------------- | ---------- | ------------------------------ | ------ | ------- | --------------- | -------------- | ------------------------------------------------ |
+| potatoField   | Potato Field   | production | wood: 15                       | 0.5    | -       | potatoes: 0.375 | -              | spring: 1.25, summer: 1, autumn: 0.85            |
+| loggingCamp   | Logging Camp   | production | scrap: 15                      | 0.5    | -       | wood: 0.2       | -              | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
+| scrapyard     | Scrap Yard     | production | wood: 12                       | 0.5    | -       | scrap: 0.06     | -              | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
+| quarry        | Quarry         | production | wood: 20, scrap: 5             | 0.5    | -       | stone: 0.08     | -              | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
+| school        | School         | production | wood: 25, scrap: 10, stone: 10 | 0.5    | -       | science: 0.5    | -              | spring: 1, summer: 1, autumn: 1, winter: 1       |
+| woodGenerator | Wood Generator | production | wood: 50, stone: 10            | 0.5    | -       | power: 1        | wood: 0.3      | spring: 1, summer: 1, autumn: 1, winter: 1       |
+| foodStorage   | Granary        | storage    | wood: 20, scrap: 5, stone: 5   | 0.5    | -       | -               | -              | -                                                |
+| rawStorage    | Warehouse      | storage    | wood: 25, scrap: 10, stone: 10 | 0.5    | -       | -               | -              | -                                                |
+| battery       | Battery        | storage    | wood: 40, stone: 20            | 0.5    | -       | -               | -              | -                                                |
 
 ## 5) Population and Roles
+
 No role-based production modifiers in effect.
 
 ## 6) Production Math (Exact Formula)
+
 Per building per tick:
 
 `effectiveCycle = cycleTimeSec * seasonSpeed`
@@ -58,24 +64,27 @@ Sum production for each resource across buildings, then `clampResource(value, ca
 Offline progress is applied in 60-second chunks.
 
 ## 7) Costs, Refunds, and Edge Rules
+
 Building costs scale by `cost * 1.15^count`, rounded up. Demolition refunds 50% of the previous cost (floored) and adds back resources subject to capacity. Resource values are rounded to 6 decimals in clamping and cannot be negative.
 
 ## 8) Starting State
+
 Starting season: spring, Year: 1.
 
 ### Resources
-| resource | amount | capacity |
-| - | - | - |
-| potatoes | 0 | 300 |
-| wood | 0 | 100 |
-| stone | 0 | 100 |
-| scrap | 0 | 100 |
-| planks | 0 | 0 |
-| metalParts | 0 | 0 |
-| science | 0 | 400 |
-| power | 0 | 2 |
+
+| resource   | amount | capacity |
+| ---------- | ------ | -------- |
+| potatoes   | 0      | 300      |
+| wood       | 0      | 100      |
+| stone      | 0      | 100      |
+| scrap      | 0      | 100      |
+| planks     | 0      | 0        |
+| metalParts | 0      | 0        |
+| science    | 0      | 400      |
+| power      | 0      | 2        |
 
 ### Buildings
-| building | count |
-| - | - |
 
+| building | count |
+| -------- | ----- |

--- a/docs/economy-snapshot.json
+++ b/docs/economy-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "version": "d4192363b46dcaabac75aaa417bc4a8a8766c279",
+  "version": "965f8303e7488ace47c19773059d713a040dfacc",
   "saveVersion": 4,
   "tickSeconds": 1,
   "seasons": {
@@ -135,6 +135,7 @@
       "baseProductionPerSec": {
         "potatoes": 0.375
       },
+      "baseInputsPerSec": {},
       "seasonalMode": "ignore",
       "seasonalCustom": null,
       "seasonalMultipliers": {
@@ -156,6 +157,7 @@
       "baseProductionPerSec": {
         "wood": 0.2
       },
+      "baseInputsPerSec": {},
       "seasonalMode": "ignore",
       "seasonalCustom": null,
       "seasonalMultipliers": {
@@ -177,6 +179,7 @@
       "baseProductionPerSec": {
         "scrap": 0.06
       },
+      "baseInputsPerSec": {},
       "seasonalMode": "ignore",
       "seasonalCustom": null,
       "seasonalMultipliers": {
@@ -199,6 +202,7 @@
       "baseProductionPerSec": {
         "stone": 0.08
       },
+      "baseInputsPerSec": {},
       "seasonalMode": "ignore",
       "seasonalCustom": null,
       "seasonalMultipliers": {
@@ -222,6 +226,7 @@
       "baseProductionPerSec": {
         "science": 0.5
       },
+      "baseInputsPerSec": {},
       "seasonalMode": "ignore",
       "seasonalCustom": null,
       "seasonalMultipliers": {
@@ -244,6 +249,9 @@
       "baseProductionPerSec": {
         "power": 1
       },
+      "baseInputsPerSec": {
+        "wood": 0.3
+      },
       "seasonalMode": "ignore",
       "seasonalCustom": null,
       "seasonalMultipliers": {
@@ -265,6 +273,7 @@
       "demolitionRefund": 0.5,
       "storageProvided": {},
       "baseProductionPerSec": {},
+      "baseInputsPerSec": {},
       "seasonalMode": "ignore",
       "seasonalCustom": null,
       "seasonalMultipliers": {}
@@ -281,6 +290,7 @@
       "demolitionRefund": 0.5,
       "storageProvided": {},
       "baseProductionPerSec": {},
+      "baseInputsPerSec": {},
       "seasonalMode": "ignore",
       "seasonalCustom": null,
       "seasonalMultipliers": {}
@@ -296,6 +306,7 @@
       "demolitionRefund": 0.5,
       "storageProvided": {},
       "baseProductionPerSec": {},
+      "baseInputsPerSec": {},
       "seasonalMode": "ignore",
       "seasonalCustom": null,
       "seasonalMultipliers": {}
@@ -303,13 +314,7 @@
   ],
   "roles": [],
   "formula": {
-    "order": [
-      "base",
-      "season",
-      "roles",
-      "sum",
-      "clamp"
-    ],
+    "order": ["base", "season", "roles", "sum", "clamp"],
     "demolitionRefund": 0.5,
     "clampRule": "min(value, capacity) and never negative"
   },

--- a/scripts/generate-economy-report.mjs
+++ b/scripts/generate-economy-report.mjs
@@ -67,6 +67,10 @@ function baseProductionPerSec(b) {
   return { ...(b.outputsPerSecBase || {}) };
 }
 
+function baseInputsPerSec(b) {
+  return { ...(b.inputsPerSecBase || {}) };
+}
+
 function getBuildingSeasonModifiers(building, season) {
   const outputs = Object.keys(building.outputsPerSecBase || {});
   const res = outputs[0];
@@ -94,6 +98,7 @@ const buildings = BUILDINGS.map((b) => ({
   demolitionRefund: 0.5,
   storageProvided: { ...(b.addsCapacity || {}) },
   baseProductionPerSec: baseProductionPerSec(b),
+  baseInputsPerSec: baseInputsPerSec(b),
   seasonalMode: b.cycleTimeSec ? 'default' : 'ignore',
   seasonalCustom: null,
   seasonalMultipliers: buildingSeasonMultipliers(b),
@@ -185,11 +190,11 @@ md += '\n';
 
 md += '## 4) Buildings\n';
 md +=
-  '| id | name | type | cost | refund | storage | base prod/s | season mults |\n';
-md += '| - | - | - | - | - | - | - | - |\n';
+  '| id | name | type | cost | refund | storage | base prod/s | inputs per sec | season mults |\n';
+md += '| - | - | - | - | - | - | - | - | - |\n';
 BUILDINGS.forEach((b, idx) => {
   const row = buildings[idx];
-  md += `| ${row.id} | ${row.name} | ${row.type} | ${formatCost(row.constructionCost)} | ${row.demolitionRefund} | ${formatObj(row.storageProvided)} | ${formatObj(row.baseProductionPerSec)} | ${formatObj(row.seasonalMultipliers)} |\n`;
+  md += `| ${row.id} | ${row.name} | ${row.type} | ${formatCost(row.constructionCost)} | ${row.demolitionRefund} | ${formatObj(row.storageProvided)} | ${formatObj(row.baseProductionPerSec)} | ${formatObj(row.baseInputsPerSec)} | ${formatObj(row.seasonalMultipliers)} |\n`;
 });
 md += '\n';
 


### PR DESCRIPTION
## Summary
- include `inputsPerSecBase` data in economy snapshot
- show building inputs per second in economy report

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a85af041c8331b829055c38aa84e6