### PR TITLE
Add processing chain and construction materials

### DIFF
--- a/docs/ECONOMY_REPORT.md
+++ b/docs/ECONOMY_REPORT.md
@@ -1,54 +1,51 @@
 # Economy Report
 
 ## 1) Overview
-
-Economy generated from commit **965f8303e7488ace47c19773059d713a040dfacc** on 2025-08-12 02:07:02 +0200. Save version: **4**.
+Economy generated from commit **c165a592774acdbc653d9db413b42c1a1d032d6f** on 2025-08-12 02:12:22 +0200. Save version: **4**.
 Each tick represents 1 second. For each building: base production is modified by season multipliers, summed, then clamped to capacity. Offline progress processes in 60-second chunks.
 
 ## 2) Resources
-
-| key        | displayName | category               | startingAmount | startingCapacity | unit |
-| ---------- | ----------- | ---------------------- | -------------- | ---------------- | ---- |
-| potatoes   | Potatoes    | FOOD                   | 0              | 300              |      |
-| wood       | Wood        | RAW                    | 0              | 100              |      |
-| stone      | Stone       | RAW                    | 0              | 100              |      |
-| scrap      | Scrap       | RAW                    | 0              | 100              |      |
-| planks     | Planks      | CONSTRUCTION_MATERIALS | 0              | 0                |      |
-| metalParts | Metal Parts | CONSTRUCTION_MATERIALS | 0              | 0                |      |
-| science    | Science     | SOCIETY                | 0              | 400              |      |
-| power      | Power       | ENERGY                 | 0              | 2                |      |
+| key | displayName | category | startingAmount | startingCapacity | unit |
+| - | - | - | - | - | - |
+| potatoes | Potatoes | FOOD | 0 | 300 |  |
+| wood | Wood | RAW | 0 | 100 |  |
+| stone | Stone | RAW | 0 | 100 |  |
+| scrap | Scrap | RAW | 0 | 100 |  |
+| planks | Planks | CONSTRUCTION_MATERIALS | 0 | 50 |  |
+| metalParts | Metal Parts | CONSTRUCTION_MATERIALS | 0 | 20 |  |
+| science | Science | SOCIETY | 0 | 400 |  |
+| power | Power | ENERGY | 0 | 2 |  |
 
 Global rules: resources cannot go negative; amounts are clamped to capacity.
 
 ## 3) Seasons and Global Modifiers
-
-| season | duration (sec) | potatoes | wood  | stone | scrap | planks | metalParts | science | power |
-| ------ | -------------- | -------- | ----- | ----- | ----- | ------ | ---------- | ------- | ----- |
-| spring | 270            | 1.250    | 1.100 | 1.100 | 1.100 | 1.000  | 1.000      | 1.000   | 1.000 |
-| summer | 270            | 1.000    | 1.000 | 1.000 | 1.000 | 1.000  | 1.000      | 1.000   | 1.000 |
-| autumn | 270            | 0.850    | 0.900 | 0.900 | 0.900 | 1.000  | 1.000      | 1.000   | 1.000 |
-| winter | 270            | 0.000    | 0.800 | 0.800 | 0.800 | 1.000  | 1.000      | 1.000   | 1.000 |
+| season | duration (sec) | potatoes | wood | stone | scrap | planks | metalParts | science | power |
+| - | - | - | - | - | - | - | - | - | - |
+| spring | 270 | 1.250 | 1.100 | 1.100 | 1.100 | 1.000 | 1.000 | 1.000 | 1.000 |
+| summer | 270 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
+| autumn | 270 | 0.850 | 0.900 | 0.900 | 0.900 | 1.000 | 1.000 | 1.000 | 1.000 |
+| winter | 270 | 0.000 | 0.800 | 0.800 | 0.800 | 1.000 | 1.000 | 1.000 | 1.000 |
 
 ## 4) Buildings
-
-| id            | name           | type       | cost                           | refund | storage | base prod/s     | inputs per sec | season mults                                     |
-| ------------- | -------------- | ---------- | ------------------------------ | ------ | ------- | --------------- | -------------- | ------------------------------------------------ |
-| potatoField   | Potato Field   | production | wood: 15                       | 0.5    | -       | potatoes: 0.375 | -              | spring: 1.25, summer: 1, autumn: 0.85            |
-| loggingCamp   | Logging Camp   | production | scrap: 15                      | 0.5    | -       | wood: 0.2       | -              | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
-| scrapyard     | Scrap Yard     | production | wood: 12                       | 0.5    | -       | scrap: 0.06     | -              | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
-| quarry        | Quarry         | production | wood: 20, scrap: 5             | 0.5    | -       | stone: 0.08     | -              | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
-| school        | School         | production | wood: 25, scrap: 10, stone: 10 | 0.5    | -       | science: 0.5    | -              | spring: 1, summer: 1, autumn: 1, winter: 1       |
-| woodGenerator | Wood Generator | production | wood: 50, stone: 10            | 0.5    | -       | power: 1        | wood: 0.3      | spring: 1, summer: 1, autumn: 1, winter: 1       |
-| foodStorage   | Granary        | storage    | wood: 20, scrap: 5, stone: 5   | 0.5    | -       | -               | -              | -                                                |
-| rawStorage    | Warehouse      | storage    | wood: 25, scrap: 10, stone: 10 | 0.5    | -       | -               | -              | -                                                |
-| battery       | Battery        | storage    | wood: 40, stone: 20            | 0.5    | -       | -               | -              | -                                                |
+| id | name | type | cost | refund | storage | base prod/s | inputs per sec | season mults |
+| - | - | - | - | - | - | - | - | - |
+| potatoField | Potato Field | production | wood: 15 | 0.5 | - | potatoes: 0.375 | - | spring: 1.25, summer: 1, autumn: 0.85 |
+| loggingCamp | Logging Camp | production | scrap: 15 | 0.5 | - | wood: 0.2 | - | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
+| scrapyard | Scrap Yard | production | wood: 12 | 0.5 | - | scrap: 0.06 | - | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
+| quarry | Quarry | production | wood: 20, scrap: 5 | 0.5 | - | stone: 0.08 | - | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
+| sawmill | Sawmill | processing | wood: 40, scrap: 15, stone: 10 | 0.5 | - | planks: 0.5 | wood: 1 | spring: 1, summer: 1, autumn: 1, winter: 1 |
+| metalWorkshop | Metal Workshop | processing | wood: 30, scrap: 30, stone: 10, planks: 10 | 0.5 | - | metalParts: 0.4 | scrap: 1 | spring: 1, summer: 1, autumn: 1, winter: 1 |
+| school | School | production | wood: 25, scrap: 10, stone: 10 | 0.5 | - | science: 0.5 | - | spring: 1, summer: 1, autumn: 1, winter: 1 |
+| woodGenerator | Wood Generator | production | wood: 50, stone: 10 | 0.5 | - | power: 1 | wood: 0.3 | spring: 1, summer: 1, autumn: 1, winter: 1 |
+| foodStorage | Granary | storage | wood: 20, scrap: 5, stone: 5 | 0.5 | - | - | - | - |
+| rawStorage | Warehouse | storage | wood: 25, scrap: 10, stone: 10 | 0.5 | - | - | - | - |
+| materialsDepot | Materials Depot | storage | wood: 25, scrap: 10, stone: 5 | 0.5 | - | - | - | - |
+| battery | Battery | storage | wood: 40, stone: 20 | 0.5 | - | - | - | - |
 
 ## 5) Population and Roles
-
 No role-based production modifiers in effect.
 
 ## 6) Production Math (Exact Formula)
-
 Per building per tick:
 
 `effectiveCycle = cycleTimeSec * seasonSpeed`
@@ -64,27 +61,24 @@ Sum production for each resource across buildings, then `clampResource(value, ca
 Offline progress is applied in 60-second chunks.
 
 ## 7) Costs, Refunds, and Edge Rules
-
 Building costs scale by `cost * 1.15^count`, rounded up. Demolition refunds 50% of the previous cost (floored) and adds back resources subject to capacity. Resource values are rounded to 6 decimals in clamping and cannot be negative.
 
 ## 8) Starting State
-
 Starting season: spring, Year: 1.
 
 ### Resources
-
-| resource   | amount | capacity |
-| ---------- | ------ | -------- |
-| potatoes   | 0      | 300      |
-| wood       | 0      | 100      |
-| stone      | 0      | 100      |
-| scrap      | 0      | 100      |
-| planks     | 0      | 0        |
-| metalParts | 0      | 0        |
-| science    | 0      | 400      |
-| power      | 0      | 2        |
+| resource | amount | capacity |
+| - | - | - |
+| potatoes | 0 | 300 |
+| wood | 0 | 100 |
+| stone | 0 | 100 |
+| scrap | 0 | 100 |
+| planks | 0 | 50 |
+| metalParts | 0 | 20 |
+| science | 0 | 400 |
+| power | 0 | 2 |
 
 ### Buildings
-
 | building | count |
-| -------- | ----- |
+| - | - |
+

--- a/docs/economy-snapshot.json
+++ b/docs/economy-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "version": "965f8303e7488ace47c19773059d713a040dfacc",
+  "version": "c165a592774acdbc653d9db413b42c1a1d032d6f",
   "saveVersion": 4,
   "tickSeconds": 1,
   "seasons": {
@@ -94,7 +94,7 @@
       "displayName": "Planks",
       "category": "CONSTRUCTION_MATERIALS",
       "startingAmount": 0,
-      "startingCapacity": 0,
+      "startingCapacity": 50,
       "unit": null
     },
     {
@@ -102,7 +102,7 @@
       "displayName": "Metal Parts",
       "category": "CONSTRUCTION_MATERIALS",
       "startingAmount": 0,
-      "startingCapacity": 0,
+      "startingCapacity": 20,
       "unit": null
     },
     {
@@ -213,6 +213,59 @@
       }
     },
     {
+      "id": "sawmill",
+      "name": "Sawmill",
+      "type": "processing",
+      "constructionCost": {
+        "wood": 40,
+        "scrap": 15,
+        "stone": 10
+      },
+      "demolitionRefund": 0.5,
+      "storageProvided": {},
+      "baseProductionPerSec": {
+        "planks": 0.5
+      },
+      "baseInputsPerSec": {
+        "wood": 1
+      },
+      "seasonalMode": "ignore",
+      "seasonalCustom": null,
+      "seasonalMultipliers": {
+        "spring": 1,
+        "summer": 1,
+        "autumn": 1,
+        "winter": 1
+      }
+    },
+    {
+      "id": "metalWorkshop",
+      "name": "Metal Workshop",
+      "type": "processing",
+      "constructionCost": {
+        "wood": 30,
+        "scrap": 30,
+        "stone": 10,
+        "planks": 10
+      },
+      "demolitionRefund": 0.5,
+      "storageProvided": {},
+      "baseProductionPerSec": {
+        "metalParts": 0.4
+      },
+      "baseInputsPerSec": {
+        "scrap": 1
+      },
+      "seasonalMode": "ignore",
+      "seasonalCustom": null,
+      "seasonalMultipliers": {
+        "spring": 1,
+        "summer": 1,
+        "autumn": 1,
+        "winter": 1
+      }
+    },
+    {
       "id": "school",
       "name": "School",
       "type": "production",
@@ -296,6 +349,23 @@
       "seasonalMultipliers": {}
     },
     {
+      "id": "materialsDepot",
+      "name": "Materials Depot",
+      "type": "storage",
+      "constructionCost": {
+        "wood": 25,
+        "scrap": 10,
+        "stone": 5
+      },
+      "demolitionRefund": 0.5,
+      "storageProvided": {},
+      "baseProductionPerSec": {},
+      "baseInputsPerSec": {},
+      "seasonalMode": "ignore",
+      "seasonalCustom": null,
+      "seasonalMultipliers": {}
+    },
+    {
       "id": "battery",
       "name": "Battery",
       "type": "storage",
@@ -314,7 +384,13 @@
   ],
   "roles": [],
   "formula": {
-    "order": ["base", "season", "roles", "sum", "clamp"],
+    "order": [
+      "base",
+      "season",
+      "roles",
+      "sum",
+      "clamp"
+    ],
     "demolitionRefund": 0.5,
     "clampRule": "min(value, capacity) and never negative"
   },

--- a/src/data/buildings.js
+++ b/src/data/buildings.js
@@ -44,6 +44,34 @@ export const BUILDINGS = [
     description: 'Extracts stone slowly but steadily.',
   },
   {
+    id: 'sawmill',
+    name: 'Sawmill',
+    type: 'processing',
+    category: 'Production',
+    requiresResearch: 'industry1',
+    inputsPerSecBase: { wood: 1 },
+    outputsPerSecBase: { planks: 0.5 },
+    costBase: { wood: 40, scrap: 15, stone: 10 },
+    costGrowth: 1.15,
+    refund: 0.5,
+    seasonProfile: 'constant',
+    description: 'Converts wood into planks.',
+  },
+  {
+    id: 'metalWorkshop',
+    name: 'Metal Workshop',
+    type: 'processing',
+    category: 'Production',
+    requiresResearch: 'industry1',
+    inputsPerSecBase: { scrap: 1 },
+    outputsPerSecBase: { metalParts: 0.4 },
+    costBase: { wood: 30, scrap: 30, stone: 10, planks: 10 },
+    costGrowth: 1.15,
+    refund: 0.5,
+    seasonProfile: 'constant',
+    description: 'Processes scrap into metal parts.',
+  },
+  {
     id: 'school',
     name: 'School',
     type: 'production',
@@ -89,6 +117,17 @@ export const BUILDINGS = [
     description: 'Increases storage for wood, stone and scrap.',
   },
   {
+    id: 'materialsDepot',
+    name: 'Materials Depot',
+    type: 'storage',
+    requiresResearch: 'industry1',
+    costBase: { wood: 25, scrap: 10, stone: 5 },
+    costGrowth: 1.15,
+    refund: 0.5,
+    capacityAdd: { planks: 150, metalParts: 60 },
+    description: 'Stores processed construction materials.',
+  },
+  {
     id: 'battery',
     name: 'Battery',
     type: 'storage',
@@ -103,7 +142,7 @@ export const BUILDINGS = [
 
 export const BUILDING_MAP = Object.fromEntries(BUILDINGS.map((b) => [b.id, b]));
 export const PRODUCTION_BUILDINGS = BUILDINGS.filter(
-  (b) => b.type === 'production',
+  (b) => b.type === 'production' || b.type === 'processing',
 );
 export const STORAGE_BUILDINGS = BUILDINGS.filter((b) => b.type === 'storage');
 

--- a/src/data/research.js
+++ b/src/data/research.js
@@ -28,6 +28,7 @@ export const RESEARCH = [
     unlocks: {
       buildings: ['sawmill', 'metalWorkshop', 'materialsDepot'],
       categories: ['CONSTRUCTION_MATERIALS'],
+      resources: ['planks', 'metalParts'],
     },
     row: 0,
     effects: [],

--- a/src/data/resources.js
+++ b/src/data/resources.js
@@ -37,7 +37,7 @@ export const RESOURCES = {
     icon: '\u{1F332}',
     category: 'CONSTRUCTION_MATERIALS',
     startingAmount: 0,
-    startingCapacity: 0,
+    startingCapacity: 50,
   },
   metalParts: {
     id: 'metalParts',
@@ -45,7 +45,7 @@ export const RESOURCES = {
     icon: '\u2699\uFE0F',
     category: 'CONSTRUCTION_MATERIALS',
     startingAmount: 0,
-    startingCapacity: 0,
+    startingCapacity: 20,
   },
   science: {
     id: 'science',

--- a/src/engine/__tests__/economy.test.js
+++ b/src/engine/__tests__/economy.test.js
@@ -26,6 +26,26 @@ describe('economy basics', () => {
     );
   });
 
+  test('sawmill processes wood into planks when inputs available', () => {
+    const state = clone(defaultState);
+    state.resources.wood.amount = 10;
+    state.buildings.loggingCamp.count = 0;
+    state.buildings.sawmill = { count: 1 };
+    const next = processTick(state, 1);
+    expect(next.resources.wood.amount).toBeCloseTo(9, 5);
+    expect(next.resources.planks.amount).toBeCloseTo(0.5, 5);
+  });
+
+  test('sawmill halts without enough wood', () => {
+    const state = clone(defaultState);
+    state.resources.wood.amount = 0.5;
+    state.buildings.loggingCamp.count = 0;
+    state.buildings.sawmill = { count: 1 };
+    const next = processTick(state, 1);
+    expect(next.resources.wood.amount).toBeCloseTo(0.5, 5);
+    expect(next.resources.planks.amount).toBeCloseTo(0, 5);
+  });
+
   test('removing last required building unassigns settlers', () => {
     const state = clone(defaultState);
     state.buildings.potatoField.count = 1;

--- a/src/views/research/ResearchNode.jsx
+++ b/src/views/research/ResearchNode.jsx
@@ -1,6 +1,7 @@
 import React, { forwardRef } from 'react';
 import { RESEARCH_MAP } from '../../data/research.js';
 import { RESOURCES } from '../../data/resources.js';
+import { BUILDING_MAP } from '../../data/buildings.js';
 import { formatAmount } from '../../utils/format.js';
 
 function formatTime(seconds) {
@@ -12,14 +13,18 @@ function formatTime(seconds) {
 function buildTooltip(node) {
   const lines = [];
   if (node.unlocks?.buildings?.length) {
-    const names = node.unlocks.buildings.map((b) => b).join(', ');
+    const names = node.unlocks.buildings
+      .map((b) => BUILDING_MAP[b]?.name || b)
+      .join(', ');
     lines.push(`New buildings: ${names}`);
   }
   if (node.unlocks?.categories?.length) {
     lines.push(`New resource category: ${node.unlocks.categories.join(', ')}`);
   }
   if (node.unlocks?.resources?.length) {
-    const names = node.unlocks.resources.map((r) => r).join(', ');
+    const names = node.unlocks.resources
+      .map((r) => RESOURCES[r]?.name || r)
+      .join(', ');
     lines.push(`New resources: ${names}`);
   }
   const effs = Array.isArray(node.effects)


### PR DESCRIPTION
## Summary
- Introduce planks and metal parts with initial storage
- Add Sawmill and Metal Workshop processing buildings and Materials Depot storage
- Wire Industry I research and processing logic; show locked buildings pre-research

## Testing
- `npm test`
- `npm run report:economy`


------
https://chatgpt.com/codex/tasks/task_e_689a8829e85883319c94146540c9098e