### PR TITLE
feat: add power priority modal

### DIFF
--- a/src/components/Accordion.jsx
+++ b/src/components/Accordion.jsx
@@ -1,16 +1,24 @@
 import React, { useState } from 'react';
 
-export default function Accordion({ title, children, defaultOpen = false }) {
+export default function Accordion({
+  title,
+  children,
+  defaultOpen = false,
+  action,
+}) {
   const [open, setOpen] = useState(defaultOpen);
   return (
     <div className="border-b border-stroke">
-      <button
-        className="w-full flex items-center justify-between p-2"
-        onClick={() => setOpen(!open)}
-      >
-        <span>{title}</span>
-        <span>{open ? '-' : '+'}</span>
-      </button>
+      <div className="flex items-center justify-between p-2">
+        <button
+          className="flex-1 flex items-center justify-between"
+          onClick={() => setOpen(!open)}
+        >
+          <span>{title}</span>
+          <span>{open ? '-' : '+'}</span>
+        </button>
+        {action && <div className="ml-2">{action}</div>}
+      </div>
       {open && <div className="p-2 space-y-2">{children}</div>}
     </div>
   );

--- a/src/components/PowerPriorityModal.jsx
+++ b/src/components/PowerPriorityModal.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { BUILDINGS } from '../data/buildings.js';
+import { useGame } from '../state/useGame.js';
+
+export default function PowerPriorityModal({ onClose }) {
+  const { state } = useGame();
+  const consumers = BUILDINGS.filter(
+    (b) => b.inputsPerSecBase?.power || b.poweredMode,
+  );
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-bg2 p-4 rounded shadow max-w-md w-full">
+        <h2 className="text-lg mb-4">Power priorities</h2>
+        <div className="space-y-2 max-h-64 overflow-y-auto">
+          {[5, 4, 3, 2, 1].map((p) => (
+            <details key={p} open>
+              <summary className="font-semibold">Priority {p}</summary>
+              <ul className="pl-4 list-disc">
+                {consumers
+                  .filter(
+                    (c) => state.powerTypePriority?.[c.id]?.priority === p,
+                  )
+                  .map((c) => (
+                    <li key={c.id}>{c.name}</li>
+                  ))}
+              </ul>
+            </details>
+          ))}
+        </div>
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            className="px-2 py-1 border rounded text-sm"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ResourceSidebar.jsx
+++ b/src/components/ResourceSidebar.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useGame } from '../state/useGame.js';
 import Accordion from './Accordion.jsx';
+import PowerPriorityModal from './PowerPriorityModal.jsx';
 import {
   getCapacity,
   getResourceRates,
@@ -34,6 +35,7 @@ function ResourceRow({ icon, name, amount, capacity, rate, tooltip }) {
 
 export default function ResourceSidebar() {
   const { state } = useGame();
+  const [showPowerModal, setShowPowerModal] = useState(false);
   const roleBonuses = computeRoleBonuses(state.population?.settlers || []);
   const netRates = getResourceRates(state, true, roleBonuses);
   const prodRates = getResourceRates(state, false, roleBonuses);
@@ -164,12 +166,31 @@ export default function ResourceSidebar() {
               )}
           </Accordion>
         ) : (
-          <Accordion key={g.title} title={g.title} defaultOpen={g.defaultOpen}>
+          <Accordion
+            key={g.title}
+            title={g.title}
+            defaultOpen={g.defaultOpen}
+            action=
+              {g.title === 'Energy' && (
+                <button
+                  className="text-xs text-blue-500 hover:underline"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setShowPowerModal(true);
+                  }}
+                >
+                  Set priorities
+                </button>
+              )}
+          >
             {g.items.map((r) => (
               <ResourceRow key={r.id} {...r} />
             ))}
           </Accordion>
         ),
+      )}
+      {showPowerModal && (
+        <PowerPriorityModal onClose={() => setShowPowerModal(false)} />
       )}
     </div>
   );

--- a/src/state/defaultState.js
+++ b/src/state/defaultState.js
@@ -1,6 +1,7 @@
 import { initSeasons } from '../engine/time.js';
 import { CURRENT_SAVE_VERSION } from '../engine/persistence.js';
 import { RESOURCES } from '../data/resources.js';
+import { BUILDINGS } from '../data/buildings.js';
 import { makeRandomSettler } from '../data/names.js';
 import { RADIO_BASE_SECONDS } from '../data/settlement.js';
 
@@ -19,6 +20,21 @@ const initBuildings = () => ({
   shelter: { count: 1 },
 });
 
+const initPowerTypePriority = () => {
+  const result = {};
+  const orderCounters = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
+  BUILDINGS.forEach((b) => {
+    if (!b.inputsPerSecBase?.power && !b.poweredMode) return;
+    let priority = 1;
+    if (b.category === 'Food') priority = 5;
+    else if (b.type === 'processing') priority = 3;
+    else if (b.category === 'Raw Materials') priority = 2;
+    const order = orderCounters[priority]++;
+    result[b.id] = { priority, order };
+  });
+  return result;
+};
+
 const initSettlers = () => [makeRandomSettler()];
 
 const initColony = () => ({
@@ -35,6 +51,7 @@ export const defaultState = {
   ui: { activeTab: 'base', drawerOpen: false, offlineProgress: null },
   resources: initResources(),
   buildings: initBuildings(),
+  powerTypePriority: initPowerTypePriority(),
   research: initResearch(),
   population: { settlers: initSettlers(), candidate: null },
   colony: initColony(),


### PR DESCRIPTION
## Summary
- allow accordions to render header actions
- add default power type priority mapping and modal UI stub
- link new "Set priorities" button from Energy sidebar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b4d8cfb0c8331859f91d0b6fe27a4