### PR TITLE
Add radio research unlock and building requirement

### DIFF
--- a/docs/ECONOMY_REPORT.md
+++ b/docs/ECONOMY_REPORT.md
@@ -2,7 +2,7 @@
 
 ## 1) Overview
 
-Economy generated from commit **c165a592774acdbc653d9db413b42c1a1d032d6f** on 2025-08-12 02:12:22 +0200. Save version: **4**.  
+Economy generated from commit **7ea0c7c0394116ca3127c3ac4b1b08d0c37c6374** on 2025-08-12 02:34:02 +0200. Save version: **5**.
 Each tick represents 1 second. For each building: base production is modified by season multipliers, summed, then clamped to capacity. Offline progress processes in 60-second chunks.
 
 ## 2) Resources
@@ -31,34 +31,37 @@ Global rules: resources cannot go negative; amounts are clamped to capacity.
 
 ## 4) Buildings
 
-| id            | name           | type       | cost                                        | refund | storage | base prod/s     | inputs per sec | season mults                                     |
-| ------------- | -------------- | ---------- | ------------------------------------------- | ------ | ------- | --------------- | -------------- | ------------------------------------------------ |
-| potatoField   | Potato Field   | production | wood: 15                                    | 0.5    | -       | potatoes: 0.375 | -              | spring: 1.25, summer: 1, autumn: 0.85            |
-| loggingCamp   | Logging Camp   | production | scrap: 15                                   | 0.5    | -       | wood: 0.2       | -              | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
-| scrapyard     | Scrap Yard     | production | wood: 12                                    | 0.5    | -       | scrap: 0.06     | -              | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
-| quarry        | Quarry         | production | wood: 20, scrap: 5                          | 0.5    | -       | stone: 0.08     | -              | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
-| sawmill       | Sawmill        | processing | wood: 40, scrap: 15, stone: 10              | 0.5    | -       | planks: 0.5     | wood: 1        | spring: 1, summer: 1, autumn: 1, winter: 1       |
-| metalWorkshop | Metal Workshop | processing | wood: 30, scrap: 30, stone: 10, planks: 10  | 0.5    | -       | metalParts: 0.4 | scrap: 1       | spring: 1, summer: 1, autumn: 1, winter: 1       |
-| school        | School         | production | wood: 25, scrap: 10, stone: 10              | 0.5    | -       | science: 0.5    | -              | spring: 1, summer: 1, autumn: 1, winter: 1       |
-| woodGenerator | Wood Generator | production | wood: 50, stone: 10                         | 0.5    | -       | power: 1        | wood: 0.3      | spring: 1, summer: 1, autumn: 1, winter: 1       |
-| foodStorage   | Granary        | storage    | wood: 20, scrap: 5, stone: 5                | 0.5    | -       | -               | -              | -                                                |
-| rawStorage    | Warehouse      | storage    | wood: 25, scrap: 10, stone: 10              | 0.5    | -       | -               | -              | -                                                |
-| materialsDepot| Materials Depot| storage    | wood: 25, scrap: 10, stone: 5                | 0.5    | -       | -               | -              | -                                                |
-| battery       | Battery        | storage    | wood: 40, stone: 20                         | 0.5    | -       | -               | -              | -                                                |
+| id             | name            | type       | cost                                       | refund | storage | base prod/s     | inputs per sec | season mults                                     |
+| -------------- | --------------- | ---------- | ------------------------------------------ | ------ | ------- | --------------- | -------------- | ------------------------------------------------ |
+| potatoField    | Potato Field    | production | wood: 15                                   | 0.5    | -       | potatoes: 0.375 | -              | spring: 1.25, summer: 1, autumn: 0.85            |
+| loggingCamp    | Logging Camp    | production | scrap: 15                                  | 0.5    | -       | wood: 0.2       | -              | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
+| scrapyard      | Scrap Yard      | production | wood: 12                                   | 0.5    | -       | scrap: 0.06     | -              | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
+| quarry         | Quarry          | production | wood: 20, scrap: 5                         | 0.5    | -       | stone: 0.08     | -              | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
+| sawmill        | Sawmill         | processing | wood: 40, scrap: 15, stone: 10             | 0.5    | -       | planks: 0.5     | wood: 1        | spring: 1, summer: 1, autumn: 1, winter: 1       |
+| metalWorkshop  | Metal Workshop  | processing | wood: 30, scrap: 30, stone: 10, planks: 10 | 0.5    | -       | metalParts: 0.4 | scrap: 1       | spring: 1, summer: 1, autumn: 1, winter: 1       |
+| school         | School          | production | wood: 25, scrap: 10, stone: 10             | 0.5    | -       | science: 0.5    | -              | spring: 1, summer: 1, autumn: 1, winter: 1       |
+| woodGenerator  | Wood Generator  | production | wood: 50, stone: 10                        | 0.5    | -       | power: 1        | wood: 0.3      | spring: 1, summer: 1, autumn: 1, winter: 1       |
+| shelter        | Shelter         | production | wood: 30, scrap: 10                        | 0.5    | -       | -               | -              | -                                                |
+| radio          | Radio           | production | wood: 80, scrap: 40, stone: 20             | 0.5    | -       | -               | power: 0.1     | -                                                |
+| foodStorage    | Granary         | storage    | wood: 20, scrap: 5, stone: 5               | 0.5    | -       | -               | -              | -                                                |
+| rawStorage     | Warehouse       | storage    | wood: 25, scrap: 10, stone: 10             | 0.5    | -       | -               | -              | -                                                |
+| materialsDepot | Materials Depot | storage    | wood: 25, scrap: 10, stone: 5              | 0.5    | -       | -               | -              | -                                                |
+| battery        | Battery         | storage    | wood: 40, stone: 20                        | 0.5    | -       | -               | -              | -                                                |
 
 ## 5) Research
 
-| id           | name           | science cost | time (sec) | prereqs                 | unlocks                                                                               |
-| ------------ | -------------- | ------------ | ---------- | ----------------------- | ------------------------------------------------------------------------------------- |
-| basicEnergy  | Basic Energy   | 20           | 120        | -                       | resources: power; buildings: woodGenerator, battery; categories: Energy               |
-| industry1    | Industry I     | 40           | 60         | -                       | buildings: sawmill, metalWorkshop, materialsDepot; categories: CONSTRUCTION_MATERIALS |
-| woodworking1 | Woodworking I  | 30           | 45         | industry1               | -                                                                                     |
-| salvaging1   | Salvaging I    | 30           | 45         | industry1               | -                                                                                     |
-| logistics1   | Logistics I    | 35           | 60         | industry1               | -                                                                                     |
-| industry2    | Industry II    | 140          | 180        | industry1               | buildings: toolsmithy                                                                 |
-| woodworking2 | Woodworking II | 70           | 120        | woodworking1, industry2 | -                                                                                     |
-| salvaging2   | Salvaging II   | 70           | 120        | salvaging1, industry2   | -                                                                                     |
-| logistics2   | Logistics II   | 80           | 150        | logistics1, industry2   | -                                                                                     |
+| id           | name           | science cost | time (sec) | prereqs                 | unlocks                                                                                                              |
+| ------------ | -------------- | ------------ | ---------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| basicEnergy  | Basic Energy   | 20           | 120        | -                       | resources: power; buildings: woodGenerator, battery; categories: Energy                                              |
+| industry1    | Industry I     | 40           | 60         | -                       | resources: planks, metalParts; buildings: sawmill, metalWorkshop, materialsDepot; categories: CONSTRUCTION_MATERIALS |
+| radio        | Radio          | 80           | 120        | industry1               | buildings: radio                                                                                                     |
+| woodworking1 | Woodworking I  | 30           | 45         | industry1               | -                                                                                                                    |
+| salvaging1   | Salvaging I    | 30           | 45         | industry1               | -                                                                                                                    |
+| logistics1   | Logistics I    | 35           | 60         | industry1               | -                                                                                                                    |
+| industry2    | Industry II    | 140          | 180        | industry1               | buildings: toolsmithy                                                                                                |
+| woodworking2 | Woodworking II | 70           | 120        | woodworking1, industry2 | -                                                                                                                    |
+| salvaging2   | Salvaging II   | 70           | 120        | salvaging1, industry2   | -                                                                                                                    |
+| logistics2   | Logistics II   | 80           | 150        | logistics1, industry2   | -                                                                                                                    |
 
 ## 6) Population and Roles
 
@@ -68,9 +71,12 @@ No role-based production modifiers in effect.
 
 Per building per tick:
 
-`effectiveCycle = cycleTimeSec * seasonSpeed`  
-`effectiveHarvest = harvestAmount * outputValue * seasonYield`  
-`cycles = floor((elapsed + timer) / effectiveCycle)`  
+`effectiveCycle = cycleTimeSec * seasonSpeed`
+
+`effectiveHarvest = harvestAmount * outputValue * seasonYield`
+
+`cycles = floor((elapsed + timer) / effectiveCycle)`
+
 `production = effectiveHarvest * count * cycles`
 
 Sum production for each resource across buildings, then `clampResource(value, capacity)` where values below 0 become 0 and above capacity become capacity.

--- a/docs/economy-snapshot.json
+++ b/docs/economy-snapshot.json
@@ -1,6 +1,6 @@
 {
-  "version": "c165a592774acdbc653d9db413b42c1a1d032d6f",
-  "saveVersion": 4,
+  "version": "7ea0c7c0394116ca3127c3ac4b1b08d0c37c6374",
+  "saveVersion": 5,
   "tickSeconds": 1,
   "seasons": {
     "spring": {
@@ -315,6 +315,41 @@
       }
     },
     {
+      "id": "shelter",
+      "name": "Shelter",
+      "type": "production",
+      "constructionCost": {
+        "wood": 30,
+        "scrap": 10
+      },
+      "demolitionRefund": 0.5,
+      "storageProvided": {},
+      "baseProductionPerSec": {},
+      "baseInputsPerSec": {},
+      "seasonalMode": "ignore",
+      "seasonalCustom": null,
+      "seasonalMultipliers": {}
+    },
+    {
+      "id": "radio",
+      "name": "Radio",
+      "type": "production",
+      "constructionCost": {
+        "wood": 80,
+        "scrap": 40,
+        "stone": 20
+      },
+      "demolitionRefund": 0.5,
+      "storageProvided": {},
+      "baseProductionPerSec": {},
+      "baseInputsPerSec": {
+        "power": 0.1
+      },
+      "seasonalMode": "ignore",
+      "seasonalCustom": null,
+      "seasonalMultipliers": {}
+    },
+    {
       "id": "foodStorage",
       "name": "Granary",
       "type": "storage",
@@ -408,7 +443,21 @@
       "prereqs": [],
       "unlocks": {
         "buildings": ["sawmill", "metalWorkshop", "materialsDepot"],
-        "categories": ["CONSTRUCTION_MATERIALS"]
+        "categories": ["CONSTRUCTION_MATERIALS"],
+        "resources": ["planks", "metalParts"]
+      },
+      "effects": []
+    },
+    {
+      "id": "radio",
+      "name": "Radio",
+      "cost": {
+        "science": 80
+      },
+      "timeSec": 120,
+      "prereqs": ["industry1"],
+      "unlocks": {
+        "buildings": ["radio"]
       },
       "effects": []
     },
@@ -534,13 +583,7 @@
   ],
   "roles": [],
   "formula": {
-    "order": [
-      "base",
-      "season",
-      "roles",
-      "sum",
-      "clamp"
-    ],
+    "order": ["base", "season", "roles", "sum", "clamp"],
     "demolitionRefund": 0.5,
     "clampRule": "min(value, capacity) and never negative"
   },

--- a/src/components/ResourceSidebar.jsx
+++ b/src/components/ResourceSidebar.jsx
@@ -86,9 +86,12 @@ export default function ResourceSidebar() {
   else if (ratio > 0.8) color = 'text-yellow-400';
   const radioCount = state.buildings?.radio?.count || 0;
   const candidatePending = !!state.population?.candidate;
-  let radioLine = 'Radio: not built';
+  const hasRadioResearch = (state.research.completed || []).includes('radio');
+  let radioLine = hasRadioResearch
+    ? 'Radio: not built'
+    : 'Radio research not complete';
   let progress = 0;
-  if (radioCount > 0) {
+  if (hasRadioResearch && radioCount > 0) {
     const powered = (state.resources.power?.amount || 0) > 0;
     if (candidatePending) {
       radioLine = 'A settler is waiting for your decision';
@@ -99,28 +102,33 @@ export default function ResourceSidebar() {
       const mm = String(Math.floor(timer / 60)).padStart(2, '0');
       const ss = String(Math.floor(timer % 60)).padStart(2, '0');
       radioLine = `Next settler in: ${mm}:${ss}`;
-      progress = Math.max(0, Math.min(1, (RADIO_BASE_SECONDS - timer) / RADIO_BASE_SECONDS));
+      progress = Math.max(
+        0,
+        Math.min(1, (RADIO_BASE_SECONDS - timer) / RADIO_BASE_SECONDS),
+      );
     }
   }
 
   const rendered = [];
   entries.forEach((g) => {
     rendered.push(g);
-    if (g.title === 'Science') rendered.push({ title: 'Settlers', settlers: true });
+    if (g.title === 'Science')
+      rendered.push({ title: 'Settlers', settlers: true });
   });
   if (!rendered.some((e) => e.title === 'Settlers'))
     rendered.push({ title: 'Settlers', settlers: true });
 
   return (
     <div className="border border-stroke rounded overflow-hidden bg-bg2">
-      {rendered.map((g) => (
+      {rendered.map((g) =>
         g.settlers ? (
           <Accordion key={g.title} title={g.title} defaultOpen>
             <div className={`text-sm mb-1 ${color}`}>
               Settlers {total}/{capacity}
             </div>
             <div className="text-xs text-muted mb-1">{radioLine}</div>
-            {radioCount > 0 && !candidatePending &&
+            {radioCount > 0 &&
+              !candidatePending &&
               (state.resources.power?.amount || 0) > 0 && (
                 <div className="h-2 bg-stroke rounded mb-1">
                   <div
@@ -136,15 +144,21 @@ export default function ResourceSidebar() {
                 .map(([id, sk]) => `${SKILL_LABELS[id] || id} ${sk.level}`)
                 .join(', ');
               return (
-                <div key={s.id} className="flex justify-between items-center text-sm">
+                <div
+                  key={s.id}
+                  className="flex justify-between items-center text-sm"
+                >
                   <span>
-                    {s.firstName} {s.lastName} • {age} • {skillStr || 'No skills'}
+                    {s.firstName} {s.lastName} • {age} •{' '}
+                    {skillStr || 'No skills'}
                   </span>
                   <button
                     className="px-1 border border-stroke rounded text-xs disabled:opacity-50"
                     onClick={() =>
                       setState((prev) => {
-                        const list = prev.population.settlers.filter((x) => x.id !== s.id);
+                        const list = prev.population.settlers.filter(
+                          (x) => x.id !== s.id,
+                        );
                         return {
                           ...prev,
                           population: { ...prev.population, settlers: list },
@@ -165,8 +179,8 @@ export default function ResourceSidebar() {
               <ResourceRow key={r.id} {...r} />
             ))}
           </Accordion>
-        )
-      ))}
+        ),
+      )}
     </div>
   );
 }

--- a/src/data/buildings.js
+++ b/src/data/buildings.js
@@ -114,6 +114,7 @@ export const BUILDINGS = [
     name: 'Radio',
     type: 'production',
     category: 'Utilities',
+    requiresResearch: 'radio',
     inputsPerSecBase: { power: 0.1 },
     costBase: { wood: 80, scrap: 40, stone: 20 },
     costGrowth: 1,

--- a/src/data/research.js
+++ b/src/data/research.js
@@ -34,6 +34,18 @@ export const RESEARCH = [
     effects: [],
   },
   {
+    id: 'radio',
+    name: 'Radio',
+    type: 'unlock',
+    shortDesc: 'Unlocks radio broadcasts to attract settlers.',
+    cost: { science: 80 },
+    timeSec: 120,
+    prereqs: ['industry1'],
+    unlocks: { buildings: ['radio'] },
+    row: 1,
+    effects: [],
+  },
+  {
     id: 'woodworking1',
     name: 'Woodworking I',
     type: 'efficiency',

--- a/src/engine/__tests__/research.test.js
+++ b/src/engine/__tests__/research.test.js
@@ -4,6 +4,7 @@ import {
   processResearchTick,
   cancelResearch,
 } from '../research.js';
+import { RESEARCH_MAP } from '../../data/research.js';
 import { defaultState } from '../../state/defaultState.js';
 import { getResearchOutputBonus } from '../../state/selectors.js';
 import { computeRoleBonuses } from '../settlers.js';
@@ -57,5 +58,16 @@ describe('research engine', () => {
     expect(s.research.current).not.toBe(null);
     s = processResearchTick(s, 1, bonuses);
     expect(s.research.current).toBe(null);
+  });
+
+  it('unlocks radio after industry research', () => {
+    const state = clone(defaultState);
+    state.resources.science.amount = 200;
+    let s = startResearch(state, 'industry1');
+    s = processResearchTick(s, RESEARCH_MAP['industry1'].timeSec);
+    s = startResearch(s, 'radio');
+    expect(s.research.current.id).toBe('radio');
+    s = processResearchTick(s, RESEARCH_MAP['radio'].timeSec);
+    expect(s.research.completed).toContain('radio');
   });
 });


### PR DESCRIPTION
## Summary
- Add new `radio` research node unlocked after Industry I
- Gate Radio building behind the new research and update sidebar text
- Cover radio research path with tests and regenerate economy docs

## Testing
- `npm test`
- `npm run lint`
- `npm run report:economy`


------
https://chatgpt.com/codex/tasks/task_e_689a8c0740048331a289ff2ae98f3708