### PR TITLE
refactor: hoist constant configs

### DIFF
--- a/src/views/BaseView.jsx
+++ b/src/views/BaseView.jsx
@@ -169,6 +169,16 @@ function BuildingRow({ building, completedResearch }) {
   );
 }
 
+export const GROUP_ORDER = [
+  'Food',
+  'Raw Materials',
+  'Construction Materials',
+  'Science',
+  'Energy',
+  'Settlement',
+  'Utilities',
+];
+
 export default function BaseView() {
   const { state } = useGame();
   const completedResearch = state.research.completed || [];
@@ -193,15 +203,6 @@ export default function BaseView() {
     if (!prodGroups[cat]) prodGroups[cat] = [];
     prodGroups[cat].push(b);
   });
-  const GROUP_ORDER = [
-    'Food',
-    'Raw Materials',
-    'Construction Materials',
-    'Science',
-    'Energy',
-    'Settlement',
-    'Utilities',
-  ];
   const prodGroupKeys = [
     ...GROUP_ORDER.filter((g) => prodGroups[g]),
     ...Object.keys(prodGroups).filter((k) => !GROUP_ORDER.includes(k)),

--- a/src/views/PopulationView.jsx
+++ b/src/views/PopulationView.jsx
@@ -7,6 +7,11 @@ import { ROLE_LIST, SKILL_LABELS } from '../data/roles.js';
 import { RESOURCES } from '../data/resources.js';
 import { getSettlerCapacity } from '../state/selectors.js';
 
+const BONUS_LABELS = ROLE_LIST.reduce((acc, r) => {
+  acc[r.id] = RESOURCES[r.resource].name;
+  return acc;
+}, {});
+
 export default function PopulationView() {
   const { state, setSettlerRole } = useGame();
   const [onlyLiving, setOnlyLiving] = useState(true);
@@ -21,10 +26,6 @@ export default function PopulationView() {
   const living = settlers.filter((s) => !s.isDead).length;
   const capacity = getSettlerCapacity(state);
   const bonuses = computeRoleBonuses(settlers);
-  const bonusLabels = {};
-  ROLE_LIST.forEach((r) => {
-    bonusLabels[r.id] = RESOURCES[r.resource].name;
-  });
 
   return (
     <div className="h-full overflow-y-auto p-4 space-y-4 pb-20">
@@ -35,7 +36,7 @@ export default function PopulationView() {
             {living}/{capacity}
           </div>
         </div>
-        {Object.entries(bonusLabels).map(([role, label]) => (
+        {Object.entries(BONUS_LABELS).map(([role, label]) => (
           <div
             key={role}
             className="border border-stroke rounded p-3 bg-bg2/50 text-center"

--- a/src/views/research/ResearchTree.jsx
+++ b/src/views/research/ResearchTree.jsx
@@ -4,6 +4,12 @@ import ResearchNode from './ResearchNode.jsx';
 import { useGame } from '../../state/useGame.ts';
 import { RESOURCES } from '../../data/resources.js';
 
+const RESEARCH_ROWS = RESEARCH.reduce((acc, r) => {
+  acc[r.row] = acc[r.row] || [];
+  acc[r.row].push(r);
+  return acc;
+}, []);
+
 function evaluate(node, state) {
   const completed = state.research.completed || [];
   if (completed.includes(node.id)) return { status: 'completed', reasons: {} };
@@ -74,12 +80,6 @@ export default function ResearchTree({ onStart }) {
     return () => window.removeEventListener('resize', computeLines);
   }, [computeLines]);
 
-  const rows = [];
-  RESEARCH.forEach((r) => {
-    rows[r.row] = rows[r.row] || [];
-    rows[r.row].push(r);
-  });
-
   return (
     <div ref={containerRef} className="relative overflow-auto h-full">
       <svg className="absolute inset-0 pointer-events-none">
@@ -110,7 +110,7 @@ export default function ResearchTree({ onStart }) {
         ))}
       </svg>
       <div className="flex flex-col gap-8 relative z-10 py-4">
-        {rows.map((nodes, idx) => (
+        {RESEARCH_ROWS.map((nodes, idx) => (
           <div key={idx} className="flex gap-8 justify-center">
             {nodes.map((node) => {
               const { status, reasons } = evaluate(node, state);


### PR DESCRIPTION
## Summary
- hoist static group ordering array outside BaseView
- precompute role bonus labels at module scope in PopulationView
- precompute research node rows outside ResearchTree component

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 6 files. Run Prettier with --write to fix.)*


------
https://chatgpt.com/codex/tasks/task_e_689b5f8fb70083319a2feffb29db0f1e