### PR TITLE
Refactor game context to TypeScript

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,7 @@ import BaseView from './views/BaseView.jsx';
 import PopulationView from './views/PopulationView.jsx';
 import ResearchView from './views/ResearchView.jsx';
 import ExpeditionsView from './views/ExpeditionsView.jsx';
-import { useGame } from './state/useGame.js';
+import { useGame } from './state/useGame.ts';
 
 function ActiveView() {
   const { state } = useGame();

--- a/src/components/BottomDock.jsx
+++ b/src/components/BottomDock.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useGame } from '../state/useGame.js';
+import { useGame } from '../state/useGame.ts';
 
 const tabs = [
   { id: 'base', icon: '🏠', label: 'Base' },

--- a/src/components/BottomDock.test.jsx
+++ b/src/components/BottomDock.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import BottomDock from './BottomDock.jsx';
-import { GameContext } from '../state/useGame.js';
+import { GameContext } from '../state/useGame.ts';
 
 describe('BottomDock accessibility', () => {
   it('announces accessible labels for buttons', () => {

--- a/src/components/CandidateBox.tsx
+++ b/src/components/CandidateBox.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from 'react';
-import { useGame } from '../state/useGame.js';
+import { useGame } from '../state/useGame.ts';
 import { SKILL_LABELS } from '../data/roles.js';
 import { RADIO_BASE_SECONDS } from '../data/settlement.js';
 import { candidateToSettler } from '../engine/candidates.js';
@@ -17,13 +17,12 @@ interface Candidate {
 }
 
 export default function CandidateBox(): JSX.Element | null {
-  const { state, setState } = useGame() as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  const { state, setState } = useGame();
   const candidate: Candidate | null = state.population?.candidate ?? null;
   if (!candidate) return null;
 
   const accept = (): void => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    setState((prev: any) => {
+    setState((prev) => {
       const settlers = [
         ...prev.population.settlers,
         candidateToSettler(candidate),
@@ -37,8 +36,7 @@ export default function CandidateBox(): JSX.Element | null {
   };
 
   const reject = (): void => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    setState((prev: any) => ({
+    setState((prev) => ({
       ...prev,
       population: { ...prev.population, candidate: null },
       colony: { ...prev.colony, radioTimer: RADIO_BASE_SECONDS },

--- a/src/components/CorruptSaveModal.jsx
+++ b/src/components/CorruptSaveModal.jsx
@@ -1,4 +1,4 @@
-import { useGame } from '../state/useGame.js';
+import { useGame } from '../state/useGame.ts';
 
 export default function CorruptSaveModal() {
   const { loadError, retryLoad, resetGame } = useGame();

--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -1,5 +1,5 @@
 import { useRef } from 'react';
-import { useGame } from '../state/useGame.js';
+import { useGame } from '../state/useGame.ts';
 import { exportSaveFile, load } from '../engine/persistence.js';
 import { createLogEntry } from '../utils/log.js';
 

--- a/src/components/OfflineProgressModal.jsx
+++ b/src/components/OfflineProgressModal.jsx
@@ -1,4 +1,4 @@
-import { useGame } from '../state/useGame.js';
+import { useGame } from '../state/useGame.ts';
 import { formatTime } from '../utils/time.js';
 
 export default function OfflineProgressModal() {

--- a/src/components/PowerPriorityModal.jsx
+++ b/src/components/PowerPriorityModal.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BUILDINGS } from '../data/buildings.js';
-import { useGame } from '../state/useGame.js';
+import { useGame } from '../state/useGame.ts';
 
 export default function PowerPriorityModal({ onClose }) {
   const { state } = useGame();

--- a/src/components/ResourceSidebar.jsx
+++ b/src/components/ResourceSidebar.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useGame } from '../state/useGame.js';
+import { useGame } from '../state/useGame.ts';
 import Accordion from './Accordion.jsx';
 import PowerPriorityModal from './PowerPriorityModal.jsx';
 import ResourceRow from './ResourceRow.jsx';

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 import type { JSX } from 'react';
 import { getSeasonModifiers, getTimeBreakdown } from '../engine/time.js';
-import { useGame } from '../state/useGame.js';
+import { useGame } from '../state/useGame.ts';
 
 export default function TopBar(): JSX.Element {
-  const { state, toggleDrawer } = useGame() as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  const { state, toggleDrawer } = useGame();
   const time = getTimeBreakdown(state);
   const modifiers: Record<string, number> = getSeasonModifiers(state);
   const [open, setOpen] = useState<boolean>(false);
@@ -13,8 +13,11 @@ export default function TopBar(): JSX.Element {
   const avgHappiness =
     settlers.length > 0
       ? Math.round(
-          settlers.reduce((sum, s) => sum + (s.happiness || 0), 0) /
-            settlers.length,
+          settlers.reduce(
+            (sum: number, s: { happiness?: number }) =>
+              sum + (s.happiness || 0),
+            0,
+          ) / settlers.length,
         )
       : 0;
 

--- a/src/state/GameContext.jsx
+++ b/src/state/GameContext.jsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { GameContext } from './useGame.js';
+import { GameContext } from './useGame.ts';
 import useGameLoop from '../engine/useGameLoop.ts';
 import { saveGame, loadGame, deleteSave } from '../engine/persistence.js';
 import { processTick, applyOfflineProgress } from '../engine/production.js';

--- a/src/state/__tests__/GameContext.test.jsx
+++ b/src/state/__tests__/GameContext.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { GameProvider } from '../GameContext.jsx';
-import { useGame } from '../useGame.js';
+import { useGame } from '../useGame.ts';
 import { loadGame } from '../../engine/persistence.js';
 
 vi.mock('../../engine/persistence.js', () => ({

--- a/src/state/useGame.js
+++ b/src/state/useGame.js
@@ -1,7 +1,0 @@
-import { createContext, useContext } from 'react';
-
-export const GameContext = createContext(null);
-
-export function useGame() {
-  return useContext(GameContext);
-}

--- a/src/state/useGame.ts
+++ b/src/state/useGame.ts
@@ -1,0 +1,33 @@
+import {
+  createContext,
+  useContext,
+  type Dispatch,
+  type SetStateAction,
+} from 'react';
+export interface GameState {
+  [key: string]: any;
+}
+
+export interface GameContextValue {
+  state: GameState;
+  setActiveTab: (tab: string) => void;
+  toggleDrawer: () => void;
+  setSettlerRole: (id: string, role: string | null) => void;
+  beginResearch: (id: string) => void;
+  abortResearch: () => void;
+  setState: Dispatch<SetStateAction<GameState>>;
+  dismissOfflineModal: () => void;
+  resetGame: () => void;
+  loadError: boolean;
+  retryLoad: () => void;
+}
+
+export const GameContext = createContext<GameContextValue | null>(null);
+
+export function useGame(): GameContextValue {
+  const ctx = useContext(GameContext);
+  if (!ctx) {
+    throw new Error('useGame must be used within a GameProvider');
+  }
+  return ctx;
+}

--- a/src/views/BaseView.jsx
+++ b/src/views/BaseView.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useGame } from '../state/useGame.js';
+import { useGame } from '../state/useGame.ts';
 import EventLog from '../components/EventLog.jsx';
 import ResourceSidebar from '../components/ResourceSidebar.jsx';
 import Accordion from '../components/Accordion.jsx';

--- a/src/views/PopulationView.jsx
+++ b/src/views/PopulationView.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useGame } from '../state/useGame.js';
+import { useGame } from '../state/useGame.ts';
 import { formatAge } from '../utils/format.js';
 import { computeRoleBonuses } from '../engine/settlers.js';
 import { XP_TIME_TO_NEXT_LEVEL_SECONDS } from '../data/balance.js';

--- a/src/views/ResearchView.jsx
+++ b/src/views/ResearchView.jsx
@@ -1,4 +1,4 @@
-import { useGame } from '../state/useGame.js';
+import { useGame } from '../state/useGame.ts';
 import ResearchTree from './research/ResearchTree.jsx';
 import { RESEARCH_MAP } from '../data/research.js';
 import { formatTime } from '../utils/time.js';
@@ -11,9 +11,7 @@ export default function ResearchView() {
   const remaining = node ? Math.max(node.timeSec - progress, 0) : 0;
   const pct = node ? Math.min(progress / node.timeSec, 1) : 0;
   return (
-
     <div className="p-4 pb-20 space-y-4 h-full flex flex-col">
-
       <div className="border border-stroke rounded p-4 bg-bg2/50">
         {current && node ? (
           <div className="space-y-2">

--- a/src/views/__tests__/BaseView.test.jsx
+++ b/src/views/__tests__/BaseView.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect } from 'vitest';
-import { useGame } from '../../state/useGame.js';
+import { useGame } from '../../state/useGame.ts';
 import EventLog from '../../components/EventLog.jsx';
 import ResourceSidebar from '../../components/ResourceSidebar.jsx';
 import Accordion from '../../components/Accordion.jsx';

--- a/src/views/__tests__/PopulationView.test.jsx
+++ b/src/views/__tests__/PopulationView.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { describe, expect, test, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import PopulationView from '../PopulationView.jsx';
-import { GameContext } from '../../state/useGame.js';
+import { GameContext } from '../../state/useGame.ts';
 
 describe('PopulationView', () => {
   test('shows idle settlers and propagates role changes', () => {

--- a/src/views/research/ResearchTree.jsx
+++ b/src/views/research/ResearchTree.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { RESEARCH, RESEARCH_MAP } from '../../data/research.js';
 import ResearchNode from './ResearchNode.jsx';
-import { useGame } from '../../state/useGame.js';
+import { useGame } from '../../state/useGame.ts';
 import { RESOURCES } from '../../data/resources.js';
 
 function evaluate(node, state) {


### PR DESCRIPTION
## Summary
- add a typed `GameContextValue` interface and `useGame` hook in TypeScript
- update all consumers to import `useGame.ts`
- drop temporary `as any` casts in TopBar and CandidateBox

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues in README-dev.md, src/data/buildings.js, src/dev/economyMath.ts, src/dev/economyReporter.ts)*
- `npm run typecheck` *(fails: type errors in src/dev/economyMath.ts and related tests)*

------
https://chatgpt.com/codex/tasks/task_e_689b5774514c8331b9ec2ba30e31cc86