### PR TITLE
feat: add type-based power priority list

### DIFF
--- a/src/components/ResourceSidebar.jsx
+++ b/src/components/ResourceSidebar.jsx
@@ -17,12 +17,12 @@ export default function ResourceSidebar() {
         g.settlers ? (
           <SettlerSection key={g.title} title={g.title} info={settlersInfo} />
         ) : (
-          <Accordion
-            key={g.title}
-            title={g.title}
-            defaultOpen={g.defaultOpen}
-            action={
-              g.title === 'Energy' && (
+          <Accordion key={g.title} title={g.title} defaultOpen={g.defaultOpen}>
+            {g.items.map((r) => (
+              <ResourceRow key={r.id} {...r} />
+            ))}
+            {g.title === 'Energy' && (
+              <div className="pt-2 text-right">
                 <button
                   className="text-xs text-blue-500 hover:underline"
                   onClick={(e) => {
@@ -32,12 +32,8 @@ export default function ResourceSidebar() {
                 >
                   Set priorities
                 </button>
-              )
-            }
-          >
-            {g.items.map((r) => (
-              <ResourceRow key={r.id} {...r} />
-            ))}
+              </div>
+            )}
           </Accordion>
         ),
       )}

--- a/src/data/buildings.js
+++ b/src/data/buildings.js
@@ -24,7 +24,7 @@ export const BUILDINGS = [
     refund: 0.5,
     seasonProfile: { spring: 1.1, summer: 1.0, autumn: 0.9, winter: 0.8 },
     description:
-      "Hunts for meat year-round; less affected by seasons than crops.",
+      'Hunts for meat year-round; less affected by seasons than crops.',
   },
   {
     id: 'loggingCamp',
@@ -129,6 +129,7 @@ export const BUILDINGS = [
     type: 'production',
     category: 'Utilities',
     requiresResearch: 'radio',
+    requiresPower: true,
     inputsPerSecBase: { power: 0.1 },
     costBase: { wood: 80, scrap: 40, stone: 20 },
     costGrowth: 1,

--- a/src/engine/power.js
+++ b/src/engine/power.js
@@ -1,0 +1,60 @@
+import { BUILDINGS, BUILDING_MAP } from '../data/buildings.js';
+
+const TIER_ORDER = { A: 0, B: 1, C: 2, D: 3 };
+
+function getTier(building) {
+  if (building.category === 'Food') return 'A';
+  if (building.type === 'processing') return 'B';
+  if (building.category === 'Raw Materials') return 'C';
+  return 'D';
+}
+
+export function getPoweredConsumerTypeIds() {
+  return BUILDINGS.filter((b) => b.requiresPower || b.poweredMode).map(
+    (b) => b.id,
+  );
+}
+
+export function ensureValidTypeId(typeId) {
+  const b = BUILDING_MAP[typeId];
+  if (!b) throw new Error(`Unknown building typeId: ${typeId}`);
+  if (!(b.requiresPower || b.poweredMode))
+    throw new Error(`Building ${typeId} is not a powered consumer`);
+}
+
+export function getTypeOrderIndex(typeId, order) {
+  const idx = order.indexOf(typeId);
+  return idx === -1 ? Number.POSITIVE_INFINITY : idx;
+}
+
+export function buildInitialPowerTypeOrder(existing = []) {
+  const powered = getPoweredConsumerTypeIds();
+  const sorted = [...powered].sort((a, b) => {
+    const ta = TIER_ORDER[getTier(BUILDING_MAP[a])];
+    const tb = TIER_ORDER[getTier(BUILDING_MAP[b])];
+    if (ta !== tb) return ta - tb;
+    return BUILDING_MAP[a].name.localeCompare(BUILDING_MAP[b].name);
+  });
+  const result = [];
+  existing.forEach((id) => {
+    if (powered.includes(id) && !result.includes(id)) result.push(id);
+  });
+  sorted.forEach((id) => {
+    if (result.includes(id)) return;
+    const tier = getTier(BUILDING_MAP[id]);
+    let insert = result.length;
+    for (let i = result.length - 1; i >= 0; i--) {
+      const otherTier = getTier(BUILDING_MAP[result[i]]);
+      if (otherTier === tier) {
+        insert = i + 1;
+        break;
+      }
+      if (TIER_ORDER[otherTier] < TIER_ORDER[tier]) {
+        insert = i + 1;
+        break;
+      }
+    }
+    result.splice(insert, 0, id);
+  });
+  return result;
+}

--- a/src/state/GameContext.jsx
+++ b/src/state/GameContext.jsx
@@ -28,6 +28,7 @@ import { ROLE_BUILDINGS } from '../data/roles.js';
 import { createLogEntry } from '../utils/log.js';
 import { updateRadio } from '../engine/radio.js';
 import { formatAmount } from '../utils/format.js';
+import { buildInitialPowerTypeOrder } from '../engine/power.js';
 
 /* eslint-disable-next-line react-refresh/only-export-components */
 export function prepareLoadedState(loaded) {
@@ -43,10 +44,7 @@ export function prepareLoadedState(loaded) {
   base.ui = { ...base.ui, ...cloned.ui };
   base.resources = { ...base.resources, ...cloned.resources };
   base.buildings = { ...base.buildings, ...cloned.buildings };
-  base.powerTypePriority = {
-    ...base.powerTypePriority,
-    ...cloned.powerTypePriority,
-  };
+  base.powerTypeOrder = buildInitialPowerTypeOrder(cloned.powerTypeOrder || []);
   base.research = { ...base.research, ...cloned.research };
   base.population = { ...base.population, ...cloned.population };
   if (Array.isArray(cloned.population?.settlers)) {

--- a/src/state/defaultState.js
+++ b/src/state/defaultState.js
@@ -1,7 +1,7 @@
 import { initSeasons } from '../engine/time.js';
 import { CURRENT_SAVE_VERSION } from '../engine/persistence.js';
 import { RESOURCES } from '../data/resources.js';
-import { BUILDINGS } from '../data/buildings.js';
+import { buildInitialPowerTypeOrder } from '../engine/power.js';
 import { makeRandomSettler } from '../data/names.js';
 import { RADIO_BASE_SECONDS } from '../data/settlement.js';
 import { BALANCE } from '../data/balance.js';
@@ -21,20 +21,7 @@ const initBuildings = () => ({
   shelter: { count: 1 },
 });
 
-const initPowerTypePriority = () => {
-  const result = {};
-  const orderCounters = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
-  BUILDINGS.forEach((b) => {
-    if (!b.inputsPerSecBase?.power && !b.poweredMode) return;
-    let priority = 1;
-    if (b.category === 'Food') priority = 5;
-    else if (b.type === 'processing') priority = 3;
-    else if (b.category === 'Raw Materials') priority = 2;
-    const order = orderCounters[priority]++;
-    result[b.id] = { priority, order };
-  });
-  return result;
-};
+const initPowerTypeOrder = () => buildInitialPowerTypeOrder([]);
 
 const initSettlers = () => [makeRandomSettler()];
 
@@ -56,7 +43,7 @@ export const defaultState = {
   ui: { activeTab: 'base', drawerOpen: false, offlineProgress: null },
   resources: initResources(),
   buildings: initBuildings(),
-  powerTypePriority: initPowerTypePriority(),
+  powerTypeOrder: initPowerTypeOrder(),
   research: initResearch(),
   population: { settlers: initSettlers(), candidate: null },
   colony: initColony(),


### PR DESCRIPTION
## Summary
- add utilities to discover powered building types and seed deterministic powerTypeOrder
- store power priorities as ordered type IDs and expose draggable modal to adjust ordering
- move "Set priorities" control to bottom of Energy sidebar and mark Radio as powered

## Testing
- `npm test`
- `npm run lint` *(fails: README-dev.md, src/dev/economyMath.ts, src/dev/economyReporter.ts, src/views/ResearchView.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_689b576db6e4833194f2003aa1323822