### PR TITLE
Refactor economy report generator for complete starting state

### DIFF
--- a/docs/ECONOMY_REPORT.md
+++ b/docs/ECONOMY_REPORT.md
@@ -1,110 +1,88 @@
 # Economy Report
 
 ## 1) Overview
-
-Economy generated from commit **070053a8d44126fb5c270ff654c22f892f457044** on 2025-08-12 02:38:49 +0200. Save version: **5**.
+Economy generated from commit **7ae16b531a8fdf5232b9e17876730285d6e57f9a** on 2025-08-12 03:15:45 +0200. Save version: **5**.
 Each tick represents 1 second. For each building: base production is modified by season multipliers, summed, then clamped to capacity. Offline progress processes in 60-second chunks.
 
 ## 2) Resources
+| key | displayName | category | startingAmount | startingCapacity | unit |
+| - | - | - | - | - | - |
+| potatoes | Potatoes | FOOD | 0 | 300 |  |
+| wood | Wood | RAW | 0 | 100 |  |
+| stone | Stone | RAW | 0 | 100 |  |
+| scrap | Scrap | RAW | 0 | 100 |  |
+| planks | Planks | CONSTRUCTION_MATERIALS | 0 | 50 |  |
+| metalParts | Metal Parts | CONSTRUCTION_MATERIALS | 0 | 20 |  |
+| science | Science | SOCIETY | 0 | 400 |  |
+| power | Power | ENERGY | 0 | 2 |  |
 
-| key        | displayName | category               | startingAmount | startingCapacity | unit |
-| ---------- | ----------- | ---------------------- | -------------- | ---------------- | ---- |
-| potatoes   | Potatoes    | FOOD                   | 0              | 300              |      |
-| wood       | Wood        | RAW                    | 0              | 100              |      |
-| stone      | Stone       | RAW                    | 0              | 100              |      |
-| scrap      | Scrap       | RAW                    | 0              | 100              |      |
-| planks     | Planks      | CONSTRUCTION_MATERIALS | 0              | 50               |      |
-| metalParts | Metal Parts | CONSTRUCTION_MATERIALS | 0              | 20               |      |
-| science    | Science     | SOCIETY                | 0              | 400              |      |
-| power      | Power       | ENERGY                 | 0              | 2                |      |
-
-Global rules: resources cannot go negative; amounts are clamped to capacity.
-
-## 3) Seasons and Global Modifiers
-
-| season | duration (sec) | potatoes | wood  | stone | scrap | planks | metalParts | science | power |
-| ------ | -------------- | -------- | ----- | ----- | ----- | ------ | ---------- | ------- | ----- |
-| spring | 270            | 1.250    | 1.100 | 1.100 | 1.100 | 1.000  | 1.000      | 1.000   | 1.000 |
-| summer | 270            | 1.000    | 1.000 | 1.000 | 1.000 | 1.000  | 1.000      | 1.000   | 1.000 |
-| autumn | 270            | 0.850    | 0.900 | 0.900 | 0.900 | 1.000  | 1.000      | 1.000   | 1.000 |
-| winter | 270            | 0.000    | 0.800 | 0.800 | 0.800 | 1.000  | 1.000      | 1.000   | 1.000 |
+## 3) Seasons
+| season | duration (sec) | potatoes | wood | stone | scrap | planks | metalParts | science | power |
+| - | - | - | - | - | - | - | - | - | - |
+| spring | 270 | 1.250 | 1.100 | 1.100 | 1.100 | 1.000 | 1.000 | 1.000 | 1.000 |
+| summer | 270 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
+| autumn | 270 | 0.850 | 0.900 | 0.900 | 0.900 | 1.000 | 1.000 | 1.000 | 1.000 |
+| winter | 270 | 0.000 | 0.800 | 0.800 | 0.800 | 1.000 | 1.000 | 1.000 | 1.000 |
 
 ## 4) Buildings
-
-| id             | name            | type       | cost                                       | refund | storage | base prod/s     | inputs per sec | season mults                                     |
-| -------------- | --------------- | ---------- | ------------------------------------------ | ------ | ------- | --------------- | -------------- | ------------------------------------------------ |
-| potatoField    | Potato Field    | production | wood: 15                                   | 0.5    | -       | potatoes: 0.375 | -              | spring: 1.25, summer: 1, autumn: 0.85            |
-| loggingCamp    | Logging Camp    | production | scrap: 15                                  | 0.5    | -       | wood: 0.2       | -              | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
-| scrapyard      | Scrap Yard      | production | wood: 12                                   | 0.5    | -       | scrap: 0.06     | -              | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
-| quarry         | Quarry          | production | wood: 20, scrap: 5                         | 0.5    | -       | stone: 0.08     | -              | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
-| sawmill        | Sawmill         | processing | wood: 40, scrap: 15, stone: 10             | 0.5    | -       | planks: 0.5     | wood: 1        | spring: 1, summer: 1, autumn: 1, winter: 1       |
-| metalWorkshop  | Metal Workshop  | processing | wood: 30, scrap: 30, stone: 10, planks: 10 | 0.5    | -       | metalParts: 0.4 | scrap: 1       | spring: 1, summer: 1, autumn: 1, winter: 1       |
-| school         | School          | production | wood: 25, scrap: 10, stone: 10             | 0.5    | -       | science: 0.5    | -              | spring: 1, summer: 1, autumn: 1, winter: 1       |
-| woodGenerator  | Wood Generator  | production | wood: 50, stone: 10                        | 0.5    | -       | power: 1        | wood: 0.3      | spring: 1, summer: 1, autumn: 1, winter: 1       |
-| shelter        | Shelter         | production | wood: 30, scrap: 10                        | 0.5    | -       | -               | -              | -                                                |
-| radio          | Radio           | production | wood: 80, scrap: 40, stone: 20             | 0.5    | -       | -               | power: 0.1     | -                                                |
-| foodStorage    | Granary         | storage    | wood: 20, scrap: 5, stone: 5               | 0.5    | -       | -               | -              | -                                                |
-| rawStorage     | Warehouse       | storage    | wood: 25, scrap: 10, stone: 10             | 0.5    | -       | -               | -              | -                                                |
-| materialsDepot | Materials Depot | storage    | wood: 25, scrap: 10, stone: 5              | 0.5    | -       | -               | -              | -                                                |
-| battery        | Battery         | storage    | wood: 40, stone: 20                        | 0.5    | -       | -               | -              | -                                                |
+| id | name | type | cost | refund | storage | base prod/s | inputs per sec | season mults |
+| - | - | - | - | - | - | - | - | - |
+| potatoField | Potato Field | production | wood: 15 | 0.5 | - | potatoes: 0.375 | - | spring: 1.25, summer: 1, autumn: 0.85, winter: 0 |
+| loggingCamp | Logging Camp | production | scrap: 15 | 0.5 | - | wood: 0.2 | - | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
+| scrapyard | Scrap Yard | production | wood: 12 | 0.5 | - | scrap: 0.06 | - | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
+| quarry | Quarry | production | wood: 20, scrap: 5 | 0.5 | - | stone: 0.08 | - | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
+| sawmill | Sawmill | processing | wood: 40, scrap: 15, stone: 10 | 0.5 | - | planks: 0.5 | wood: 1 | spring: 1, summer: 1, autumn: 1, winter: 1 |
+| metalWorkshop | Metal Workshop | processing | wood: 30, scrap: 30, stone: 10, planks: 10 | 0.5 | - | metalParts: 0.4 | scrap: 1 | spring: 1, summer: 1, autumn: 1, winter: 1 |
+| school | School | production | wood: 25, scrap: 10, stone: 10 | 0.5 | - | science: 0.5 | - | spring: 1, summer: 1, autumn: 1, winter: 1 |
+| woodGenerator | Wood Generator | production | wood: 50, stone: 10 | 0.5 | - | power: 1 | wood: 0.3 | spring: 1, summer: 1, autumn: 1, winter: 1 |
+| shelter | Shelter | production | wood: 30, scrap: 10 | 0.5 | - | - | - | - |
+| radio | Radio | production | wood: 80, scrap: 40, stone: 20 | 0.5 | - | - | power: 0.1 | - |
+| foodStorage | Granary | storage | wood: 20, scrap: 5, stone: 5 | 0.5 | potatoes: 300 | - | - | - |
+| rawStorage | Warehouse | storage | wood: 25, scrap: 10, stone: 10 | 0.5 | wood: 200, stone: 80, scrap: 120 | - | - | - |
+| materialsDepot | Materials Depot | storage | wood: 25, scrap: 10, stone: 5 | 0.5 | planks: 150, metalParts: 60 | - | - | - |
+| battery | Battery | storage | wood: 40, stone: 20 | 0.5 | power: 20 | - | - | - |
 
 ## 5) Research
+| id | name | science cost | time (sec) | prereqs | unlocks |
+| - | - | - | - | - | - |
+| basicEnergy | Basic Energy | 50 | 90 | industry1 | resources: power; buildings: woodGenerator, battery; categories: Energy |
+| industry1 | Industry I | 40 | 60 | - | resources: planks, metalParts; buildings: sawmill, metalWorkshop, materialsDepot; categories: CONSTRUCTION_MATERIALS |
+| radio | Radio | 80 | 120 | industry1 | buildings: radio |
+| woodworking1 | Woodworking I | 30 | 45 | industry1 | effects: { category=WOOD, percent=5.0%, type=output } |
+| salvaging1 | Salvaging I | 30 | 45 | industry1 | effects: { category=SCRAP, percent=5.0%, type=output } |
+| logistics1 | Logistics I | 35 | 60 | industry1 | effects: { category=RAW, percent=5.0%, type=storage }, { category=CONSTRUCTION_MATERIALS, percent=5.0%, type=storage } |
+| industry2 | Industry II | 140 | 180 | industry1 | buildings: toolsmithy |
+| woodworking2 | Woodworking II | 70 | 120 | woodworking1, industry2 | effects: { category=WOOD, percent=5.0%, type=output } |
+| salvaging2 | Salvaging II | 70 | 120 | salvaging1, industry2 | effects: { category=SCRAP, percent=5.0%, type=output } |
+| logistics2 | Logistics II | 80 | 150 | logistics1, industry2 | effects: { category=RAW, percent=5.0%, type=storage }, { category=CONSTRUCTION_MATERIALS, percent=5.0%, type=storage } |
 
-| id           | name           | science cost | time (sec) | prereqs                 | unlocks                                                                                                              |
-| ------------ | -------------- | ------------ | ---------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| basicEnergy  | Basic Energy   | 50           | 90         | industry1               | resources: power; buildings: woodGenerator, battery; categories: Energy                                              |
-| industry1    | Industry I     | 40           | 60         | -                       | resources: planks, metalParts; buildings: sawmill, metalWorkshop, materialsDepot; categories: CONSTRUCTION_MATERIALS |
-| radio        | Radio          | 80           | 120        | industry1               | buildings: radio                                                                                                     |
-| woodworking1 | Woodworking I  | 30           | 45         | industry1               | -                                                                                                                    |
-| salvaging1   | Salvaging I    | 30           | 45         | industry1               | -                                                                                                                    |
-| logistics1   | Logistics I    | 35           | 60         | industry1               | -                                                                                                                    |
-| industry2    | Industry II    | 140          | 180        | industry1               | buildings: toolsmithy                                                                                                |
-| woodworking2 | Woodworking II | 70           | 120        | woodworking1, industry2 | -                                                                                                                    |
-| salvaging2   | Salvaging II   | 70           | 120        | salvaging1, industry2   | -                                                                                                                    |
-| logistics2   | Logistics II   | 80           | 150        | logistics1, industry2   | -                                                                                                                    |
+## 6) Roles
+| id | name | resource | building |
+| - | - | - | - |
+| farmer | Farmer | potatoes | potatoField |
+| woodcutter | Woodcutter | wood | loggingCamp |
+| scavenger | Scavenger | scrap | scrapyard |
+| quarryWorker | Quarry Worker | stone | quarry |
+| scientist | Scientist | science | school |
 
-## 6) Population and Roles
-
-No role-based production modifiers in effect.
-
-## 7) Production Math (Exact Formula)
-
-Per building per tick:
-
-`effectiveCycle = cycleTimeSec * seasonSpeed`
-
-`effectiveHarvest = harvestAmount * outputValue * seasonYield`
-
-`cycles = floor((elapsed + timer) / effectiveCycle)`
-
-`production = effectiveHarvest * count * cycles`
-
-Sum production for each resource across buildings, then `clampResource(value, capacity)` where values below 0 become 0 and above capacity become capacity.
-
-Offline progress is applied in 60-second chunks.
-
-## 8) Costs, Refunds, and Edge Rules
-
-Building costs scale by `cost * 1.15^count`, rounded up. Demolition refunds 50% of the previous cost (floored) and adds back resources subject to capacity. Resource values are rounded to 6 decimals in clamping and cannot be negative.
-
-## 9) Starting State
-
+## 7) Starting State
 Starting season: spring, Year: 1.
 
 ### Resources
-
-| resource   | amount | capacity |
-| ---------- | ------ | -------- |
-| potatoes   | 0      | 300      |
-| wood       | 0      | 100      |
-| stone      | 0      | 100      |
-| scrap      | 0      | 100      |
-| planks     | 0      | 50       |
-| metalParts | 0      | 20       |
-| science    | 0      | 400      |
-| power      | 0      | 2        |
+| resource | amount | capacity |
+| - | - | - |
+| potatoes | 0 | 300 |
+| wood | 0 | 100 |
+| stone | 0 | 100 |
+| scrap | 0 | 100 |
+| planks | 0 | 50 |
+| metalParts | 0 | 20 |
+| science | 0 | 400 |
+| power | 0 | 2 |
 
 ### Buildings
-
 | building | count |
-| -------- | ----- |
+| - | - |
+| potatoField | 2 |
+| loggingCamp | 1 |
+

--- a/docs/economy-snapshot.json
+++ b/docs/economy-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "version": "070053a8d44126fb5c270ff654c22f892f457044",
+  "version": "7ae16b531a8fdf5232b9e17876730285d6e57f9a",
   "saveVersion": 5,
   "tickSeconds": 1,
   "seasons": {
@@ -136,8 +136,6 @@
         "potatoes": 0.375
       },
       "baseInputsPerSec": {},
-      "seasonalMode": "ignore",
-      "seasonalCustom": null,
       "seasonalMultipliers": {
         "spring": 1.25,
         "summer": 1,
@@ -158,8 +156,6 @@
         "wood": 0.2
       },
       "baseInputsPerSec": {},
-      "seasonalMode": "ignore",
-      "seasonalCustom": null,
       "seasonalMultipliers": {
         "spring": 1.1,
         "summer": 1,
@@ -180,8 +176,6 @@
         "scrap": 0.06
       },
       "baseInputsPerSec": {},
-      "seasonalMode": "ignore",
-      "seasonalCustom": null,
       "seasonalMultipliers": {
         "spring": 1.1,
         "summer": 1,
@@ -203,8 +197,6 @@
         "stone": 0.08
       },
       "baseInputsPerSec": {},
-      "seasonalMode": "ignore",
-      "seasonalCustom": null,
       "seasonalMultipliers": {
         "spring": 1.1,
         "summer": 1,
@@ -229,8 +221,6 @@
       "baseInputsPerSec": {
         "wood": 1
       },
-      "seasonalMode": "ignore",
-      "seasonalCustom": null,
       "seasonalMultipliers": {
         "spring": 1,
         "summer": 1,
@@ -256,8 +246,6 @@
       "baseInputsPerSec": {
         "scrap": 1
       },
-      "seasonalMode": "ignore",
-      "seasonalCustom": null,
       "seasonalMultipliers": {
         "spring": 1,
         "summer": 1,
@@ -280,8 +268,6 @@
         "science": 0.5
       },
       "baseInputsPerSec": {},
-      "seasonalMode": "ignore",
-      "seasonalCustom": null,
       "seasonalMultipliers": {
         "spring": 1,
         "summer": 1,
@@ -305,8 +291,6 @@
       "baseInputsPerSec": {
         "wood": 0.3
       },
-      "seasonalMode": "ignore",
-      "seasonalCustom": null,
       "seasonalMultipliers": {
         "spring": 1,
         "summer": 1,
@@ -326,8 +310,6 @@
       "storageProvided": {},
       "baseProductionPerSec": {},
       "baseInputsPerSec": {},
-      "seasonalMode": "ignore",
-      "seasonalCustom": null,
       "seasonalMultipliers": {}
     },
     {
@@ -345,8 +327,6 @@
       "baseInputsPerSec": {
         "power": 0.1
       },
-      "seasonalMode": "ignore",
-      "seasonalCustom": null,
       "seasonalMultipliers": {}
     },
     {
@@ -359,11 +339,11 @@
         "stone": 5
       },
       "demolitionRefund": 0.5,
-      "storageProvided": {},
+      "storageProvided": {
+        "potatoes": 300
+      },
       "baseProductionPerSec": {},
       "baseInputsPerSec": {},
-      "seasonalMode": "ignore",
-      "seasonalCustom": null,
       "seasonalMultipliers": {}
     },
     {
@@ -376,11 +356,13 @@
         "stone": 10
       },
       "demolitionRefund": 0.5,
-      "storageProvided": {},
+      "storageProvided": {
+        "wood": 200,
+        "stone": 80,
+        "scrap": 120
+      },
       "baseProductionPerSec": {},
       "baseInputsPerSec": {},
-      "seasonalMode": "ignore",
-      "seasonalCustom": null,
       "seasonalMultipliers": {}
     },
     {
@@ -393,11 +375,12 @@
         "stone": 5
       },
       "demolitionRefund": 0.5,
-      "storageProvided": {},
+      "storageProvided": {
+        "planks": 150,
+        "metalParts": 60
+      },
       "baseProductionPerSec": {},
       "baseInputsPerSec": {},
-      "seasonalMode": "ignore",
-      "seasonalCustom": null,
       "seasonalMultipliers": {}
     },
     {
@@ -409,11 +392,11 @@
         "stone": 20
       },
       "demolitionRefund": 0.5,
-      "storageProvided": {},
+      "storageProvided": {
+        "power": 20
+      },
       "baseProductionPerSec": {},
       "baseInputsPerSec": {},
-      "seasonalMode": "ignore",
-      "seasonalCustom": null,
       "seasonalMultipliers": {}
     }
   ],
@@ -421,54 +404,70 @@
     {
       "id": "basicEnergy",
       "name": "Basic Energy",
-      "cost": {
-        "science": 50
-      },
+      "scienceCost": 50,
       "timeSec": 90,
-      "prereqs": ["industry1"],
+      "prereqs": [
+        "industry1"
+      ],
       "unlocks": {
-        "resources": ["power"],
-        "buildings": ["woodGenerator", "battery"],
-        "categories": ["Energy"]
+        "resources": [
+          "power"
+        ],
+        "buildings": [
+          "woodGenerator",
+          "battery"
+        ],
+        "categories": [
+          "Energy"
+        ]
       },
       "effects": []
     },
     {
       "id": "industry1",
       "name": "Industry I",
-      "cost": {
-        "science": 40
-      },
+      "scienceCost": 40,
       "timeSec": 60,
       "prereqs": [],
       "unlocks": {
-        "buildings": ["sawmill", "metalWorkshop", "materialsDepot"],
-        "categories": ["CONSTRUCTION_MATERIALS"],
-        "resources": ["planks", "metalParts"]
+        "buildings": [
+          "sawmill",
+          "metalWorkshop",
+          "materialsDepot"
+        ],
+        "categories": [
+          "CONSTRUCTION_MATERIALS"
+        ],
+        "resources": [
+          "planks",
+          "metalParts"
+        ]
       },
       "effects": []
     },
     {
       "id": "radio",
       "name": "Radio",
-      "cost": {
-        "science": 80
-      },
+      "scienceCost": 80,
       "timeSec": 120,
-      "prereqs": ["industry1"],
+      "prereqs": [
+        "industry1"
+      ],
       "unlocks": {
-        "buildings": ["radio"]
+        "buildings": [
+          "radio"
+        ]
       },
       "effects": []
     },
     {
       "id": "woodworking1",
       "name": "Woodworking I",
-      "cost": {
-        "science": 30
-      },
+      "scienceCost": 30,
       "timeSec": 45,
-      "prereqs": ["industry1"],
+      "prereqs": [
+        "industry1"
+      ],
       "effects": [
         {
           "category": "WOOD",
@@ -480,11 +479,11 @@
     {
       "id": "salvaging1",
       "name": "Salvaging I",
-      "cost": {
-        "science": 30
-      },
+      "scienceCost": 30,
       "timeSec": 45,
-      "prereqs": ["industry1"],
+      "prereqs": [
+        "industry1"
+      ],
       "effects": [
         {
           "category": "SCRAP",
@@ -496,11 +495,11 @@
     {
       "id": "logistics1",
       "name": "Logistics I",
-      "cost": {
-        "science": 35
-      },
+      "scienceCost": 35,
       "timeSec": 60,
-      "prereqs": ["industry1"],
+      "prereqs": [
+        "industry1"
+      ],
       "effects": [
         {
           "category": "RAW",
@@ -517,24 +516,27 @@
     {
       "id": "industry2",
       "name": "Industry II",
-      "cost": {
-        "science": 140
-      },
+      "scienceCost": 140,
       "timeSec": 180,
-      "prereqs": ["industry1"],
+      "prereqs": [
+        "industry1"
+      ],
       "unlocks": {
-        "buildings": ["toolsmithy"]
+        "buildings": [
+          "toolsmithy"
+        ]
       },
       "effects": []
     },
     {
       "id": "woodworking2",
       "name": "Woodworking II",
-      "cost": {
-        "science": 70
-      },
+      "scienceCost": 70,
       "timeSec": 120,
-      "prereqs": ["woodworking1", "industry2"],
+      "prereqs": [
+        "woodworking1",
+        "industry2"
+      ],
       "effects": [
         {
           "category": "WOOD",
@@ -546,11 +548,12 @@
     {
       "id": "salvaging2",
       "name": "Salvaging II",
-      "cost": {
-        "science": 70
-      },
+      "scienceCost": 70,
       "timeSec": 120,
-      "prereqs": ["salvaging1", "industry2"],
+      "prereqs": [
+        "salvaging1",
+        "industry2"
+      ],
       "effects": [
         {
           "category": "SCRAP",
@@ -562,11 +565,12 @@
     {
       "id": "logistics2",
       "name": "Logistics II",
-      "cost": {
-        "science": 80
-      },
+      "scienceCost": 80,
       "timeSec": 150,
-      "prereqs": ["logistics1", "industry2"],
+      "prereqs": [
+        "logistics1",
+        "industry2"
+      ],
       "effects": [
         {
           "category": "RAW",
@@ -581,25 +585,89 @@
       ]
     }
   ],
-  "roles": [],
+  "roles": [
+    {
+      "id": "farmer",
+      "name": "Farmer",
+      "resource": "potatoes",
+      "building": "potatoField"
+    },
+    {
+      "id": "woodcutter",
+      "name": "Woodcutter",
+      "resource": "wood",
+      "building": "loggingCamp"
+    },
+    {
+      "id": "scavenger",
+      "name": "Scavenger",
+      "resource": "scrap",
+      "building": "scrapyard"
+    },
+    {
+      "id": "quarryWorker",
+      "name": "Quarry Worker",
+      "resource": "stone",
+      "building": "quarry"
+    },
+    {
+      "id": "scientist",
+      "name": "Scientist",
+      "resource": "science",
+      "building": "school"
+    }
+  ],
   "formula": {
-    "order": ["base", "season", "roles", "sum", "clamp"],
+    "order": [
+      "base",
+      "season",
+      "roles",
+      "sum",
+      "clamp"
+    ],
     "demolitionRefund": 0.5,
     "clampRule": "min(value, capacity) and never negative"
   },
   "startingState": {
     "season": "spring",
-    "year": 1,
-    "resources": {
-      "potatoes": 0,
-      "wood": 0,
-      "stone": 0,
-      "scrap": 0,
-      "planks": 0,
-      "metalParts": 0,
-      "science": 0,
-      "power": 0
+    "year": 1
+  },
+  "startingResources": {
+    "potatoes": {
+      "amount": 0,
+      "capacity": 300
     },
-    "buildings": {}
+    "wood": {
+      "amount": 0,
+      "capacity": 100
+    },
+    "stone": {
+      "amount": 0,
+      "capacity": 100
+    },
+    "scrap": {
+      "amount": 0,
+      "capacity": 100
+    },
+    "planks": {
+      "amount": 0,
+      "capacity": 50
+    },
+    "metalParts": {
+      "amount": 0,
+      "capacity": 20
+    },
+    "science": {
+      "amount": 0,
+      "capacity": 400
+    },
+    "power": {
+      "amount": 0,
+      "capacity": 2
+    }
+  },
+  "startingBuildings": {
+    "potatoField": 2,
+    "loggingCamp": 1
   }
 }


### PR DESCRIPTION
## Summary
- generate resources using live state with starting amounts and capacities
- include seasons, buildings, research, and roles in synced Markdown and JSON outputs
- expose new `startingResources` and `startingBuildings` fields for real game start snapshot

## Testing
- `npm test`
- `npm run report:economy`

------
https://chatgpt.com/codex/tasks/task_e_689a95b094888331b74d6b3518678828