### PR TITLE
Make top bar sticky and split main content scroll

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,9 +27,9 @@ function ActiveView() {
 export default function App() {
   return (
     <GameProvider>
-      <div className="min-h-screen flex flex-col bg-bg text-ink">
+      <div className="h-screen flex flex-col bg-bg text-ink overflow-hidden">
         <TopBar />
-        <div className="flex-1 overflow-auto">
+        <div className="flex-1 overflow-hidden">
           <ActiveView />
         </div>
         <BottomDock />

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -11,7 +11,7 @@ export default function TopBar(): JSX.Element {
   const labels: Record<string, string> = { FOOD: 'Food', RAW: 'Raw' };
 
   return (
-    <header className="flex items-center justify-between px-4 py-2 border-b border-stroke bg-bg2">
+    <header className="sticky top-0 z-10 flex items-center justify-between px-4 py-2 border-b border-stroke bg-bg2">
       <span className="tabular-nums text-xl">Year {time.year}</span>
       <h1 className="font-semibold">Apocalypse Idle</h1>
       <div className="relative flex items-center gap-2">

--- a/src/views/BaseView.jsx
+++ b/src/views/BaseView.jsx
@@ -195,11 +195,11 @@ export default function BaseView() {
     ...Object.keys(prodGroups).filter((k) => !GROUP_ORDER.includes(k)),
   ];
   return (
-    <div className="p-4 space-y-6 pb-20 md:flex md:space-y-0 md:space-x-6">
-      <div className="md:w-64 md:flex-shrink-0">
+    <div className="h-full flex flex-col md:flex-row md:space-x-6 overflow-y-auto md:overflow-hidden">
+      <div className="p-4 pb-20 md:w-64 md:flex-shrink-0 md:overflow-y-auto">
         <ResourceSidebar />
       </div>
-      <div className="flex-1 space-y-6">
+      <div className="flex-1 p-4 space-y-6 pb-20 md:overflow-y-auto">
         <CandidateBox />
         <div className="border border-stroke rounded">
           {prodGroupKeys.map((key) => (
@@ -223,9 +223,10 @@ export default function BaseView() {
             ))}
           </Accordion>
         </div>
-        <div>
-          <h2 className="font-semibold mb-2">Event Log</h2>
-          <EventLog log={state.log} />
+        <div className="border border-stroke rounded">
+          <Accordion title="Change Log">
+            <EventLog log={state.log} />
+          </Accordion>
         </div>
       </div>
     </div>

--- a/src/views/ExpeditionsView.jsx
+++ b/src/views/ExpeditionsView.jsx
@@ -1,3 +1,3 @@
 export default function ExpeditionsView() {
-  return <div className="p-4 pb-20">Coming soon</div>;
+  return <div className="h-full overflow-y-auto p-4 pb-20">Coming soon</div>;
 }

--- a/src/views/PopulationView.jsx
+++ b/src/views/PopulationView.jsx
@@ -27,7 +27,7 @@ export default function PopulationView() {
   });
 
   return (
-    <div className="p-4 space-y-4 pb-20">
+    <div className="h-full overflow-y-auto p-4 space-y-4 pb-20">
       <div className="flex flex-wrap gap-2">
         <div className="border border-stroke rounded p-3 bg-bg2/50 text-center">
           <div className="text-xs text-muted">Settlers</div>

--- a/src/views/ResearchView.jsx
+++ b/src/views/ResearchView.jsx
@@ -11,7 +11,7 @@ export default function ResearchView() {
   const remaining = node ? Math.max(node.timeSec - progress, 0) : 0;
   const pct = node ? Math.min(progress / node.timeSec, 1) : 0;
   return (
-    <div className="p-4 pb-20 space-y-4">
+    <div className="h-full overflow-y-auto p-4 pb-20 space-y-4">
       <div className="border border-stroke rounded p-4 bg-bg2/50">
         {current && node ? (
           <div className="space-y-2">


### PR DESCRIPTION
## Summary
- Keep the top navigation bar fixed at the top of the screen
- Adjust layout to use separate scroll areas for sidebar and main content
- Wrap change log in a collapsible accordion box like the building list

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b1a1361b083318a96d328f12f50f8