### PR TITLE
Skip non-output buildings in resource rate calc

### DIFF
--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -35,6 +35,7 @@ export function getResourceRates(
   PRODUCTION_BUILDINGS.forEach((b) => {
     const count = state.buildings?.[b.id]?.count || 0;
     if (count <= 0) return;
+    if (!b.outputsPerSecBase) return;
     let factor = 1;
     if (b.inputsPerSecBase) {
       if (b.type === 'processing') {


### PR DESCRIPTION
## Summary
- guard getResourceRates against buildings without outputs so shelters don't crash resource calculations

## Testing
- `node -e "import {getResourceRates} from './src/state/selectors.js'; const state={buildings:{shelter:{count:1}},resources:{}}; console.log(getResourceRates(state));"`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a8e844eec8331a9ecca3262b0eceb