### PR TITLE
Use post-production state for radio updates

### DIFF
--- a/src/engine/__tests__/radio.test.js
+++ b/src/engine/__tests__/radio.test.js
@@ -7,7 +7,7 @@ vi.mock('../candidates.js', () => ({
 }));
 
 import { updateRadio } from '../radio.js';
-import { applyProduction } from '../production.js';
+import { applyProduction, applyOfflineProgress } from '../production.js';
 import { getResourceRates } from '../../state/selectors.js';
 import { generateCandidate } from '../candidates.js';
 
@@ -52,6 +52,22 @@ describe('radio building production', () => {
     };
     const rates = getResourceRates(state);
     expect(rates.power.perSec).toBeCloseTo(-0.1, 5);
+  });
+});
+
+describe('applyOfflineProgress', () => {
+  it('uses post-production state to update radio', () => {
+    generateCandidate.mockClear();
+    const state = {
+      buildings: { radio: { count: 1 }, woodGenerator: { count: 1 } },
+      resources: { power: { amount: 0 }, wood: { amount: 100 } },
+      population: { candidate: null },
+      colony: { radioTimer: 3 },
+    };
+    const { state: next } = applyOfflineProgress(state, 5);
+    expect(generateCandidate).toHaveBeenCalledOnce();
+    expect(next.population.candidate).toEqual(fakeCandidate);
+    expect(next.colony.radioTimer).toBe(0);
   });
 });
 

--- a/src/engine/production.js
+++ b/src/engine/production.js
@@ -167,7 +167,12 @@ export function applyOfflineProgress(state, elapsedSeconds, roleBonuses = {}) {
     if (current.resources[res].amount > 0)
       current.resources[res].discovered = true;
   });
-  const { candidate, radioTimer } = updateRadio(state, elapsedSeconds);
+  const { candidate, radioTimer } = updateRadio(current, elapsedSeconds);
+  current = {
+    ...current,
+    population: { ...current.population, candidate },
+    colony: { ...current.colony, radioTimer },
+  };
   const gains = {};
   Object.keys(before).forEach((res) => {
     const gain =
@@ -175,11 +180,7 @@ export function applyOfflineProgress(state, elapsedSeconds, roleBonuses = {}) {
     if (gain > 0) gains[res] = gain;
   });
   return {
-    state: {
-      ...current,
-      population: { ...current.population, candidate },
-      colony: { ...current.colony, radioTimer },
-    },
+    state: current,
     gains,
   };
 }


### PR DESCRIPTION
## Summary
- Update `applyOfflineProgress` to run `updateRadio` on post-production state and return the updated candidate and radio timer
- Cover offline radio updates with a new unit test

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 5 files)*

------
https://chatgpt.com/codex/tasks/task_e_689b4df709e0833185753aadf5b8084e