### PR TITLE
Gate basic energy behind Industry I

### DIFF
--- a/docs/ECONOMY_REPORT.md
+++ b/docs/ECONOMY_REPORT.md
@@ -2,7 +2,7 @@
 
 ## 1) Overview
 
-Economy generated from commit **7ea0c7c0394116ca3127c3ac4b1b08d0c37c6374** on 2025-08-12 02:34:02 +0200. Save version: **5**.
+Economy generated from commit **070053a8d44126fb5c270ff654c22f892f457044** on 2025-08-12 02:38:49 +0200. Save version: **5**.
 Each tick represents 1 second. For each building: base production is modified by season multipliers, summed, then clamped to capacity. Offline progress processes in 60-second chunks.
 
 ## 2) Resources
@@ -52,7 +52,7 @@ Global rules: resources cannot go negative; amounts are clamped to capacity.
 
 | id           | name           | science cost | time (sec) | prereqs                 | unlocks                                                                                                              |
 | ------------ | -------------- | ------------ | ---------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| basicEnergy  | Basic Energy   | 20           | 120        | -                       | resources: power; buildings: woodGenerator, battery; categories: Energy                                              |
+| basicEnergy  | Basic Energy   | 50           | 90         | industry1               | resources: power; buildings: woodGenerator, battery; categories: Energy                                              |
 | industry1    | Industry I     | 40           | 60         | -                       | resources: planks, metalParts; buildings: sawmill, metalWorkshop, materialsDepot; categories: CONSTRUCTION_MATERIALS |
 | radio        | Radio          | 80           | 120        | industry1               | buildings: radio                                                                                                     |
 | woodworking1 | Woodworking I  | 30           | 45         | industry1               | -                                                                                                                    |

--- a/docs/economy-snapshot.json
+++ b/docs/economy-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "version": "7ea0c7c0394116ca3127c3ac4b1b08d0c37c6374",
+  "version": "070053a8d44126fb5c270ff654c22f892f457044",
   "saveVersion": 5,
   "tickSeconds": 1,
   "seasons": {
@@ -422,10 +422,10 @@
       "id": "basicEnergy",
       "name": "Basic Energy",
       "cost": {
-        "science": 20
+        "science": 50
       },
-      "timeSec": 120,
-      "prereqs": [],
+      "timeSec": 90,
+      "prereqs": ["industry1"],
       "unlocks": {
         "resources": ["power"],
         "buildings": ["woodGenerator", "battery"],

--- a/src/data/research.js
+++ b/src/data/research.js
@@ -5,15 +5,15 @@ export const RESEARCH = [
     type: 'unlock',
     shortDesc:
       'Learn the fundamentals of generating and storing electrical power.',
-    cost: { science: 20 },
-    timeSec: 120,
-    prereqs: [],
+    cost: { science: 50 },
+    timeSec: 90,
+    prereqs: ['industry1'],
     unlocks: {
       resources: ['power'],
       buildings: ['woodGenerator', 'battery'],
       categories: ['Energy'],
     },
-    row: 0,
+    row: 1,
     effects: [],
   },
   {


### PR DESCRIPTION
## Summary
- Require Industry I before researching Basic Energy
- Adjust Basic Energy cost to 50 science and move to research tree row 1
- Update economy docs and snapshot for Basic Energy's new position

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 4 files: src/components/CandidateBox.jsx, src/engine/production.js, src/state/selectors.js, src/views/BaseView.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_689a8d233e2c83318f5cb495b53ffb99