### PR TITLE
Handle power shortages with offline status

### DIFF
--- a/src/engine/__tests__/power.test.js
+++ b/src/engine/__tests__/power.test.js
@@ -1,0 +1,27 @@
+import { describe, test, expect } from 'vitest';
+import { processTick } from '../production.js';
+import { defaultState } from '../../state/defaultState.js';
+
+const clone = (obj) => structuredClone(obj);
+
+describe('power shortages', () => {
+  test('buildings go offline when power runs out and recover when restored', () => {
+    const state = clone(defaultState);
+    state.buildings.radio = { count: 1 };
+    state.resources.power.amount = 0.15;
+    state.resources.power.discovered = true;
+
+    let next = processTick(state, 1);
+    expect(next.buildings.radio.offlineReason).toBeUndefined();
+    expect(next.resources.power.amount).toBeCloseTo(0.05, 5);
+
+    next = processTick(next, 1);
+    expect(next.buildings.radio.offlineReason).toBe('power');
+    expect(next.resources.power.amount).toBeCloseTo(0.05, 5);
+
+    next.resources.power.amount = 1;
+    next = processTick(next, 1);
+    expect(next.buildings.radio.offlineReason).toBeUndefined();
+    expect(next.resources.power.amount).toBeCloseTo(0.9, 5);
+  });
+});

--- a/src/views/BaseView.jsx
+++ b/src/views/BaseView.jsx
@@ -23,6 +23,7 @@ function BuildingRow({ building, completedResearch }) {
   const season = getSeason(state);
   const scaledCost = getBuildingCost(building, count);
   const costEntries = Object.entries(scaledCost);
+  const offlineReason = state.buildings[building.id]?.offlineReason;
   const unlocked =
     !building.requiresResearch ||
     completedResearch.includes(building.requiresResearch);
@@ -83,12 +84,19 @@ function BuildingRow({ building, completedResearch }) {
   return (
     <div className="p-2 rounded border border-stroke bg-bg2 space-y-1">
       <div className="flex items-center justify-between">
-        <span>
-          {building.name}{' '}
-          {building.maxCount != null
-            ? `${count}/${building.maxCount}`
-            : `(${count})`}
-        </span>
+        <div className="flex items-center gap-2">
+          <span>
+            {building.name}{' '}
+            {building.maxCount != null
+              ? `${count}/${building.maxCount}`
+              : `(${count})`}
+          </span>
+          {offlineReason && (
+            <span className="px-1 text-xs text-white bg-red-600 rounded">
+              {offlineReason === 'power' ? 'No Power' : 'Offline'}
+            </span>
+          )}
+        </div>
         <div className="space-x-2">
           <button
             className="px-2 py-1 border border-stroke rounded disabled:opacity-50"

--- a/src/views/__tests__/BaseView.test.jsx
+++ b/src/views/__tests__/BaseView.test.jsx
@@ -24,6 +24,7 @@ function BuildingRow({ building }) {
   const season = getSeason(state);
   const scaledCost = getBuildingCost(building, count);
   const costEntries = Object.entries(scaledCost);
+  const offlineReason = state.buildings[building.id]?.offlineReason;
   const completedResearch = state.research.completed || [];
   const unlocked =
     !building.requiresResearch ||
@@ -85,12 +86,19 @@ function BuildingRow({ building }) {
   return (
     <div className="p-2 rounded border border-stroke bg-bg2 space-y-1">
       <div className="flex items-center justify-between">
-        <span>
-          {building.name}{' '}
-          {building.maxCount != null
-            ? `${count}/${building.maxCount}`
-            : `(${count})`}
-        </span>
+        <div className="flex items-center gap-2">
+          <span>
+            {building.name}{' '}
+            {building.maxCount != null
+              ? `${count}/${building.maxCount}`
+              : `(${count})`}
+          </span>
+          {offlineReason && (
+            <span className="px-1 text-xs text-white bg-red-600 rounded">
+              {offlineReason === 'power' ? 'No Power' : 'Offline'}
+            </span>
+          )}
+        </div>
         <div className="space-x-2">
           <button
             className="px-2 py-1 border border-stroke rounded disabled:opacity-50"


### PR DESCRIPTION
## Summary
- Mark power-starved buildings as offline and prevent partial production
- Show "No Power" badge on buildings with power shortages
- Test that buildings go offline when power runs out and recover once restored

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 2 files)*

------
https://chatgpt.com/codex/tasks/task_e_689b320989308331bc67012fae4351ca