### PR TITLE
Fix settlers food accounting

### DIFF
--- a/src/engine/__tests__/settlers.test.js
+++ b/src/engine/__tests__/settlers.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { processTick } from '../production.js';
+import { processSettlersTick, computeRoleBonuses } from '../settlers.js';
+import { getResourceRates } from '../../state/selectors.js';
+import { defaultState } from '../../state/defaultState.js';
+import { RESOURCES } from '../../data/resources.js';
+import { BALANCE } from '../../data/balance.js';
+
+const clone = (obj) => JSON.parse(JSON.stringify(obj));
+
+describe('settlers tick', () => {
+  it('keeps potato totals consistent with farming bonus and consumption', () => {
+    const state = clone(defaultState);
+    state.buildings.potatoField.count = 1;
+    state.resources.potatoes.amount = 0;
+    state.population.settlers = [
+      {
+        id: 's1',
+        role: 'farmer',
+        skills: { farmer: { level: 1, xp: 0 } },
+      },
+    ];
+
+    const roleBonuses = computeRoleBonuses(state.population.settlers);
+    const productionBonuses = { ...roleBonuses };
+    delete productionBonuses.farmer;
+    const afterTick = processTick(state, 1, productionBonuses);
+
+    const rates = getResourceRates(afterTick);
+    let totalFoodProdBase = 0;
+    Object.keys(RESOURCES).forEach((id) => {
+      if (RESOURCES[id].category === 'FOOD') {
+        totalFoodProdBase += rates[id]?.perSec || 0;
+      }
+    });
+    const bonusFoodPerSec =
+      totalFoodProdBase * ((roleBonuses['farmer'] || 0) / 100);
+
+    const { state: final } = processSettlersTick(
+      afterTick,
+      1,
+      bonusFoodPerSec,
+    );
+
+    const expected =
+      afterTick.resources.potatoes.amount +
+      bonusFoodPerSec -
+      BALANCE.FOOD_CONSUMPTION_PER_SETTLER;
+
+    expect(final.resources.potatoes.amount).toBeCloseTo(expected, 5);
+  });
+});

--- a/src/engine/settlers.js
+++ b/src/engine/settlers.js
@@ -27,7 +27,7 @@ export function assignmentsSummary(settlers) {
 export function processSettlersTick(
   state,
   seconds = BALANCE.TICK_SECONDS,
-  totalFoodProdBase = 0,
+  bonusFoodPerSec = 0,
   rng = Math.random,
   roleBonuses = null,
 ) {
@@ -40,12 +40,11 @@ export function processSettlersTick(
   const bonuses = roleBonuses || computeRoleBonuses(living);
   const totalFoodBonusPercent = bonuses['farmer'] || 0;
 
-  const bonusGainPerSec = totalFoodProdBase * (totalFoodBonusPercent / 100);
+  const bonusGainPerSec = bonusFoodPerSec;
   const totalSettlersConsumption =
     living.length * BALANCE.FOOD_CONSUMPTION_PER_SETTLER;
   // Final food change per second after bonuses and consumption
-  const netFoodPerSec =
-    totalFoodProdBase + bonusGainPerSec - totalSettlersConsumption;
+  const netFoodPerSec = bonusGainPerSec - totalSettlersConsumption;
 
   const capacity = getCapacity(state, 'potatoes');
   const currentEntry = state.resources.potatoes || {
@@ -130,7 +129,7 @@ export function processSettlersTick(
 
   const telemetry = {
     netFoodPerSec,
-    totalFoodProdBase,
+    bonusFoodPerSec: bonusGainPerSec,
     totalFoodBonusPercent,
     totalSettlersConsumption,
     potatoes: nextAmount,

--- a/src/state/GameContext.jsx
+++ b/src/state/GameContext.jsx
@@ -106,7 +106,9 @@ export function GameProvider({ children }) {
   useGameLoop((dt) => {
     setState((prev) => {
       const roleBonuses = computeRoleBonuses(prev.population?.settlers || []);
-      const afterTick = processTick(prev, dt, roleBonuses);
+      const productionBonuses = { ...roleBonuses };
+      delete productionBonuses.farmer;
+      const afterTick = processTick(prev, dt, productionBonuses);
       const withResearch = processResearchTick(afterTick, dt, roleBonuses);
       const rates = getResourceRates(withResearch);
       let totalFoodProdBase = 0;
@@ -115,10 +117,12 @@ export function GameProvider({ children }) {
           totalFoodProdBase += rates[id]?.perSec || 0;
         }
       });
+      const bonusFoodPerSec =
+        totalFoodProdBase * ((roleBonuses['farmer'] || 0) / 100);
       const { state: settlersProcessed, telemetry } = processSettlersTick(
         withResearch,
         dt,
-        totalFoodProdBase,
+        bonusFoodPerSec,
         Math.random,
         roleBonuses,
       );


### PR DESCRIPTION
## Summary
- compute settlers' net food from farming bonus and consumption only
- exclude farmer bonus from production and pass explicit food bonus per second
- test to ensure potatoes are consistent after a tick

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a95caeb988331bf00b646c208e5b3