### PR TITLE
Keep game loop interval across renders

### DIFF
--- a/src/engine/__tests__/useGameLoop.test.jsx
+++ b/src/engine/__tests__/useGameLoop.test.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, act } from '@testing-library/react';
+import useGameLoop from '../useGameLoop.js';
+
+function TestComponent({ cb }) {
+  useGameLoop(cb, 1000);
+  return null;
+}
+
+describe('useGameLoop', () => {
+  it('keeps interval running across renders and uses latest callback', () => {
+    vi.useFakeTimers();
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
+
+    const first = vi.fn();
+    const second = vi.fn();
+
+    const { rerender, unmount } = render(<TestComponent cb={first} />);
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(0);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(0);
+
+    rerender(<TestComponent cb={second} />);
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(0);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+
+    setIntervalSpy.mockRestore();
+    clearIntervalSpy.mockRestore();
+    vi.useRealTimers();
+  });
+});

--- a/src/engine/useGameLoop.js
+++ b/src/engine/useGameLoop.js
@@ -3,14 +3,19 @@ import { useEffect, useRef } from 'react';
 // Simple game loop using setInterval; dt in seconds
 export default function useGameLoop(callback, intervalMs = 1000) {
   const lastRef = useRef(performance.now());
+  const callbackRef = useRef(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
 
   useEffect(() => {
     const id = setInterval(() => {
       const now = performance.now();
       const dt = (now - lastRef.current) / 1000;
       lastRef.current = now;
-      callback(dt);
+      callbackRef.current(dt);
     }, intervalMs);
     return () => clearInterval(id);
-  }, [callback, intervalMs]);
+  }, [intervalMs]);
 }


### PR DESCRIPTION
## Summary
- Preserve game loop interval and call latest callback via ref
- Add unit test confirming interval survives re-renders without restarting

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in docs/ECONOMY_REPORT.md, docs/economy-snapshot.json, scripts/generate-economy-report.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_689a974fd548833183975983aa54a8f6