### PR TITLE
Append payback analysis to economy report

### DIFF
--- a/docs/ECONOMY_REPORT.md
+++ b/docs/ECONOMY_REPORT.md
@@ -1,7 +1,7 @@
 # Economy Report
 
 ## 1) Overview
-Economy generated from commit **a3fb5663baffae94b60f810b0a0ee8af49372baf** on 2025-08-12 14:32:02 +0200. Save version: **6**.
+Economy generated from commit **4fe4a75ff117d80df4c6437ccd2de54590ccf272** on 2025-08-12 14:46:53 +0200. Save version: **6**.
 Each tick represents 1 second. For each building: base production is modified by season multipliers, summed, then clamped to capacity. Offline progress processes in 60-second chunks.
 
 ## 2) Resources
@@ -104,13 +104,12 @@ Starting season: spring, Year: 1.
 - SHELTER_COST_GROWTH = 1.8 (source: settlement.js:SHELTER_COST_GROWTH)
 - RADIO_BASE_SECONDS = 60 (source: settlement.js:RADIO_BASE_SECONDS)
 
-## 9) Payback Times
-### Summary
+## Summary
 Analyzed **15** buildings. Season mode: **average**.
 Weights: {"wood":1,"stone":1.3,"scrap":2.2,"planks":4,"metalParts":6,"power":1,"potatoes":0.9,"meat":1.4,"science":2.5}. Targets: 1, 10, 50.
 Outliers – too fast: 5, too slow: 14.
 
-### Buildings
+## Buildings
 | id | category | type | growth | PBT@1 | PBT@10 | PBT@50 | out/s (base) | in/s (base) |
 | - | - | - | - | - | - | - | - | - |
 | potatoField | Food | production | 1.15 | 44.44 | 157.04 | 41,881.48 | potatoes:0.375 | - |
@@ -129,13 +128,13 @@ Outliers – too fast: 5, too slow: 14.
 | materialsDepot |  | storage | 1.15 | — | — | — | - | - |
 | battery |  | storage | 1.15 | — | — | — | - | - |
 
-### Converters
+## Converters
 | id | growth | in/s | out/s | ratio(out/in) | PBT@1 | PBT@10 | PBT@50 | mode |
 | - | - | - | - | - | - | - | - | - |
 | sawmill | 1.15 | wood:0.8 | planks:0.5 | 2.5 | 71.67 | 253.67 | 67,534.33 | all-or-nothing |
 | metalWorkshop | 1.15 | scrap:0.4 | metalParts:0.4 | 2.73 | 98.03 | 348.68 | 92,375.79 | all-or-nothing |
 
-### Storage
+## Storage
 | id | growth | +capacity |
 | - | - | - |
 | foodStorage | 1.15 | potatoes:300,meat:150 |
@@ -143,14 +142,14 @@ Outliers – too fast: 5, too slow: 14.
 | materialsDepot | 1.15 | planks:150,metalParts:60 |
 | battery | 1.15 | power:40 |
 
-### Outliers
-#### Too Fast
+## Outliers
+### Too Fast
 - potatoField @1: 44.44 sec
 - potatoField @10: 157.04 sec
 - sawmill @1: 71.67 sec
 - school @1: 48 sec
 - school @10: 171.2 sec
-#### Too Slow
+### Too Slow
 - potatoField @50: 41,881.48 sec
 - huntersHut @1: 268.17 sec
 - huntersHut @10: 955.39 sec

--- a/docs/economy-snapshot.json
+++ b/docs/economy-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "version": "a3fb5663baffae94b60f810b0a0ee8af49372baf",
+  "version": "4fe4a75ff117d80df4c6437ccd2de54590ccf272",
   "saveVersion": 6,
   "tickSeconds": 1,
   "seasons": {

--- a/scripts/generate-economy-report.mjs
+++ b/scripts/generate-economy-report.mjs
@@ -287,9 +287,8 @@ const paybackOpts = parseArgs([]);
 const paybackRaw = generateReport(paybackOpts);
 const paybackSection = paybackRaw
   .replace(/^# Economy Report\n\n?/, '')
-  .replace(/^##/gm, '###')
   .trimStart();
-md += '\n## 9) Payback Times\n';
+md += '\n';
 md += paybackSection;
 
 fs.writeFileSync(path.join(repoRoot, 'docs/ECONOMY_REPORT.md'), md);


### PR DESCRIPTION
## Summary
- keep resource, season, research, role and starting state sections in generated economy report
- append payback analysis from economyReporter (PBT, converter, storage, outlier sections) after existing sections

## Testing
- `npm test`
- `npm run report:economy`

------
https://chatgpt.com/codex/tasks/task_e_689b37c3b578833192f25f3560a58394