### PR TITLE
refactor: use structuredClone for deep copies

### DIFF
--- a/src/engine/__tests__/economy.test.js
+++ b/src/engine/__tests__/economy.test.js
@@ -3,7 +3,7 @@ import { processTick, demolishBuilding } from '../production.js';
 import { defaultState } from '../../state/defaultState.js';
 import { BUILDING_MAP, getBuildingCost } from '../../data/buildings.js';
 
-const clone = (obj) => JSON.parse(JSON.stringify(obj));
+const clone = (obj) => structuredClone(obj);
 
 describe('economy basics', () => {
   test('spring potato field output', () => {

--- a/src/engine/__tests__/research.test.js
+++ b/src/engine/__tests__/research.test.js
@@ -10,7 +10,7 @@ import { getResearchOutputBonus } from '../../state/selectors.js';
 import { computeRoleBonuses } from '../settlers.js';
 
 function clone(obj) {
-  return JSON.parse(JSON.stringify(obj));
+  return structuredClone(obj);
 }
 
 describe('research engine', () => {

--- a/src/engine/__tests__/settlers.test.js
+++ b/src/engine/__tests__/settlers.test.js
@@ -6,7 +6,7 @@ import { defaultState } from '../../state/defaultState.js';
 import { RESOURCES } from '../../data/resources.js';
 import { BALANCE } from '../../data/balance.js';
 
-const clone = (obj) => JSON.parse(JSON.stringify(obj));
+const clone = (obj) => structuredClone(obj);
 
 describe('settlers tick', () => {
   it('keeps potato totals consistent with farming bonus and consumption', () => {

--- a/src/engine/persistence.js
+++ b/src/engine/persistence.js
@@ -1,6 +1,9 @@
 import { createLogEntry } from '../utils/log.js';
 import { RADIO_BASE_SECONDS } from '../data/settlement.js';
 
+const structuredClone =
+  globalThis.structuredClone || ((obj) => JSON.parse(JSON.stringify(obj)));
+
 const STORAGE_KEY = 'apocalypse-idle-save';
 
 export const CURRENT_SAVE_VERSION = 5;
@@ -192,7 +195,7 @@ export function save(state) {
 
 export function load(raw) {
   const save =
-    typeof raw === 'string' ? JSON.parse(raw) : JSON.parse(JSON.stringify(raw));
+    typeof raw === 'string' ? JSON.parse(raw) : structuredClone(raw);
   save.version = save.version ?? save.schemaVersion ?? 1;
   validateSave(save);
   const start = save.version;

--- a/src/engine/production.js
+++ b/src/engine/production.js
@@ -11,6 +11,9 @@ import { BALANCE } from '../data/balance.js';
 import { RADIO_BASE_SECONDS } from '../data/settlement.js';
 import { generateCandidate } from './candidates.js';
 
+const structuredClone =
+  globalThis.structuredClone || ((obj) => JSON.parse(JSON.stringify(obj)));
+
 export function clampResource(value, capacity) {
   let v = Number.isFinite(value) ? value : 0;
   const c = Number.isFinite(capacity) ? Math.max(0, capacity) : 0;
@@ -104,7 +107,7 @@ export function processTick(state, seconds = 1, roleBonuses = {}) {
 
 export function applyOfflineProgress(state, elapsedSeconds, roleBonuses = {}) {
   if (elapsedSeconds <= 0) return { state, gains: {} };
-  const before = JSON.parse(JSON.stringify(state.resources));
+  const before = structuredClone(state.resources);
   let current = applyProduction({ ...state }, elapsedSeconds, roleBonuses);
   const settlers =
     state.population?.settlers?.filter((s) => !s.isDead)?.length || 0;


### PR DESCRIPTION
## Summary
- replace JSON.parse cloning with structuredClone in production and persistence engines
- update tests to clone game state using structuredClone

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a9a5412608331a1fccf9b18c35ad6