### PR TITLE
Group resource buildings as Raw Materials

### DIFF
--- a/src/views/BaseView.jsx
+++ b/src/views/BaseView.jsx
@@ -183,9 +183,7 @@ export default function BaseView() {
   });
   const GROUP_ORDER = [
     'Food',
-    'Wood',
-    'Scrap',
-    'Stone',
+    'Raw Materials',
     'Construction Materials',
     'Science',
     'Energy',


### PR DESCRIPTION
## Summary
- Group wood, scrap, and stone buildings under a single Raw Materials category for consistent grouping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689aa0c95bb48331818c3fd432d89b08