### PR TITLE
refactor: hoist constant objects

### DIFF
--- a/src/components/PowerPriorityModal.jsx
+++ b/src/components/PowerPriorityModal.jsx
@@ -2,27 +2,27 @@ import React from 'react';
 import { BUILDINGS } from '../data/buildings.js';
 import { useGame } from '../state/useGame.js';
 
+const POWER_CONSUMERS = BUILDINGS.filter(
+  (b) => b.inputsPerSecBase?.power || b.poweredMode,
+);
+const PRIORITY_LEVELS = [5, 4, 3, 2, 1];
+
 export default function PowerPriorityModal({ onClose }) {
   const { state } = useGame();
-  const consumers = BUILDINGS.filter(
-    (b) => b.inputsPerSecBase?.power || b.poweredMode,
-  );
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
       <div className="bg-bg2 p-4 rounded shadow max-w-md w-full">
         <h2 className="text-lg mb-4">Power priorities</h2>
         <div className="space-y-2 max-h-64 overflow-y-auto">
-          {[5, 4, 3, 2, 1].map((p) => (
+          {PRIORITY_LEVELS.map((p) => (
             <details key={p} open>
               <summary className="font-semibold">Priority {p}</summary>
               <ul className="pl-4 list-disc">
-                {consumers
-                  .filter(
-                    (c) => state.powerTypePriority?.[c.id]?.priority === p,
-                  )
-                  .map((c) => (
-                    <li key={c.id}>{c.name}</li>
-                  ))}
+                {POWER_CONSUMERS.filter(
+                  (c) => state.powerTypePriority?.[c.id]?.priority === p,
+                ).map((c) => (
+                  <li key={c.id}>{c.name}</li>
+                ))}
               </ul>
             </details>
           ))}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -3,12 +3,13 @@ import type { JSX } from 'react';
 import { getSeasonModifiers, getTimeBreakdown } from '../engine/time.js';
 import { useGame } from '../state/useGame.js';
 
+const CATEGORY_LABELS: Record<string, string> = { FOOD: 'Food', RAW: 'Raw' };
+
 export default function TopBar(): JSX.Element {
   const { state, toggleDrawer } = useGame() as any; // eslint-disable-line @typescript-eslint/no-explicit-any
   const time = getTimeBreakdown(state);
   const modifiers: Record<string, number> = getSeasonModifiers(state);
   const [open, setOpen] = useState<boolean>(false);
-  const labels: Record<string, string> = { FOOD: 'Food', RAW: 'Raw' };
   const settlers = state.population?.settlers || [];
   const avgHappiness =
     settlers.length > 0
@@ -42,7 +43,7 @@ export default function TopBar(): JSX.Element {
           >
             {Object.entries(modifiers).map(([key, val]) => (
               <div key={key} className="whitespace-nowrap">
-                {labels[key] || key} x{val.toFixed(2)}
+                {CATEGORY_LABELS[key] || key} x{val.toFixed(2)}
               </div>
             ))}
           </div>

--- a/src/views/BaseView.jsx
+++ b/src/views/BaseView.jsx
@@ -16,6 +16,16 @@ import { formatAmount } from '../utils/format.js';
 import { clampResource, demolishBuilding } from '../engine/production.js';
 import { RESEARCH_MAP } from '../data/research.js';
 
+const GROUP_ORDER = [
+  'Food',
+  'Raw Materials',
+  'Construction Materials',
+  'Science',
+  'Energy',
+  'Settlement',
+  'Utilities',
+];
+
 function BuildingRow({ building, completedResearch }) {
   const { state, setState } = useGame();
   const count = state.buildings[building.id]?.count || 0;
@@ -193,15 +203,6 @@ export default function BaseView() {
     if (!prodGroups[cat]) prodGroups[cat] = [];
     prodGroups[cat].push(b);
   });
-  const GROUP_ORDER = [
-    'Food',
-    'Raw Materials',
-    'Construction Materials',
-    'Science',
-    'Energy',
-    'Settlement',
-    'Utilities',
-  ];
   const prodGroupKeys = [
     ...GROUP_ORDER.filter((g) => prodGroups[g]),
     ...Object.keys(prodGroups).filter((k) => !GROUP_ORDER.includes(k)),

--- a/src/views/PopulationView.jsx
+++ b/src/views/PopulationView.jsx
@@ -7,6 +7,11 @@ import { ROLE_LIST, SKILL_LABELS } from '../data/roles.js';
 import { RESOURCES } from '../data/resources.js';
 import { getSettlerCapacity } from '../state/selectors.js';
 
+const BONUS_LABELS = ROLE_LIST.reduce((acc, r) => {
+  acc[r.id] = RESOURCES[r.resource].name;
+  return acc;
+}, {});
+
 export default function PopulationView() {
   const { state, setSettlerRole } = useGame();
   const [onlyLiving, setOnlyLiving] = useState(true);
@@ -21,10 +26,6 @@ export default function PopulationView() {
   const living = settlers.filter((s) => !s.isDead).length;
   const capacity = getSettlerCapacity(state);
   const bonuses = computeRoleBonuses(settlers);
-  const bonusLabels = {};
-  ROLE_LIST.forEach((r) => {
-    bonusLabels[r.id] = RESOURCES[r.resource].name;
-  });
 
   return (
     <div className="h-full overflow-y-auto p-4 space-y-4 pb-20">
@@ -35,7 +36,7 @@ export default function PopulationView() {
             {living}/{capacity}
           </div>
         </div>
-        {Object.entries(bonusLabels).map(([role, label]) => (
+        {Object.entries(BONUS_LABELS).map(([role, label]) => (
           <div
             key={role}
             className="border border-stroke rounded p-3 bg-bg2/50 text-center"

--- a/src/views/research/ResearchTree.jsx
+++ b/src/views/research/ResearchTree.jsx
@@ -4,6 +4,12 @@ import ResearchNode from './ResearchNode.jsx';
 import { useGame } from '../../state/useGame.js';
 import { RESOURCES } from '../../data/resources.js';
 
+const RESEARCH_ROWS = [];
+RESEARCH.forEach((r) => {
+  RESEARCH_ROWS[r.row] = RESEARCH_ROWS[r.row] || [];
+  RESEARCH_ROWS[r.row].push(r);
+});
+
 function evaluate(node, state) {
   const completed = state.research.completed || [];
   if (completed.includes(node.id)) return { status: 'completed', reasons: {} };
@@ -74,12 +80,6 @@ export default function ResearchTree({ onStart }) {
     return () => window.removeEventListener('resize', computeLines);
   }, [computeLines]);
 
-  const rows = [];
-  RESEARCH.forEach((r) => {
-    rows[r.row] = rows[r.row] || [];
-    rows[r.row].push(r);
-  });
-
   return (
     <div ref={containerRef} className="relative overflow-auto h-full">
       <svg className="absolute inset-0 pointer-events-none">
@@ -110,7 +110,7 @@ export default function ResearchTree({ onStart }) {
         ))}
       </svg>
       <div className="flex flex-col gap-8 relative z-10 py-4">
-        {rows.map((nodes, idx) => (
+        {RESEARCH_ROWS.map((nodes, idx) => (
           <div key={idx} className="flex gap-8 justify-center">
             {nodes.map((node) => {
               const { status, reasons } = evaluate(node, state);


### PR DESCRIPTION
## Summary
- move power priority lists and consumers outside modal
- extract shared labels for TopBar and population bonuses
- compute research tree rows and base group ordering once

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b577afe748331b7dea854e4a9eab0