### PR TITLE
Hide settlers sidebar until radio research

### DIFF
--- a/src/components/CandidateBox.jsx
+++ b/src/components/CandidateBox.jsx
@@ -40,7 +40,8 @@ export default function CandidateBox() {
     <div className="p-4 border border-stroke bg-bg2 rounded space-y-2">
       <div className="font-semibold">A new settler has arrived!</div>
       <div className="text-sm">
-        {candidate.firstName} {candidate.lastName} • {candidate.sex === 'M' ? 'Male' : 'Female'} • Age {candidate.age}
+        {candidate.firstName} {candidate.lastName} •{' '}
+        {candidate.sex === 'M' ? 'Male' : 'Female'} • Age {candidate.age}
       </div>
       <div className="text-xs text-muted">{skills || 'No skills'}</div>
       <div className="space-x-2">

--- a/src/components/ResourceSidebar.jsx
+++ b/src/components/ResourceSidebar.jsx
@@ -10,8 +10,6 @@ import { computeRoleBonuses } from '../engine/settlers.js';
 import { formatAmount } from '../utils/format.js';
 import { RESOURCE_LIST } from '../data/resources.js';
 import { RADIO_BASE_SECONDS } from '../data/settlement.js';
-import { SKILL_LABELS } from '../data/roles.js';
-import { DAYS_PER_YEAR } from '../engine/time.js';
 
 function ResourceRow({ icon, name, amount, capacity, rate, tooltip }) {
   return (
@@ -34,7 +32,7 @@ function ResourceRow({ icon, name, amount, capacity, rate, tooltip }) {
 }
 
 export default function ResourceSidebar() {
-  const { state, setState } = useGame();
+  const { state } = useGame();
   const roleBonuses = computeRoleBonuses(state.population?.settlers || []);
   const rates = getResourceRates(state, true, roleBonuses);
   const groups = {};
@@ -112,10 +110,10 @@ export default function ResourceSidebar() {
   const rendered = [];
   entries.forEach((g) => {
     rendered.push(g);
-    if (g.title === 'Science')
+    if (hasRadioResearch && g.title === 'Science')
       rendered.push({ title: 'Settlers', settlers: true });
   });
-  if (!rendered.some((e) => e.title === 'Settlers'))
+  if (hasRadioResearch && !rendered.some((e) => e.title === 'Settlers'))
     rendered.push({ title: 'Settlers', settlers: true });
 
   return (
@@ -137,41 +135,6 @@ export default function ResourceSidebar() {
                   />
                 </div>
               )}
-            {settlers.map((s) => {
-              const age = Math.floor((s.ageDays || 0) / DAYS_PER_YEAR);
-              const skillStr = Object.entries(s.skills || {})
-                .filter(([, sk]) => sk.level > 0)
-                .map(([id, sk]) => `${SKILL_LABELS[id] || id} ${sk.level}`)
-                .join(', ');
-              return (
-                <div
-                  key={s.id}
-                  className="flex justify-between items-center text-sm"
-                >
-                  <span>
-                    {s.firstName} {s.lastName} • {age} •{' '}
-                    {skillStr || 'No skills'}
-                  </span>
-                  <button
-                    className="px-1 border border-stroke rounded text-xs disabled:opacity-50"
-                    onClick={() =>
-                      setState((prev) => {
-                        const list = prev.population.settlers.filter(
-                          (x) => x.id !== s.id,
-                        );
-                        return {
-                          ...prev,
-                          population: { ...prev.population, settlers: list },
-                        };
-                      })
-                    }
-                    disabled={total <= 1}
-                  >
-                    Exile
-                  </button>
-                </div>
-              );
-            })}
           </Accordion>
         ) : (
           <Accordion key={g.title} title={g.title} defaultOpen={g.defaultOpen}>

--- a/src/engine/production.js
+++ b/src/engine/production.js
@@ -27,11 +27,13 @@ export function applyProduction(state, seconds = 1, roleBonuses = {}) {
     let factor = 1;
     if (b.inputsPerSecBase) {
       if (b.type === 'processing') {
-        const canRun = Object.entries(b.inputsPerSecBase).every(([res, base]) => {
-          const need = base * count * seconds;
-          const have = resources[res]?.amount || 0;
-          return have >= need;
-        });
+        const canRun = Object.entries(b.inputsPerSecBase).every(
+          ([res, base]) => {
+            const need = base * count * seconds;
+            const have = resources[res]?.amount || 0;
+            return have >= need;
+          },
+        );
         if (!canRun) return;
         Object.entries(b.inputsPerSecBase).forEach(([res, base]) => {
           const amt = base * count * seconds;

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -39,11 +39,13 @@ export function getResourceRates(
     let factor = 1;
     if (b.inputsPerSecBase) {
       if (b.type === 'processing') {
-        const canRun = Object.entries(b.inputsPerSecBase).every(([res, base]) => {
-          const need = base * count;
-          const have = state.resources[res]?.amount || 0;
-          return have >= need;
-        });
+        const canRun = Object.entries(b.inputsPerSecBase).every(
+          ([res, base]) => {
+            const need = base * count;
+            const have = state.resources[res]?.amount || 0;
+            return have >= need;
+          },
+        );
         if (!canRun) return;
         Object.entries(b.inputsPerSecBase).forEach(([res, base]) => {
           const amt = base * count;

--- a/src/views/BaseView.jsx
+++ b/src/views/BaseView.jsx
@@ -82,7 +82,9 @@ function BuildingRow({ building }) {
       <div className="flex items-center justify-between">
         <span>
           {building.name}{' '}
-          {building.maxCount != null ? `${count}/${building.maxCount}` : `(${count})`}
+          {building.maxCount != null
+            ? `${count}/${building.maxCount}`
+            : `(${count})`}
         </span>
         <div className="space-x-2">
           <button
@@ -96,8 +98,8 @@ function BuildingRow({ building }) {
                     building.requiresResearch
                   }`
                 : atMax
-                ? `Max ${building.maxCount}`
-                : undefined
+                  ? `Max ${building.maxCount}`
+                  : undefined
             }
           >
             Build

--- a/src/views/PopulationView.jsx
+++ b/src/views/PopulationView.jsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
 import { useGame } from '../state/useGame.js';
 import { formatAge } from '../utils/format.js';
-import { assignmentsSummary, computeRoleBonuses } from '../engine/settlers.js';
+import { computeRoleBonuses } from '../engine/settlers.js';
 import { XP_TIME_TO_NEXT_LEVEL_SECONDS } from '../data/balance.js';
 import { ROLE_LIST, SKILL_LABELS } from '../data/roles.js';
 import { RESOURCES } from '../data/resources.js';
+import { getSettlerCapacity } from '../state/selectors.js';
 
 export default function PopulationView() {
   const { state, setSettlerRole } = useGame();
@@ -17,7 +18,8 @@ export default function PopulationView() {
   const filtered = settlers
     .filter((s) => !onlyLiving || !s.isDead)
     .filter((s) => !unassignedOnly || s.role == null);
-  const { assigned, living } = assignmentsSummary(settlers);
+  const living = settlers.filter((s) => !s.isDead).length;
+  const capacity = getSettlerCapacity(state);
   const bonuses = computeRoleBonuses(settlers);
   const bonusLabels = {};
   ROLE_LIST.forEach((r) => {
@@ -30,7 +32,7 @@ export default function PopulationView() {
         <div className="border border-stroke rounded p-3 bg-bg2/50 text-center">
           <div className="text-xs text-muted">Settlers</div>
           <div className="text-lg font-semibold">
-            {assigned}/{living}
+            {living}/{capacity}
           </div>
         </div>
         {Object.entries(bonusLabels).map(([role, label]) => (


### PR DESCRIPTION
## Summary
- Show settlers sidebar section only after radio research
- Sidebar now displays only total settlers, capacity and radio timer
- Survivor view displays settler limit instead of assignments
- Run Prettier formatting on affected files

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a8fe29ffc83318583f3ba67743cac