### PR TITLE
Handle buildings without resource outputs

### DIFF
--- a/src/engine/__tests__/radio.test.js
+++ b/src/engine/__tests__/radio.test.js
@@ -7,6 +7,8 @@ vi.mock('../candidates.js', () => ({
 }));
 
 import { updateRadio } from '../radio.js';
+import { applyProduction } from '../production.js';
+import { getResourceRates } from '../../state/selectors.js';
 import { generateCandidate } from '../candidates.js';
 
 const baseState = {
@@ -30,5 +32,37 @@ describe('updateRadio', () => {
     expect(generateCandidate).toHaveBeenCalledOnce();
     expect(candidate).toEqual(fakeCandidate);
     expect(radioTimer).toBe(0);
+  });
+});
+
+describe('radio building production', () => {
+  it('consumes power without producing resources', () => {
+    const state = {
+      buildings: { radio: { count: 1 } },
+      resources: { power: { amount: 1 } },
+    };
+    const next = applyProduction(state, 5);
+    expect(next.resources.power.amount).toBeCloseTo(0.5, 5);
+  });
+
+  it('reports power consumption in resource rates', () => {
+    const state = {
+      buildings: { radio: { count: 1 } },
+      resources: { power: { amount: 1 } },
+    };
+    const rates = getResourceRates(state);
+    expect(rates.power.perSec).toBeCloseTo(-0.1, 5);
+  });
+});
+
+describe('buildings without inputs or outputs', () => {
+  it('do not crash resource rate calculations', () => {
+    const state = { buildings: { shelter: { count: 1 } }, resources: {} };
+    expect(() => getResourceRates(state)).not.toThrow();
+  });
+
+  it('do not crash production calculations', () => {
+    const state = { buildings: { shelter: { count: 1 } }, resources: {} };
+    expect(() => applyProduction(state, 5)).not.toThrow();
   });
 });

--- a/src/engine/production.js
+++ b/src/engine/production.js
@@ -70,28 +70,30 @@ export function applyProduction(state, seconds = 1, roleBonuses = {}) {
         });
       }
     }
-    Object.entries(b.outputsPerSecBase).forEach(([res, base]) => {
-      const category = RESOURCES[res].category;
-      const mult = getSeasonMultiplier(season, category);
-      const role = ROLE_BY_RESOURCE[res];
-      const bonusPercent = roleBonuses[role] || 0;
-      const researchBonus = getResearchOutputBonus(state, res);
-      const gain =
-        base *
-        mult *
-        count *
-        (1 + bonusPercent / 100 + researchBonus) *
-        seconds *
-        factor;
-      const capacity = getCapacity(state, res);
-      const currentEntry = resources[res] || { amount: 0, discovered: false };
-      const next = clampResource(currentEntry.amount + gain, capacity);
-      resources[res] = {
-        amount: next,
-        discovered: currentEntry.discovered || count > 0 || next > 0,
-        produced: (currentEntry.produced || 0) + Math.max(0, gain),
-      };
-    });
+    if (b.outputsPerSecBase) {
+      Object.entries(b.outputsPerSecBase).forEach(([res, base]) => {
+        const category = RESOURCES[res].category;
+        const mult = getSeasonMultiplier(season, category);
+        const role = ROLE_BY_RESOURCE[res];
+        const bonusPercent = roleBonuses[role] || 0;
+        const researchBonus = getResearchOutputBonus(state, res);
+        const gain =
+          base *
+          mult *
+          count *
+          (1 + bonusPercent / 100 + researchBonus) *
+          seconds *
+          factor;
+        const capacity = getCapacity(state, res);
+        const currentEntry = resources[res] || { amount: 0, discovered: false };
+        const next = clampResource(currentEntry.amount + gain, capacity);
+        resources[res] = {
+          amount: next,
+          discovered: currentEntry.discovered || count > 0 || next > 0,
+          produced: (currentEntry.produced || 0) + Math.max(0, gain),
+        };
+      });
+    }
   });
   Object.keys(resources).forEach((res) => {
     const entry = resources[res];

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -35,7 +35,6 @@ export function getResourceRates(
   PRODUCTION_BUILDINGS.forEach((b) => {
     const count = state.buildings?.[b.id]?.count || 0;
     if (count <= 0) return;
-    if (!b.outputsPerSecBase) return;
     let factor = 1;
     if (b.inputsPerSecBase) {
       if (b.type === 'processing') {
@@ -66,16 +65,22 @@ export function getResourceRates(
         });
       }
     }
-    Object.entries(b.outputsPerSecBase).forEach(([res, base]) => {
-      const category = RESOURCES[res].category;
-      const mult = getSeasonMultiplier(season, category);
-      const role = ROLE_BY_RESOURCE[res];
-      const bonusPercent = roleBonuses[role] || 0;
-      const researchBonus = getResearchOutputBonus(state, res);
-      const perSec =
-        base * mult * count * (1 + bonusPercent / 100 + researchBonus) * factor;
-      rates[res] = (rates[res] || 0) + perSec;
-    });
+    if (b.outputsPerSecBase) {
+      Object.entries(b.outputsPerSecBase).forEach(([res, base]) => {
+        const category = RESOURCES[res].category;
+        const mult = getSeasonMultiplier(season, category);
+        const role = ROLE_BY_RESOURCE[res];
+        const bonusPercent = roleBonuses[role] || 0;
+        const researchBonus = getResearchOutputBonus(state, res);
+        const perSec =
+          base *
+          mult *
+          count *
+          (1 + bonusPercent / 100 + researchBonus) *
+          factor;
+        rates[res] = (rates[res] || 0) + perSec;
+      });
+    }
   });
 
   if (includeConsumption) {


### PR DESCRIPTION
## Summary
- avoid crashes by guarding output loops when buildings lack outputs
- ensure resource rates include consumption for input-only buildings
- add tests covering radio power usage and shelter safety

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a9fe2568c8331bacaead3d4eb1e3c