### PR TITLE
feat: centralize radio candidate generation

### DIFF
--- a/src/engine/__tests__/radio.test.js
+++ b/src/engine/__tests__/radio.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+
+const fakeCandidate = { id: 'cand1' };
+
+vi.mock('../candidates.js', () => ({
+  generateCandidate: vi.fn(() => fakeCandidate),
+}));
+
+import { updateRadio } from '../radio.js';
+import { generateCandidate } from '../candidates.js';
+
+const baseState = {
+  buildings: { radio: { count: 1 } },
+  resources: { power: { amount: 1 } },
+  population: { candidate: null },
+  colony: { radioTimer: 10 },
+};
+
+describe('updateRadio', () => {
+  it('decrements timer without creating a candidate if time remains', () => {
+    const state = { ...baseState, colony: { radioTimer: 10 } };
+    const { candidate, radioTimer } = updateRadio(state, 3);
+    expect(candidate).toBeNull();
+    expect(radioTimer).toBe(7);
+  });
+
+  it('creates candidate and resets timer when countdown completes', () => {
+    const state = { ...baseState, colony: { radioTimer: 2 } };
+    const { candidate, radioTimer } = updateRadio(state, 5);
+    expect(generateCandidate).toHaveBeenCalledOnce();
+    expect(candidate).toEqual(fakeCandidate);
+    expect(radioTimer).toBe(0);
+  });
+});

--- a/src/engine/production.js
+++ b/src/engine/production.js
@@ -8,8 +8,7 @@ import { ROLE_BY_RESOURCE, BUILDING_ROLES } from '../data/roles.js';
 import { getSeason, getSeasonMultiplier } from './time.js';
 import { getCapacity, getResearchOutputBonus } from '../state/selectors.js';
 import { BALANCE } from '../data/balance.js';
-import { RADIO_BASE_SECONDS } from '../data/settlement.js';
-import { generateCandidate } from './candidates.js';
+import { updateRadio } from './radio.js';
 
 export function clampResource(value, capacity) {
   let v = Number.isFinite(value) ? value : 0;
@@ -126,19 +125,7 @@ export function applyOfflineProgress(state, elapsedSeconds, roleBonuses = {}) {
     if (current.resources[res].amount > 0)
       current.resources[res].discovered = true;
   });
-  let candidate = state.population?.candidate || null;
-  let radioTimer = state.colony?.radioTimer ?? RADIO_BASE_SECONDS;
-  if (
-    (state.buildings?.radio?.count || 0) > 0 &&
-    !candidate &&
-    (state.resources.power?.amount || 0) > 0
-  ) {
-    radioTimer = Math.max(0, radioTimer - elapsedSeconds);
-    if (radioTimer <= 0) {
-      candidate = generateCandidate();
-      radioTimer = 0;
-    }
-  }
+  const { candidate, radioTimer } = updateRadio(state, elapsedSeconds);
   const gains = {};
   Object.keys(before).forEach((res) => {
     const gain =

--- a/src/engine/radio.js
+++ b/src/engine/radio.js
@@ -1,0 +1,18 @@
+import { RADIO_BASE_SECONDS } from '../data/settlement.js';
+import { generateCandidate } from './candidates.js';
+
+export function updateRadio(state, elapsedSeconds, candidateGenerator = generateCandidate) {
+  let candidate = state.population?.candidate || null;
+  let radioTimer = state.colony?.radioTimer ?? RADIO_BASE_SECONDS;
+  if ((state.buildings?.radio?.count || 0) > 0) {
+    const powered = (state.resources?.power?.amount || 0) > 0;
+    if (powered && !candidate) {
+      radioTimer = Math.max(0, radioTimer - elapsedSeconds);
+      if (radioTimer <= 0) {
+        candidate = candidateGenerator();
+        radioTimer = 0;
+      }
+    }
+  }
+  return { candidate, radioTimer };
+}

--- a/src/state/GameContext.jsx
+++ b/src/state/GameContext.jsx
@@ -26,8 +26,7 @@ import { getResourceRates } from './selectors.js';
 import { RESOURCES } from '../data/resources.js';
 import { ROLE_BUILDINGS } from '../data/roles.js';
 import { createLogEntry } from '../utils/log.js';
-import { RADIO_BASE_SECONDS } from '../data/settlement.js';
-import { generateCandidate } from '../engine/candidates.js';
+import { updateRadio } from '../engine/radio.js';
 
 function mergeDeep(target, source) {
   const out = { ...target };
@@ -126,18 +125,7 @@ export function GameProvider({ children }) {
         Math.random,
         roleBonuses,
       );
-      let candidate = prev.population?.candidate || null;
-      let radioTimer = prev.colony?.radioTimer ?? RADIO_BASE_SECONDS;
-      if (prev.buildings?.radio?.count > 0) {
-        const powered = (prev.resources.power?.amount || 0) > 0;
-        if (powered && !candidate) {
-          radioTimer = Math.max(0, radioTimer - dt);
-          if (radioTimer <= 0) {
-            candidate = generateCandidate();
-            radioTimer = 0;
-          }
-        }
-      }
+      const { candidate, radioTimer } = updateRadio(prev, dt);
       const nextSeconds = (settlersProcessed.gameTime?.seconds || 0) + dt;
       const computedYear = getYear({
         ...settlersProcessed,


### PR DESCRIPTION
## Summary
- add `updateRadio` helper to handle candidate generation and timer
- use helper in offline progress and main loop to avoid duplication
- test radio helper for candidate creation and timer reset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a9a57c5a483318f7b5c243f16ba92