### PR TITLE
Make research tree fill screen and scroll

### DIFF
--- a/src/components/BottomDock.jsx
+++ b/src/components/BottomDock.jsx
@@ -12,7 +12,7 @@ export default function BottomDock() {
   const { state, setActiveTab } = useGame();
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 flex border-t border-stroke bg-bg2">
+    <nav className="fixed bottom-0 left-0 right-0 z-20 flex border-t border-stroke bg-bg2">
       {tabs.map((t) => (
         <button
           key={t.id}

--- a/src/views/ResearchView.jsx
+++ b/src/views/ResearchView.jsx
@@ -11,7 +11,7 @@ export default function ResearchView() {
   const remaining = node ? Math.max(node.timeSec - progress, 0) : 0;
   const pct = node ? Math.min(progress / node.timeSec, 1) : 0;
   return (
-    <div className="p-4 pb-20 space-y-4">
+    <div className="p-4 pb-20 space-y-4 h-full flex flex-col">
       <div className="border border-stroke rounded p-4 bg-bg2/50">
         {current && node ? (
           <div className="space-y-2">
@@ -38,7 +38,9 @@ export default function ResearchView() {
           <div>No research in progress.</div>
         )}
       </div>
-      <ResearchTree onStart={beginResearch} />
+      <div className="flex-1 overflow-hidden">
+        <ResearchTree onStart={beginResearch} />
+      </div>
     </div>
   );
 }

--- a/src/views/research/ResearchTree.jsx
+++ b/src/views/research/ResearchTree.jsx
@@ -81,7 +81,7 @@ export default function ResearchTree({ onStart }) {
   });
 
   return (
-    <div ref={containerRef} className="relative overflow-y-auto max-h-[60vh]">
+    <div ref={containerRef} className="relative overflow-auto h-full">
       <svg className="absolute inset-0 pointer-events-none">
         <defs>
           <marker


### PR DESCRIPTION
## Summary
- make ResearchView a full-height flex column
- wrap ResearchTree to consume remaining space
- allow ResearchTree to scroll within its container
- ensure BottomDock sits above the research tree

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b19882d288331851c42aee17d68b0