### PR TITLE
Add shelter to starting buildings

### DIFF
--- a/docs/ECONOMY_REPORT.md
+++ b/docs/ECONOMY_REPORT.md
@@ -1,7 +1,7 @@
 # Economy Report
 
 ## 1) Overview
-Economy generated from commit **8c7304eda7c13985bd2fbb4bf829d7118c52c925** on 2025-08-12 03:40:40 +0200. Save version: **5**.
+Economy generated from commit **817ab1aa9f0ca61c503b8319294da30152cc6ca2** on 2025-08-12 04:05:51 +0200. Save version: **5**.
 Each tick represents 1 second. For each building: base production is modified by season multipliers, summed, then clamped to capacity. Offline progress processes in 60-second chunks.
 
 ## 2) Resources
@@ -85,4 +85,5 @@ Starting season: spring, Year: 1.
 | - | - |
 | potatoField | 2 |
 | loggingCamp | 1 |
+| shelter | 1 |
 

--- a/docs/economy-snapshot.json
+++ b/docs/economy-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "version": "8c7304eda7c13985bd2fbb4bf829d7118c52c925",
+  "version": "817ab1aa9f0ca61c503b8319294da30152cc6ca2",
   "saveVersion": 5,
   "tickSeconds": 1,
   "seasons": {
@@ -669,6 +669,7 @@
   },
   "startingBuildings": {
     "potatoField": 2,
-    "loggingCamp": 1
+    "loggingCamp": 1,
+    "shelter": 1
   }
 }

--- a/src/state/defaultState.js
+++ b/src/state/defaultState.js
@@ -16,6 +16,7 @@ const initResources = () => {
 const initBuildings = () => ({
   potatoField: { count: 2 },
   loggingCamp: { count: 1 },
+  shelter: { count: 1 },
 });
 
 const initSettlers = () => [makeRandomSettler()];


### PR DESCRIPTION
## Summary
- Add a Shelter to the game's starting buildings.
- Regenerate economy documentation to include new starting Shelter.

## Testing
- `npm run report:economy`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689aa16726188331a10218f10ffbea5a