### PR TITLE
Add research tree to economy report

### DIFF
--- a/docs/ECONOMY_REPORT.md
+++ b/docs/ECONOMY_REPORT.md
@@ -1,48 +1,68 @@
 # Economy Report
 
 ## 1) Overview
-Economy generated from commit **d4192363b46dcaabac75aaa417bc4a8a8766c279** on 2025-08-12 01:59:03 +0200. Save version: **4**.
+
+Economy generated from commit **965f8303e7488ace47c19773059d713a040dfacc** on 2025-08-12 02:07:02 +0200. Save version: **4**.
 Each tick represents 1 second. For each building: base production is modified by season multipliers, summed, then clamped to capacity. Offline progress processes in 60-second chunks.
 
 ## 2) Resources
-| key | displayName | category | startingAmount | startingCapacity | unit |
-| - | - | - | - | - | - |
-| potatoes | Potatoes | FOOD | 0 | 300 |  |
-| wood | Wood | RAW | 0 | 100 |  |
-| stone | Stone | RAW | 0 | 100 |  |
-| scrap | Scrap | RAW | 0 | 100 |  |
-| planks | Planks | CONSTRUCTION_MATERIALS | 0 | 0 |  |
-| metalParts | Metal Parts | CONSTRUCTION_MATERIALS | 0 | 0 |  |
-| science | Science | SOCIETY | 0 | 400 |  |
-| power | Power | ENERGY | 0 | 2 |  |
+
+| key        | displayName | category               | startingAmount | startingCapacity | unit |
+| ---------- | ----------- | ---------------------- | -------------- | ---------------- | ---- |
+| potatoes   | Potatoes    | FOOD                   | 0              | 300              |      |
+| wood       | Wood        | RAW                    | 0              | 100              |      |
+| stone      | Stone       | RAW                    | 0              | 100              |      |
+| scrap      | Scrap       | RAW                    | 0              | 100              |      |
+| planks     | Planks      | CONSTRUCTION_MATERIALS | 0              | 0                |      |
+| metalParts | Metal Parts | CONSTRUCTION_MATERIALS | 0              | 0                |      |
+| science    | Science     | SOCIETY                | 0              | 400              |      |
+| power      | Power       | ENERGY                 | 0              | 2                |      |
 
 Global rules: resources cannot go negative; amounts are clamped to capacity.
 
 ## 3) Seasons and Global Modifiers
-| season | duration (sec) | potatoes | wood | stone | scrap | planks | metalParts | science | power |
-| - | - | - | - | - | - | - | - | - | - |
-| spring | 270 | 1.250 | 1.100 | 1.100 | 1.100 | 1.000 | 1.000 | 1.000 | 1.000 |
-| summer | 270 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
-| autumn | 270 | 0.850 | 0.900 | 0.900 | 0.900 | 1.000 | 1.000 | 1.000 | 1.000 |
-| winter | 270 | 0.000 | 0.800 | 0.800 | 0.800 | 1.000 | 1.000 | 1.000 | 1.000 |
+
+| season | duration (sec) | potatoes | wood  | stone | scrap | planks | metalParts | science | power |
+| ------ | -------------- | -------- | ----- | ----- | ----- | ------ | ---------- | ------- | ----- |
+| spring | 270            | 1.250    | 1.100 | 1.100 | 1.100 | 1.000  | 1.000      | 1.000   | 1.000 |
+| summer | 270            | 1.000    | 1.000 | 1.000 | 1.000 | 1.000  | 1.000      | 1.000   | 1.000 |
+| autumn | 270            | 0.850    | 0.900 | 0.900 | 0.900 | 1.000  | 1.000      | 1.000   | 1.000 |
+| winter | 270            | 0.000    | 0.800 | 0.800 | 0.800 | 1.000  | 1.000      | 1.000   | 1.000 |
 
 ## 4) Buildings
-| id | name | type | cost | refund | storage | base prod/s | season mults |
-| - | - | - | - | - | - | - | - |
-| potatoField | Potato Field | production | wood: 15 | 0.5 | - | potatoes: 0.375 | spring: 1.25, summer: 1, autumn: 0.85 |
-| loggingCamp | Logging Camp | production | scrap: 15 | 0.5 | - | wood: 0.2 | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
-| scrapyard | Scrap Yard | production | wood: 12 | 0.5 | - | scrap: 0.06 | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
-| quarry | Quarry | production | wood: 20, scrap: 5 | 0.5 | - | stone: 0.08 | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
-| school | School | production | wood: 25, scrap: 10, stone: 10 | 0.5 | - | science: 0.5 | spring: 1, summer: 1, autumn: 1, winter: 1 |
-| woodGenerator | Wood Generator | production | wood: 50, stone: 10 | 0.5 | - | power: 1 | spring: 1, summer: 1, autumn: 1, winter: 1 |
-| foodStorage | Granary | storage | wood: 20, scrap: 5, stone: 5 | 0.5 | - | - | - |
-| rawStorage | Warehouse | storage | wood: 25, scrap: 10, stone: 10 | 0.5 | - | - | - |
-| battery | Battery | storage | wood: 40, stone: 20 | 0.5 | - | - | - |
 
-## 5) Population and Roles
+| id            | name           | type       | cost                           | refund | storage | base prod/s     | season mults                                     |
+| ------------- | -------------- | ---------- | ------------------------------ | ------ | ------- | --------------- | ------------------------------------------------ |
+| potatoField   | Potato Field   | production | wood: 15                       | 0.5    | -       | potatoes: 0.375 | spring: 1.25, summer: 1, autumn: 0.85            |
+| loggingCamp   | Logging Camp   | production | scrap: 15                      | 0.5    | -       | wood: 0.2       | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
+| scrapyard     | Scrap Yard     | production | wood: 12                       | 0.5    | -       | scrap: 0.06     | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
+| quarry        | Quarry         | production | wood: 20, scrap: 5             | 0.5    | -       | stone: 0.08     | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
+| school        | School         | production | wood: 25, scrap: 10, stone: 10 | 0.5    | -       | science: 0.5    | spring: 1, summer: 1, autumn: 1, winter: 1       |
+| woodGenerator | Wood Generator | production | wood: 50, stone: 10            | 0.5    | -       | power: 1        | spring: 1, summer: 1, autumn: 1, winter: 1       |
+| foodStorage   | Granary        | storage    | wood: 20, scrap: 5, stone: 5   | 0.5    | -       | -               | -                                                |
+| rawStorage    | Warehouse      | storage    | wood: 25, scrap: 10, stone: 10 | 0.5    | -       | -               | -                                                |
+| battery       | Battery        | storage    | wood: 40, stone: 20            | 0.5    | -       | -               | -                                                |
+
+## 5) Research
+
+| id           | name           | science cost | time (sec) | prereqs                 | unlocks                                                                               |
+| ------------ | -------------- | ------------ | ---------- | ----------------------- | ------------------------------------------------------------------------------------- |
+| basicEnergy  | Basic Energy   | 20           | 120        | -                       | resources: power; buildings: woodGenerator, battery; categories: Energy               |
+| industry1    | Industry I     | 40           | 60         | -                       | buildings: sawmill, metalWorkshop, materialsDepot; categories: CONSTRUCTION_MATERIALS |
+| woodworking1 | Woodworking I  | 30           | 45         | industry1               | -                                                                                     |
+| salvaging1   | Salvaging I    | 30           | 45         | industry1               | -                                                                                     |
+| logistics1   | Logistics I    | 35           | 60         | industry1               | -                                                                                     |
+| industry2    | Industry II    | 140          | 180        | industry1               | buildings: toolsmithy                                                                 |
+| woodworking2 | Woodworking II | 70           | 120        | woodworking1, industry2 | -                                                                                     |
+| salvaging2   | Salvaging II   | 70           | 120        | salvaging1, industry2   | -                                                                                     |
+| logistics2   | Logistics II   | 80           | 150        | logistics1, industry2   | -                                                                                     |
+
+## 6) Population and Roles
+
 No role-based production modifiers in effect.
 
-## 6) Production Math (Exact Formula)
+## 7) Production Math (Exact Formula)
+
 Per building per tick:
 
 `effectiveCycle = cycleTimeSec * seasonSpeed`
@@ -57,25 +77,28 @@ Sum production for each resource across buildings, then `clampResource(value, ca
 
 Offline progress is applied in 60-second chunks.
 
-## 7) Costs, Refunds, and Edge Rules
+## 8) Costs, Refunds, and Edge Rules
+
 Building costs scale by `cost * 1.15^count`, rounded up. Demolition refunds 50% of the previous cost (floored) and adds back resources subject to capacity. Resource values are rounded to 6 decimals in clamping and cannot be negative.
 
-## 8) Starting State
+## 9) Starting State
+
 Starting season: spring, Year: 1.
 
 ### Resources
-| resource | amount | capacity |
-| - | - | - |
-| potatoes | 0 | 300 |
-| wood | 0 | 100 |
-| stone | 0 | 100 |
-| scrap | 0 | 100 |
-| planks | 0 | 0 |
-| metalParts | 0 | 0 |
-| science | 0 | 400 |
-| power | 0 | 2 |
+
+| resource   | amount | capacity |
+| ---------- | ------ | -------- |
+| potatoes   | 0      | 300      |
+| wood       | 0      | 100      |
+| stone      | 0      | 100      |
+| scrap      | 0      | 100      |
+| planks     | 0      | 0        |
+| metalParts | 0      | 0        |
+| science    | 0      | 400      |
+| power      | 0      | 2        |
 
 ### Buildings
-| building | count |
-| - | - |
 
+| building | count |
+| -------- | ----- |

--- a/docs/economy-snapshot.json
+++ b/docs/economy-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "version": "d4192363b46dcaabac75aaa417bc4a8a8766c279",
+  "version": "965f8303e7488ace47c19773059d713a040dfacc",
   "saveVersion": 4,
   "tickSeconds": 1,
   "seasons": {
@@ -301,15 +301,159 @@
       "seasonalMultipliers": {}
     }
   ],
+  "research": [
+    {
+      "id": "basicEnergy",
+      "name": "Basic Energy",
+      "cost": {
+        "science": 20
+      },
+      "timeSec": 120,
+      "prereqs": [],
+      "unlocks": {
+        "resources": ["power"],
+        "buildings": ["woodGenerator", "battery"],
+        "categories": ["Energy"]
+      },
+      "effects": []
+    },
+    {
+      "id": "industry1",
+      "name": "Industry I",
+      "cost": {
+        "science": 40
+      },
+      "timeSec": 60,
+      "prereqs": [],
+      "unlocks": {
+        "buildings": ["sawmill", "metalWorkshop", "materialsDepot"],
+        "categories": ["CONSTRUCTION_MATERIALS"]
+      },
+      "effects": []
+    },
+    {
+      "id": "woodworking1",
+      "name": "Woodworking I",
+      "cost": {
+        "science": 30
+      },
+      "timeSec": 45,
+      "prereqs": ["industry1"],
+      "effects": [
+        {
+          "category": "WOOD",
+          "percent": 0.05,
+          "type": "output"
+        }
+      ]
+    },
+    {
+      "id": "salvaging1",
+      "name": "Salvaging I",
+      "cost": {
+        "science": 30
+      },
+      "timeSec": 45,
+      "prereqs": ["industry1"],
+      "effects": [
+        {
+          "category": "SCRAP",
+          "percent": 0.05,
+          "type": "output"
+        }
+      ]
+    },
+    {
+      "id": "logistics1",
+      "name": "Logistics I",
+      "cost": {
+        "science": 35
+      },
+      "timeSec": 60,
+      "prereqs": ["industry1"],
+      "effects": [
+        {
+          "category": "RAW",
+          "percent": 0.05,
+          "type": "storage"
+        },
+        {
+          "category": "CONSTRUCTION_MATERIALS",
+          "percent": 0.05,
+          "type": "storage"
+        }
+      ]
+    },
+    {
+      "id": "industry2",
+      "name": "Industry II",
+      "cost": {
+        "science": 140
+      },
+      "timeSec": 180,
+      "prereqs": ["industry1"],
+      "unlocks": {
+        "buildings": ["toolsmithy"]
+      },
+      "effects": []
+    },
+    {
+      "id": "woodworking2",
+      "name": "Woodworking II",
+      "cost": {
+        "science": 70
+      },
+      "timeSec": 120,
+      "prereqs": ["woodworking1", "industry2"],
+      "effects": [
+        {
+          "category": "WOOD",
+          "percent": 0.05,
+          "type": "output"
+        }
+      ]
+    },
+    {
+      "id": "salvaging2",
+      "name": "Salvaging II",
+      "cost": {
+        "science": 70
+      },
+      "timeSec": 120,
+      "prereqs": ["salvaging1", "industry2"],
+      "effects": [
+        {
+          "category": "SCRAP",
+          "percent": 0.05,
+          "type": "output"
+        }
+      ]
+    },
+    {
+      "id": "logistics2",
+      "name": "Logistics II",
+      "cost": {
+        "science": 80
+      },
+      "timeSec": 150,
+      "prereqs": ["logistics1", "industry2"],
+      "effects": [
+        {
+          "category": "RAW",
+          "percent": 0.05,
+          "type": "storage"
+        },
+        {
+          "category": "CONSTRUCTION_MATERIALS",
+          "percent": 0.05,
+          "type": "storage"
+        }
+      ]
+    }
+  ],
   "roles": [],
   "formula": {
-    "order": [
-      "base",
-      "season",
-      "roles",
-      "sum",
-      "clamp"
-    ],
+    "order": ["base", "season", "roles", "sum", "clamp"],
     "demolitionRefund": 0.5,
     "clampRule": "min(value, capacity) and never negative"
   },


### PR DESCRIPTION
## Summary
- include research nodes in economy snapshot
- document research tree in economy report

## Testing
- `npm test`
- `npm run lint`
- `npm run report:economy`


------
https://chatgpt.com/codex/tasks/task_e_689a866327888331a83f7227501a2d3d