### PR TITLE
feat: enrich economy report with origins

### DIFF
--- a/docs/ECONOMY_REPORT.md
+++ b/docs/ECONOMY_REPORT.md
@@ -1,88 +1,99 @@
 # Economy Report
 
 ## 1) Overview
-Economy generated from commit **8c7304eda7c13985bd2fbb4bf829d7118c52c925** on 2025-08-12 03:40:40 +0200. Save version: **5**.
+Economy generated from commit **fea12af6a78ea53efde6c6b33916b2cdc4d64b21** on 2025-08-12 03:58:01 +0200. Save version: **5**.
 Each tick represents 1 second. For each building: base production is modified by season multipliers, summed, then clamped to capacity. Offline progress processes in 60-second chunks.
 
 ## 2) Resources
-| key | displayName | category | startingAmount | startingCapacity | unit |
-| - | - | - | - | - | - |
-| potatoes | Potatoes | FOOD | 0 | 300 |  |
-| wood | Wood | RAW | 0 | 100 |  |
-| stone | Stone | RAW | 0 | 100 |  |
-| scrap | Scrap | RAW | 0 | 100 |  |
-| planks | Planks | CONSTRUCTION_MATERIALS | 0 | 50 |  |
-| metalParts | Metal Parts | CONSTRUCTION_MATERIALS | 0 | 20 |  |
-| science | Science | SOCIETY | 0 | 400 |  |
-| power | Power | ENERGY | 0 | 2 |  |
+| key | displayName | category | startingAmount | startingCapacity | unit | source |
+| - | - | - | - | - | - | - |
+| potatoes | Potatoes | FOOD | 0 | 300 |  | resources.js:RESOURCES.potatoes |
+| wood | Wood | RAW | 0 | 100 |  | resources.js:RESOURCES.wood |
+| stone | Stone | RAW | 0 | 100 |  | resources.js:RESOURCES.stone |
+| scrap | Scrap | RAW | 0 | 100 |  | resources.js:RESOURCES.scrap |
+| planks | Planks | CONSTRUCTION_MATERIALS | 0 | 50 |  | resources.js:RESOURCES.planks |
+| metalParts | Metal Parts | CONSTRUCTION_MATERIALS | 0 | 20 |  | resources.js:RESOURCES.metalParts |
+| science | Science | SOCIETY | 0 | 400 |  | resources.js:RESOURCES.science |
+| power | Power | ENERGY | 0 | 2 |  | resources.js:RESOURCES.power |
 
 ## 3) Seasons
-| season | duration (sec) | potatoes | wood | stone | scrap | planks | metalParts | science | power |
-| - | - | - | - | - | - | - | - | - | - |
-| spring | 270 | 1.250 | 1.100 | 1.100 | 1.100 | 1.000 | 1.000 | 1.000 | 1.000 |
-| summer | 270 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
-| autumn | 270 | 0.850 | 0.900 | 0.900 | 0.900 | 1.000 | 1.000 | 1.000 | 1.000 |
-| winter | 270 | 0.000 | 0.800 | 0.800 | 0.800 | 1.000 | 1.000 | 1.000 | 1.000 |
+| season | duration (sec) | potatoes | wood | stone | scrap | planks | metalParts | science | power | source |
+| - | - | - | - | - | - | - | - | - | - | - |
+| spring | 270 | 1.250 | 1.100 | 1.100 | 1.100 | 1.000 | 1.000 | 1.000 | 1.000 | time.js:SEASONS[0] |
+| summer | 270 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | time.js:SEASONS[1] |
+| autumn | 270 | 0.850 | 0.900 | 0.900 | 0.900 | 1.000 | 1.000 | 1.000 | 1.000 | time.js:SEASONS[2] |
+| winter | 270 | 0.000 | 0.800 | 0.800 | 0.800 | 1.000 | 1.000 | 1.000 | 1.000 | time.js:SEASONS[3] |
 
 ## 4) Buildings
-| id | name | type | cost | refund | storage | base prod/s | inputs per sec | season mults |
-| - | - | - | - | - | - | - | - | - |
-| potatoField | Potato Field | production | wood: 15 | 0.5 | - | potatoes: 0.375 | - | spring: 1.25, summer: 1, autumn: 0.85, winter: 0 |
-| loggingCamp | Logging Camp | production | scrap: 15 | 0.5 | - | wood: 0.25 | - | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
-| scrapyard | Scrap Yard | production | wood: 12 | 0.5 | - | scrap: 0.08 | - | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
-| quarry | Quarry | production | wood: 20, scrap: 5 | 0.5 | - | stone: 0.08 | - | spring: 1.1, summer: 1, autumn: 0.9, winter: 0.8 |
-| sawmill | Sawmill | processing | wood: 40, scrap: 15, stone: 10 | 0.5 | - | planks: 0.5 | wood: 0.8 | spring: 1, summer: 1, autumn: 1, winter: 1 |
-| metalWorkshop | Metal Workshop | processing | wood: 30, scrap: 30, stone: 10, planks: 10 | 0.5 | - | metalParts: 0.4 | scrap: 0.4 | spring: 1, summer: 1, autumn: 1, winter: 1 |
-| school | School | production | wood: 25, scrap: 10, stone: 10 | 0.5 | - | science: 0.5 | - | spring: 1, summer: 1, autumn: 1, winter: 1 |
-| woodGenerator | Wood Generator | production | wood: 50, stone: 10 | 0.5 | - | power: 1 | wood: 0.25 | spring: 1, summer: 1, autumn: 1, winter: 1 |
-| shelter | Shelter | production | wood: 30, scrap: 10 | 0.5 | - | - | - | - |
-| radio | Radio | production | wood: 80, scrap: 40, stone: 20 | 0.5 | - | - | power: 0.1 | - |
-| foodStorage | Granary | storage | wood: 20, scrap: 5, stone: 5 | 0.5 | potatoes: 300 | - | - | - |
-| rawStorage | Warehouse | storage | wood: 25, scrap: 10, stone: 10 | 0.5 | wood: 200, stone: 80, scrap: 120 | - | - | - |
-| materialsDepot | Materials Depot | storage | wood: 25, scrap: 10, stone: 5 | 0.5 | planks: 150, metalParts: 60 | - | - | - |
-| battery | Battery | storage | wood: 40, stone: 20 | 0.5 | power: 40 | - | - | - |
+| id | name | type | cost | costGrowth | refund | storage | base prod/s | inputs per sec | requiresResearch | season mults | source |
+| - | - | - | - | - | - | - | - | - | - | - | - |
+| potatoField | Potato Field | production | {"wood":15} | 1.15 | 0.5 | - | {"potatoes":0.375} | - | - | {"spring":1.25,"summer":1,"autumn":0.85,"winter":0} | buildings.js:BUILDINGS[0] |
+| loggingCamp | Logging Camp | production | {"scrap":15} | 1.15 | 0.5 | - | {"wood":0.25} | - | - | {"spring":1.1,"summer":1,"autumn":0.9,"winter":0.8} | buildings.js:BUILDINGS[1] |
+| scrapyard | Scrap Yard | production | {"wood":12} | 1.15 | 0.5 | - | {"scrap":0.08} | - | - | {"spring":1.1,"summer":1,"autumn":0.9,"winter":0.8} | buildings.js:BUILDINGS[2] |
+| quarry | Quarry | production | {"wood":20,"scrap":5} | 1.15 | 0.5 | - | {"stone":0.08} | - | - | {"spring":1.1,"summer":1,"autumn":0.9,"winter":0.8} | buildings.js:BUILDINGS[3] |
+| sawmill | Sawmill | processing | {"wood":40,"scrap":15,"stone":10} | 1.15 | 0.5 | - | {"planks":0.5} | {"wood":0.8} | industry1 | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[4] |
+| metalWorkshop | Metal Workshop | processing | {"wood":30,"scrap":30,"stone":10,"planks":10} | 1.15 | 0.5 | - | {"metalParts":0.4} | {"scrap":0.4} | industry1 | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[5] |
+| school | School | production | {"wood":25,"scrap":10,"stone":10} | 1.15 | 0.5 | - | {"science":0.5} | - | - | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[6] |
+| woodGenerator | Wood Generator | production | {"wood":50,"stone":10} | 1.15 | 0.5 | - | {"power":1} | {"wood":0.25} | basicEnergy | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[7] |
+| shelter | Shelter | production | {"wood":30,"scrap":10} | 1.8 | 0.5 | - | - | - | - | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[8] |
+| radio | Radio | production | {"wood":80,"scrap":40,"stone":20} | 1 | 0.5 | - | - | {"power":0.1} | radio | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[9] |
+| foodStorage | Granary | storage | {"wood":20,"scrap":5,"stone":5} | 1.15 | 0.5 | {"potatoes":300} | - | - | - | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[10] |
+| rawStorage | Warehouse | storage | {"wood":25,"scrap":10,"stone":10} | 1.15 | 0.5 | {"wood":200,"stone":80,"scrap":120} | - | - | - | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[11] |
+| materialsDepot | Materials Depot | storage | {"wood":25,"scrap":10,"stone":5} | 1.15 | 0.5 | {"planks":150,"metalParts":60} | - | - | industry1 | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[12] |
+| battery | Battery | storage | {"wood":40,"stone":20} | 1.15 | 0.5 | {"power":40} | - | - | basicEnergy | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[13] |
 
 ## 5) Research
-| id | name | science cost | time (sec) | prereqs | unlocks |
-| - | - | - | - | - | - |
-| basicEnergy | Basic Energy | 80 | 120 | industry1 | resources: power; buildings: woodGenerator, battery; categories: Energy |
-| industry1 | Industry I | 60 | 90 | - | resources: planks, metalParts; buildings: sawmill, metalWorkshop, materialsDepot; categories: CONSTRUCTION_MATERIALS |
-| radio | Radio | 120 | 180 | industry1, basicEnergy | buildings: radio |
-| woodworking1 | Woodworking I | 50 | 70 | industry1 | effects: { category=WOOD, percent=5.0%, type=output } |
-| salvaging1 | Salvaging I | 50 | 70 | industry1 | effects: { category=SCRAP, percent=5.0%, type=output } |
-| logistics1 | Logistics I | 60 | 90 | industry1 | effects: { category=RAW, percent=5.0%, type=storage }, { category=CONSTRUCTION_MATERIALS, percent=5.0%, type=storage } |
-| industry2 | Industry II | 200 | 240 | industry1 | buildings: toolsmithy |
-| woodworking2 | Woodworking II | 110 | 180 | woodworking1, industry2 | effects: { category=WOOD, percent=5.0%, type=output } |
-| salvaging2 | Salvaging II | 110 | 180 | salvaging1, industry2 | effects: { category=SCRAP, percent=5.0%, type=output } |
-| logistics2 | Logistics II | 120 | 210 | logistics1, industry2 | effects: { category=RAW, percent=5.0%, type=storage }, { category=CONSTRUCTION_MATERIALS, percent=5.0%, type=storage } |
+| id | name | science cost | time (sec) | prereqs | milestones | unlocks | effects | source |
+| - | - | - | - | - | - | - | - | - |
+| basicEnergy | Basic Energy | 80 | 120 | industry1 | - | {"resources":["power"],"buildings":["woodGenerator","battery"],"categories":["Energy"]} | - | research.js:RESEARCH[0] |
+| industry1 | Industry I | 60 | 90 | - | - | {"resources":["planks","metalParts"],"buildings":["sawmill","metalWorkshop","materialsDepot"],"categories":["CONSTRUCTION_MATERIALS"]} | - | research.js:RESEARCH[1] |
+| radio | Radio | 120 | 180 | industry1, basicEnergy | - | {"resources":[],"buildings":["radio"],"categories":[]} | - | research.js:RESEARCH[2] |
+| woodworking1 | Woodworking I | 50 | 70 | industry1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"WOOD","percent":0.05,"type":"output"}] | research.js:RESEARCH[3] |
+| salvaging1 | Salvaging I | 50 | 70 | industry1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"SCRAP","percent":0.05,"type":"output"}] | research.js:RESEARCH[4] |
+| logistics1 | Logistics I | 60 | 90 | industry1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"RAW","percent":0.05,"type":"storage"},{"category":"CONSTRUCTION_MATERIALS","percent":0.05,"type":"storage"}] | research.js:RESEARCH[5] |
+| industry2 | Industry II | 200 | 240 | industry1 | {"produced":{"planks":50,"metalParts":30}} | {"resources":[],"buildings":["toolsmithy"],"categories":[]} | - | research.js:RESEARCH[6] |
+| woodworking2 | Woodworking II | 110 | 180 | woodworking1, industry2 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"WOOD","percent":0.05,"type":"output"}] | research.js:RESEARCH[7] |
+| salvaging2 | Salvaging II | 110 | 180 | salvaging1, industry2 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"SCRAP","percent":0.05,"type":"output"}] | research.js:RESEARCH[8] |
+| logistics2 | Logistics II | 120 | 210 | logistics1, industry2 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"RAW","percent":0.05,"type":"storage"},{"category":"CONSTRUCTION_MATERIALS","percent":0.05,"type":"storage"}] | research.js:RESEARCH[9] |
 
 ## 6) Roles
-| id | name | resource | building |
-| - | - | - | - |
-| farmer | Farmer | potatoes | potatoField |
-| woodcutter | Woodcutter | wood | loggingCamp |
-| scavenger | Scavenger | scrap | scrapyard |
-| quarryWorker | Quarry Worker | stone | quarry |
-| scientist | Scientist | science | school |
+| id | name | skill | resource | building | source |
+| - | - | - | - | - | - |
+| farmer | Farmer | Farming | potatoes | potatoField | roles.js:ROLES.farmer |
+| woodcutter | Woodcutter | Woodcutting | wood | loggingCamp | roles.js:ROLES.woodcutter |
+| scavenger | Scavenger | Scavenging | scrap | scrapyard | roles.js:ROLES.scavenger |
+| quarryWorker | Quarry Worker | Quarrying | stone | quarry | roles.js:ROLES.quarryWorker |
+| scientist | Scientist | Scientist | science | school | roles.js:ROLES.scientist |
 
 ## 7) Starting State
 Starting season: spring, Year: 1.
 
 ### Resources
-| resource | amount | capacity |
-| - | - | - |
-| potatoes | 0 | 300 |
-| wood | 0 | 100 |
-| stone | 0 | 100 |
-| scrap | 0 | 100 |
-| planks | 0 | 50 |
-| metalParts | 0 | 20 |
-| science | 0 | 400 |
-| power | 0 | 2 |
+| resource | amount | capacity | source |
+| - | - | - | - |
+| potatoes | 0 | 300 | resources.js:RESOURCES.potatoes.startingAmount/startingCapacity |
+| wood | 0 | 100 | resources.js:RESOURCES.wood.startingAmount/startingCapacity |
+| stone | 0 | 100 | resources.js:RESOURCES.stone.startingAmount/startingCapacity |
+| scrap | 0 | 100 | resources.js:RESOURCES.scrap.startingAmount/startingCapacity |
+| planks | 0 | 50 | resources.js:RESOURCES.planks.startingAmount/startingCapacity |
+| metalParts | 0 | 20 | resources.js:RESOURCES.metalParts.startingAmount/startingCapacity |
+| science | 0 | 400 | resources.js:RESOURCES.science.startingAmount/startingCapacity |
+| power | 0 | 2 | resources.js:RESOURCES.power.startingAmount/startingCapacity |
 
 ### Buildings
-| building | count |
-| - | - |
-| potatoField | 2 |
-| loggingCamp | 1 |
+| building | count | source |
+| - | - | - |
+| potatoField | 2 | defaultState.js:initBuildings().potatoField.count |
+| loggingCamp | 1 | defaultState.js:initBuildings().loggingCamp.count |
 
+## 8) Rules & Formulas
+- Building cost: costBase * costGrowth^count, rounded up (source: buildings.js:getBuildingCost())
+- Demolition refund: refund * last cost (source: buildings.js:BUILDINGS[].refund)
+- Clamp: clampResource(value, capacity) (source: production.js:clampResource())
+- TICK_SECONDS = 1 (source: balance.js:BALANCE.TICK_SECONDS)
+- FOOD_CONSUMPTION_PER_SETTLER = 0.4 (source: balance.js:BALANCE.FOOD_CONSUMPTION_PER_SETTLER)
+- STARVATION_DEATH_TIMER_SECONDS = 90 (source: balance.js:BALANCE.STARVATION_DEATH_TIMER_SECONDS)
+- ROLE_BONUS_PER_SETTLER(level): level<=10 -> 0.1*level; else 1 + 0.05*(level-10) (source: balance.js:ROLE_BONUS_PER_SETTLER)
+- SHELTER_MAX = 5 (source: settlement.js:SHELTER_MAX)
+- SHELTER_COST_GROWTH = 1.8 (source: settlement.js:SHELTER_COST_GROWTH)
+- RADIO_BASE_SECONDS = 60 (source: settlement.js:RADIO_BASE_SECONDS)

--- a/docs/economy-snapshot.json
+++ b/docs/economy-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "version": "8c7304eda7c13985bd2fbb4bf829d7118c52c925",
+  "version": "fea12af6a78ea53efde6c6b33916b2cdc4d64b21",
   "saveVersion": 5,
   "tickSeconds": 1,
   "seasons": {
@@ -14,6 +14,10 @@
         "metalParts": 1,
         "science": 1,
         "power": 1
+      },
+      "origin": {
+        "file": "time.js",
+        "path": "SEASONS[0]"
       }
     },
     "summer": {
@@ -27,6 +31,10 @@
         "metalParts": 1,
         "science": 1,
         "power": 1
+      },
+      "origin": {
+        "file": "time.js",
+        "path": "SEASONS[1]"
       }
     },
     "autumn": {
@@ -40,6 +48,10 @@
         "metalParts": 1,
         "science": 1,
         "power": 1
+      },
+      "origin": {
+        "file": "time.js",
+        "path": "SEASONS[2]"
       }
     },
     "winter": {
@@ -53,6 +65,10 @@
         "metalParts": 1,
         "science": 1,
         "power": 1
+      },
+      "origin": {
+        "file": "time.js",
+        "path": "SEASONS[3]"
       }
     }
   },
@@ -63,7 +79,11 @@
       "category": "FOOD",
       "startingAmount": 0,
       "startingCapacity": 300,
-      "unit": null
+      "unit": null,
+      "origin": {
+        "file": "resources.js",
+        "path": "RESOURCES.potatoes"
+      }
     },
     {
       "key": "wood",
@@ -71,7 +91,11 @@
       "category": "RAW",
       "startingAmount": 0,
       "startingCapacity": 100,
-      "unit": null
+      "unit": null,
+      "origin": {
+        "file": "resources.js",
+        "path": "RESOURCES.wood"
+      }
     },
     {
       "key": "stone",
@@ -79,7 +103,11 @@
       "category": "RAW",
       "startingAmount": 0,
       "startingCapacity": 100,
-      "unit": null
+      "unit": null,
+      "origin": {
+        "file": "resources.js",
+        "path": "RESOURCES.stone"
+      }
     },
     {
       "key": "scrap",
@@ -87,7 +115,11 @@
       "category": "RAW",
       "startingAmount": 0,
       "startingCapacity": 100,
-      "unit": null
+      "unit": null,
+      "origin": {
+        "file": "resources.js",
+        "path": "RESOURCES.scrap"
+      }
     },
     {
       "key": "planks",
@@ -95,7 +127,11 @@
       "category": "CONSTRUCTION_MATERIALS",
       "startingAmount": 0,
       "startingCapacity": 50,
-      "unit": null
+      "unit": null,
+      "origin": {
+        "file": "resources.js",
+        "path": "RESOURCES.planks"
+      }
     },
     {
       "key": "metalParts",
@@ -103,7 +139,11 @@
       "category": "CONSTRUCTION_MATERIALS",
       "startingAmount": 0,
       "startingCapacity": 20,
-      "unit": null
+      "unit": null,
+      "origin": {
+        "file": "resources.js",
+        "path": "RESOURCES.metalParts"
+      }
     },
     {
       "key": "science",
@@ -111,7 +151,11 @@
       "category": "SOCIETY",
       "startingAmount": 0,
       "startingCapacity": 400,
-      "unit": null
+      "unit": null,
+      "origin": {
+        "file": "resources.js",
+        "path": "RESOURCES.science"
+      }
     },
     {
       "key": "power",
@@ -119,7 +163,11 @@
       "category": "ENERGY",
       "startingAmount": 0,
       "startingCapacity": 2,
-      "unit": null
+      "unit": null,
+      "origin": {
+        "file": "resources.js",
+        "path": "RESOURCES.power"
+      }
     }
   ],
   "buildings": [
@@ -127,277 +175,391 @@
       "id": "potatoField",
       "name": "Potato Field",
       "type": "production",
-      "constructionCost": {
+      "cost": {
         "wood": 15
       },
-      "demolitionRefund": 0.5,
-      "storageProvided": {},
-      "baseProductionPerSec": {
+      "costGrowth": 1.15,
+      "refund": 0.5,
+      "storage": {},
+      "outputsPerSec": {
         "potatoes": 0.375
       },
-      "baseInputsPerSec": {},
-      "seasonalMultipliers": {
+      "inputsPerSec": {},
+      "requiresResearch": "",
+      "seasonMults": {
         "spring": 1.25,
         "summer": 1,
         "autumn": 0.85,
         "winter": 0
+      },
+      "origin": {
+        "file": "buildings.js",
+        "path": "BUILDINGS[0]"
       }
     },
     {
       "id": "loggingCamp",
       "name": "Logging Camp",
       "type": "production",
-      "constructionCost": {
+      "cost": {
         "scrap": 15
       },
-      "demolitionRefund": 0.5,
-      "storageProvided": {},
-      "baseProductionPerSec": {
+      "costGrowth": 1.15,
+      "refund": 0.5,
+      "storage": {},
+      "outputsPerSec": {
         "wood": 0.25
       },
-      "baseInputsPerSec": {},
-      "seasonalMultipliers": {
+      "inputsPerSec": {},
+      "requiresResearch": "",
+      "seasonMults": {
         "spring": 1.1,
         "summer": 1,
         "autumn": 0.9,
         "winter": 0.8
+      },
+      "origin": {
+        "file": "buildings.js",
+        "path": "BUILDINGS[1]"
       }
     },
     {
       "id": "scrapyard",
       "name": "Scrap Yard",
       "type": "production",
-      "constructionCost": {
+      "cost": {
         "wood": 12
       },
-      "demolitionRefund": 0.5,
-      "storageProvided": {},
-      "baseProductionPerSec": {
+      "costGrowth": 1.15,
+      "refund": 0.5,
+      "storage": {},
+      "outputsPerSec": {
         "scrap": 0.08
       },
-      "baseInputsPerSec": {},
-      "seasonalMultipliers": {
+      "inputsPerSec": {},
+      "requiresResearch": "",
+      "seasonMults": {
         "spring": 1.1,
         "summer": 1,
         "autumn": 0.9,
         "winter": 0.8
+      },
+      "origin": {
+        "file": "buildings.js",
+        "path": "BUILDINGS[2]"
       }
     },
     {
       "id": "quarry",
       "name": "Quarry",
       "type": "production",
-      "constructionCost": {
+      "cost": {
         "wood": 20,
         "scrap": 5
       },
-      "demolitionRefund": 0.5,
-      "storageProvided": {},
-      "baseProductionPerSec": {
+      "costGrowth": 1.15,
+      "refund": 0.5,
+      "storage": {},
+      "outputsPerSec": {
         "stone": 0.08
       },
-      "baseInputsPerSec": {},
-      "seasonalMultipliers": {
+      "inputsPerSec": {},
+      "requiresResearch": "",
+      "seasonMults": {
         "spring": 1.1,
         "summer": 1,
         "autumn": 0.9,
         "winter": 0.8
+      },
+      "origin": {
+        "file": "buildings.js",
+        "path": "BUILDINGS[3]"
       }
     },
     {
       "id": "sawmill",
       "name": "Sawmill",
       "type": "processing",
-      "constructionCost": {
+      "cost": {
         "wood": 40,
         "scrap": 15,
         "stone": 10
       },
-      "demolitionRefund": 0.5,
-      "storageProvided": {},
-      "baseProductionPerSec": {
+      "costGrowth": 1.15,
+      "refund": 0.5,
+      "storage": {},
+      "outputsPerSec": {
         "planks": 0.5
       },
-      "baseInputsPerSec": {
+      "inputsPerSec": {
         "wood": 0.8
       },
-      "seasonalMultipliers": {
+      "requiresResearch": "industry1",
+      "seasonMults": {
         "spring": 1,
         "summer": 1,
         "autumn": 1,
         "winter": 1
+      },
+      "origin": {
+        "file": "buildings.js",
+        "path": "BUILDINGS[4]"
       }
     },
     {
       "id": "metalWorkshop",
       "name": "Metal Workshop",
       "type": "processing",
-      "constructionCost": {
+      "cost": {
         "wood": 30,
         "scrap": 30,
         "stone": 10,
         "planks": 10
       },
-      "demolitionRefund": 0.5,
-      "storageProvided": {},
-      "baseProductionPerSec": {
+      "costGrowth": 1.15,
+      "refund": 0.5,
+      "storage": {},
+      "outputsPerSec": {
         "metalParts": 0.4
       },
-      "baseInputsPerSec": {
+      "inputsPerSec": {
         "scrap": 0.4
       },
-      "seasonalMultipliers": {
+      "requiresResearch": "industry1",
+      "seasonMults": {
         "spring": 1,
         "summer": 1,
         "autumn": 1,
         "winter": 1
+      },
+      "origin": {
+        "file": "buildings.js",
+        "path": "BUILDINGS[5]"
       }
     },
     {
       "id": "school",
       "name": "School",
       "type": "production",
-      "constructionCost": {
+      "cost": {
         "wood": 25,
         "scrap": 10,
         "stone": 10
       },
-      "demolitionRefund": 0.5,
-      "storageProvided": {},
-      "baseProductionPerSec": {
+      "costGrowth": 1.15,
+      "refund": 0.5,
+      "storage": {},
+      "outputsPerSec": {
         "science": 0.5
       },
-      "baseInputsPerSec": {},
-      "seasonalMultipliers": {
+      "inputsPerSec": {},
+      "requiresResearch": "",
+      "seasonMults": {
         "spring": 1,
         "summer": 1,
         "autumn": 1,
         "winter": 1
+      },
+      "origin": {
+        "file": "buildings.js",
+        "path": "BUILDINGS[6]"
       }
     },
     {
       "id": "woodGenerator",
       "name": "Wood Generator",
       "type": "production",
-      "constructionCost": {
+      "cost": {
         "wood": 50,
         "stone": 10
       },
-      "demolitionRefund": 0.5,
-      "storageProvided": {},
-      "baseProductionPerSec": {
+      "costGrowth": 1.15,
+      "refund": 0.5,
+      "storage": {},
+      "outputsPerSec": {
         "power": 1
       },
-      "baseInputsPerSec": {
+      "inputsPerSec": {
         "wood": 0.25
       },
-      "seasonalMultipliers": {
+      "requiresResearch": "basicEnergy",
+      "seasonMults": {
         "spring": 1,
         "summer": 1,
         "autumn": 1,
         "winter": 1
+      },
+      "origin": {
+        "file": "buildings.js",
+        "path": "BUILDINGS[7]"
       }
     },
     {
       "id": "shelter",
       "name": "Shelter",
       "type": "production",
-      "constructionCost": {
+      "cost": {
         "wood": 30,
         "scrap": 10
       },
-      "demolitionRefund": 0.5,
-      "storageProvided": {},
-      "baseProductionPerSec": {},
-      "baseInputsPerSec": {},
-      "seasonalMultipliers": {}
+      "costGrowth": 1.8,
+      "refund": 0.5,
+      "storage": {},
+      "outputsPerSec": {},
+      "inputsPerSec": {},
+      "requiresResearch": "",
+      "seasonMults": {
+        "spring": 1,
+        "summer": 1,
+        "autumn": 1,
+        "winter": 1
+      },
+      "origin": {
+        "file": "buildings.js",
+        "path": "BUILDINGS[8]"
+      }
     },
     {
       "id": "radio",
       "name": "Radio",
       "type": "production",
-      "constructionCost": {
+      "cost": {
         "wood": 80,
         "scrap": 40,
         "stone": 20
       },
-      "demolitionRefund": 0.5,
-      "storageProvided": {},
-      "baseProductionPerSec": {},
-      "baseInputsPerSec": {
+      "costGrowth": 1,
+      "refund": 0.5,
+      "storage": {},
+      "outputsPerSec": {},
+      "inputsPerSec": {
         "power": 0.1
       },
-      "seasonalMultipliers": {}
+      "requiresResearch": "radio",
+      "seasonMults": {
+        "spring": 1,
+        "summer": 1,
+        "autumn": 1,
+        "winter": 1
+      },
+      "origin": {
+        "file": "buildings.js",
+        "path": "BUILDINGS[9]"
+      }
     },
     {
       "id": "foodStorage",
       "name": "Granary",
       "type": "storage",
-      "constructionCost": {
+      "cost": {
         "wood": 20,
         "scrap": 5,
         "stone": 5
       },
-      "demolitionRefund": 0.5,
-      "storageProvided": {
+      "costGrowth": 1.15,
+      "refund": 0.5,
+      "storage": {
         "potatoes": 300
       },
-      "baseProductionPerSec": {},
-      "baseInputsPerSec": {},
-      "seasonalMultipliers": {}
+      "outputsPerSec": {},
+      "inputsPerSec": {},
+      "requiresResearch": "",
+      "seasonMults": {
+        "spring": 1,
+        "summer": 1,
+        "autumn": 1,
+        "winter": 1
+      },
+      "origin": {
+        "file": "buildings.js",
+        "path": "BUILDINGS[10]"
+      }
     },
     {
       "id": "rawStorage",
       "name": "Warehouse",
       "type": "storage",
-      "constructionCost": {
+      "cost": {
         "wood": 25,
         "scrap": 10,
         "stone": 10
       },
-      "demolitionRefund": 0.5,
-      "storageProvided": {
+      "costGrowth": 1.15,
+      "refund": 0.5,
+      "storage": {
         "wood": 200,
         "stone": 80,
         "scrap": 120
       },
-      "baseProductionPerSec": {},
-      "baseInputsPerSec": {},
-      "seasonalMultipliers": {}
+      "outputsPerSec": {},
+      "inputsPerSec": {},
+      "requiresResearch": "",
+      "seasonMults": {
+        "spring": 1,
+        "summer": 1,
+        "autumn": 1,
+        "winter": 1
+      },
+      "origin": {
+        "file": "buildings.js",
+        "path": "BUILDINGS[11]"
+      }
     },
     {
       "id": "materialsDepot",
       "name": "Materials Depot",
       "type": "storage",
-      "constructionCost": {
+      "cost": {
         "wood": 25,
         "scrap": 10,
         "stone": 5
       },
-      "demolitionRefund": 0.5,
-      "storageProvided": {
+      "costGrowth": 1.15,
+      "refund": 0.5,
+      "storage": {
         "planks": 150,
         "metalParts": 60
       },
-      "baseProductionPerSec": {},
-      "baseInputsPerSec": {},
-      "seasonalMultipliers": {}
+      "outputsPerSec": {},
+      "inputsPerSec": {},
+      "requiresResearch": "industry1",
+      "seasonMults": {
+        "spring": 1,
+        "summer": 1,
+        "autumn": 1,
+        "winter": 1
+      },
+      "origin": {
+        "file": "buildings.js",
+        "path": "BUILDINGS[12]"
+      }
     },
     {
       "id": "battery",
       "name": "Battery",
       "type": "storage",
-      "constructionCost": {
+      "cost": {
         "wood": 40,
         "stone": 20
       },
-      "demolitionRefund": 0.5,
-      "storageProvided": {
+      "costGrowth": 1.15,
+      "refund": 0.5,
+      "storage": {
         "power": 40
       },
-      "baseProductionPerSec": {},
-      "baseInputsPerSec": {},
-      "seasonalMultipliers": {}
+      "outputsPerSec": {},
+      "inputsPerSec": {},
+      "requiresResearch": "basicEnergy",
+      "seasonMults": {
+        "spring": 1,
+        "summer": 1,
+        "autumn": 1,
+        "winter": 1
+      },
+      "origin": {
+        "file": "buildings.js",
+        "path": "BUILDINGS[13]"
+      }
     }
   ],
   "research": [
@@ -409,6 +571,7 @@
       "prereqs": [
         "industry1"
       ],
+      "milestones": null,
       "unlocks": {
         "resources": [
           "power"
@@ -421,7 +584,11 @@
           "Energy"
         ]
       },
-      "effects": []
+      "effects": [],
+      "origin": {
+        "file": "research.js",
+        "path": "RESEARCH[0]"
+      }
     },
     {
       "id": "industry1",
@@ -429,7 +596,12 @@
       "scienceCost": 60,
       "timeSec": 90,
       "prereqs": [],
+      "milestones": null,
       "unlocks": {
+        "resources": [
+          "planks",
+          "metalParts"
+        ],
         "buildings": [
           "sawmill",
           "metalWorkshop",
@@ -437,13 +609,13 @@
         ],
         "categories": [
           "CONSTRUCTION_MATERIALS"
-        ],
-        "resources": [
-          "planks",
-          "metalParts"
         ]
       },
-      "effects": []
+      "effects": [],
+      "origin": {
+        "file": "research.js",
+        "path": "RESEARCH[1]"
+      }
     },
     {
       "id": "radio",
@@ -454,12 +626,19 @@
         "industry1",
         "basicEnergy"
       ],
+      "milestones": null,
       "unlocks": {
+        "resources": [],
         "buildings": [
           "radio"
-        ]
+        ],
+        "categories": []
       },
-      "effects": []
+      "effects": [],
+      "origin": {
+        "file": "research.js",
+        "path": "RESEARCH[2]"
+      }
     },
     {
       "id": "woodworking1",
@@ -469,13 +648,23 @@
       "prereqs": [
         "industry1"
       ],
+      "milestones": null,
+      "unlocks": {
+        "resources": [],
+        "buildings": [],
+        "categories": []
+      },
       "effects": [
         {
           "category": "WOOD",
           "percent": 0.05,
           "type": "output"
         }
-      ]
+      ],
+      "origin": {
+        "file": "research.js",
+        "path": "RESEARCH[3]"
+      }
     },
     {
       "id": "salvaging1",
@@ -485,13 +674,23 @@
       "prereqs": [
         "industry1"
       ],
+      "milestones": null,
+      "unlocks": {
+        "resources": [],
+        "buildings": [],
+        "categories": []
+      },
       "effects": [
         {
           "category": "SCRAP",
           "percent": 0.05,
           "type": "output"
         }
-      ]
+      ],
+      "origin": {
+        "file": "research.js",
+        "path": "RESEARCH[4]"
+      }
     },
     {
       "id": "logistics1",
@@ -501,6 +700,12 @@
       "prereqs": [
         "industry1"
       ],
+      "milestones": null,
+      "unlocks": {
+        "resources": [],
+        "buildings": [],
+        "categories": []
+      },
       "effects": [
         {
           "category": "RAW",
@@ -512,7 +717,11 @@
           "percent": 0.05,
           "type": "storage"
         }
-      ]
+      ],
+      "origin": {
+        "file": "research.js",
+        "path": "RESEARCH[5]"
+      }
     },
     {
       "id": "industry2",
@@ -522,12 +731,24 @@
       "prereqs": [
         "industry1"
       ],
+      "milestones": {
+        "produced": {
+          "planks": 50,
+          "metalParts": 30
+        }
+      },
       "unlocks": {
+        "resources": [],
         "buildings": [
           "toolsmithy"
-        ]
+        ],
+        "categories": []
       },
-      "effects": []
+      "effects": [],
+      "origin": {
+        "file": "research.js",
+        "path": "RESEARCH[6]"
+      }
     },
     {
       "id": "woodworking2",
@@ -538,13 +759,23 @@
         "woodworking1",
         "industry2"
       ],
+      "milestones": null,
+      "unlocks": {
+        "resources": [],
+        "buildings": [],
+        "categories": []
+      },
       "effects": [
         {
           "category": "WOOD",
           "percent": 0.05,
           "type": "output"
         }
-      ]
+      ],
+      "origin": {
+        "file": "research.js",
+        "path": "RESEARCH[7]"
+      }
     },
     {
       "id": "salvaging2",
@@ -555,13 +786,23 @@
         "salvaging1",
         "industry2"
       ],
+      "milestones": null,
+      "unlocks": {
+        "resources": [],
+        "buildings": [],
+        "categories": []
+      },
       "effects": [
         {
           "category": "SCRAP",
           "percent": 0.05,
           "type": "output"
         }
-      ]
+      ],
+      "origin": {
+        "file": "research.js",
+        "path": "RESEARCH[8]"
+      }
     },
     {
       "id": "logistics2",
@@ -572,6 +813,12 @@
         "logistics1",
         "industry2"
       ],
+      "milestones": null,
+      "unlocks": {
+        "resources": [],
+        "buildings": [],
+        "categories": []
+      },
       "effects": [
         {
           "category": "RAW",
@@ -583,39 +830,68 @@
           "percent": 0.05,
           "type": "storage"
         }
-      ]
+      ],
+      "origin": {
+        "file": "research.js",
+        "path": "RESEARCH[9]"
+      }
     }
   ],
   "roles": [
     {
       "id": "farmer",
       "name": "Farmer",
+      "skill": "Farming",
       "resource": "potatoes",
-      "building": "potatoField"
+      "building": "potatoField",
+      "origin": {
+        "file": "roles.js",
+        "path": "ROLES.farmer"
+      }
     },
     {
       "id": "woodcutter",
       "name": "Woodcutter",
+      "skill": "Woodcutting",
       "resource": "wood",
-      "building": "loggingCamp"
+      "building": "loggingCamp",
+      "origin": {
+        "file": "roles.js",
+        "path": "ROLES.woodcutter"
+      }
     },
     {
       "id": "scavenger",
       "name": "Scavenger",
+      "skill": "Scavenging",
       "resource": "scrap",
-      "building": "scrapyard"
+      "building": "scrapyard",
+      "origin": {
+        "file": "roles.js",
+        "path": "ROLES.scavenger"
+      }
     },
     {
       "id": "quarryWorker",
       "name": "Quarry Worker",
+      "skill": "Quarrying",
       "resource": "stone",
-      "building": "quarry"
+      "building": "quarry",
+      "origin": {
+        "file": "roles.js",
+        "path": "ROLES.quarryWorker"
+      }
     },
     {
       "id": "scientist",
       "name": "Scientist",
+      "skill": "Scientist",
       "resource": "science",
-      "building": "school"
+      "building": "school",
+      "origin": {
+        "file": "roles.js",
+        "path": "ROLES.scientist"
+      }
     }
   ],
   "formula": {
@@ -626,8 +902,48 @@
       "sum",
       "clamp"
     ],
-    "demolitionRefund": 0.5,
-    "clampRule": "min(value, capacity) and never negative"
+    "rulesOrigins": {
+      "getBuildingCost": {
+        "file": "buildings.js",
+        "path": "getBuildingCost()"
+      },
+      "refund": {
+        "file": "buildings.js",
+        "path": "BUILDINGS[].refund"
+      },
+      "clamp": {
+        "file": "production.js",
+        "path": "clampResource()"
+      },
+      "tickSeconds": {
+        "file": "balance.js",
+        "path": "BALANCE.TICK_SECONDS"
+      },
+      "foodConsumption": {
+        "file": "balance.js",
+        "path": "BALANCE.FOOD_CONSUMPTION_PER_SETTLER"
+      },
+      "starvationTimer": {
+        "file": "balance.js",
+        "path": "BALANCE.STARVATION_DEATH_TIMER_SECONDS"
+      },
+      "roleBonusFn": {
+        "file": "balance.js",
+        "path": "ROLE_BONUS_PER_SETTLER"
+      },
+      "shelterMax": {
+        "file": "settlement.js",
+        "path": "SHELTER_MAX"
+      },
+      "shelterCostGrowth": {
+        "file": "settlement.js",
+        "path": "SHELTER_COST_GROWTH"
+      },
+      "radioBaseSeconds": {
+        "file": "settlement.js",
+        "path": "RADIO_BASE_SECONDS"
+      }
+    }
   },
   "startingState": {
     "season": "spring",


### PR DESCRIPTION
## Summary
- overhaul economy report generator to extract data with per-field origins
- output compact ECONOMY_REPORT.md and economy-snapshot.json including source paths and rules metadata

## Testing
- `npm test`
- `npm run lint`
- `node scripts/generate-economy-report.mjs`


------
https://chatgpt.com/codex/tasks/task_e_689a9fb4596c833189ab729a68900148