### PR TITLE
Refactor game context into composable hooks

### DIFF
--- a/src/state/__tests__/prepareLoadedState.test.js
+++ b/src/state/__tests__/prepareLoadedState.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { prepareLoadedState } from '../GameContext.jsx';
+import { prepareLoadedState } from '../prepareLoadedState.ts';
 import { defaultState } from '../defaultState.js';
 
 // Test that offline gains produce log entries

--- a/src/state/hooks/useAutosave.ts
+++ b/src/state/hooks/useAutosave.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react';
+import { saveGame } from '../../engine/persistence.js';
+
+export default function useAutosave(state: any, setState: any) {
+  const stateRef = useRef(state);
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
+  useEffect(() => {
+    const save = () => {
+      setState(() => saveGame(stateRef.current));
+    };
+    const id = setInterval(save, 10000);
+    window.addEventListener('beforeunload', save);
+    return () => {
+      clearInterval(id);
+      window.removeEventListener('beforeunload', save);
+    };
+  }, [setState]);
+}

--- a/src/state/hooks/useGameActions.ts
+++ b/src/state/hooks/useGameActions.ts
@@ -1,0 +1,106 @@
+import { useCallback } from 'react';
+import { ROLE_BUILDINGS } from '../../data/roles.js';
+import { createLogEntry } from '../../utils/log.js';
+import { startResearch, cancelResearch } from '../../engine/research.js';
+import { loadGame, deleteSave, saveGame } from '../../engine/persistence.js';
+import { defaultState } from '../defaultState.js';
+import { prepareLoadedState } from '../prepareLoadedState.ts';
+
+export default function useGameActions(
+  setState: any,
+  setLoadError: (err: boolean) => void,
+) {
+  const setActiveTab = useCallback(
+    (tab: string) => {
+      setState((prev: any) => ({
+        ...prev,
+        ui: { ...prev.ui, activeTab: tab },
+      }));
+    },
+    [setState],
+  );
+
+  const toggleDrawer = useCallback(() => {
+    setState((prev: any) => ({
+      ...prev,
+      ui: { ...prev.ui, drawerOpen: !prev.ui.drawerOpen },
+    }));
+  }, [setState]);
+
+  const setSettlerRole = useCallback(
+    (id: string, role: string | null) => {
+      setState((prev: any) => {
+        const settler = prev.population.settlers.find((s: any) => s.id === id);
+        if (!settler) return prev;
+        const normalized = role === 'idle' ? null : role;
+        if (normalized) {
+          const building =
+            ROLE_BUILDINGS[normalized as keyof typeof ROLE_BUILDINGS];
+          const count = prev.buildings?.[building]?.count || 0;
+          if (count <= 0) return prev;
+        }
+        const settlers = prev.population.settlers.map((s: any) =>
+          s.id === id ? { ...s, role: normalized } : s,
+        );
+        const roleName = normalized ?? 'idle';
+        const entry = createLogEntry(
+          `${settler.firstName} ${settler.lastName} is now ${roleName}`,
+        );
+        const log = [entry, ...prev.log].slice(0, 100);
+        return { ...prev, population: { ...prev.population, settlers }, log };
+      });
+    },
+    [setState],
+  );
+
+  const beginResearch = useCallback(
+    (id: string) => {
+      setState((prev: any) => startResearch(prev, id));
+    },
+    [setState],
+  );
+
+  const abortResearch = useCallback(() => {
+    setState((prev: any) => cancelResearch(prev));
+  }, [setState]);
+
+  const dismissOfflineModal = useCallback(() => {
+    setState((prev: any) => ({
+      ...prev,
+      ui: { ...prev.ui, offlineProgress: null },
+    }));
+  }, [setState]);
+
+  const retryLoad = useCallback(() => {
+    const { state: loaded, error } = loadGame();
+    if (error) {
+      setLoadError(true);
+      return;
+    }
+    setLoadError(false);
+    if (loaded) {
+      setState(prepareLoadedState(loaded));
+    }
+  }, [setState, setLoadError]);
+
+  const resetGame = useCallback(() => {
+    if (window.confirm('Reset colony? This will wipe your save.')) {
+      deleteSave();
+      const fresh = { ...defaultState, lastSaved: Date.now() };
+      setState(fresh);
+      saveGame(fresh);
+      setLoadError(false);
+    }
+  }, [setState, setLoadError]);
+
+  return {
+    setActiveTab,
+    toggleDrawer,
+    setSettlerRole,
+    beginResearch,
+    abortResearch,
+    dismissOfflineModal,
+    retryLoad,
+    resetGame,
+  };
+}

--- a/src/state/hooks/useGameTick.ts
+++ b/src/state/hooks/useGameTick.ts
@@ -1,0 +1,69 @@
+import { Dispatch, SetStateAction } from 'react';
+import useGameLoop from '../../engine/useGameLoop.ts';
+import { processTick } from '../../engine/production.js';
+import { processResearchTick } from '../../engine/research.js';
+import { getResourceRates } from '../selectors.js';
+import { RESOURCES } from '../../data/resources.js';
+import {
+  processSettlersTick,
+  computeRoleBonuses,
+} from '../../engine/settlers.js';
+import { updateRadio } from '../../engine/radio.js';
+import { getYear, DAYS_PER_YEAR } from '../../engine/time.js';
+
+export default function useGameTick(setState: Dispatch<SetStateAction<any>>) {
+  useGameLoop((dt) => {
+    setState((prev) => {
+      const roleBonuses = computeRoleBonuses(prev.population?.settlers || []);
+      const productionBonuses = { ...roleBonuses };
+      delete productionBonuses.farmer;
+      const afterTick = processTick(prev, dt, productionBonuses);
+      const withResearch = processResearchTick(afterTick, dt, roleBonuses);
+      const rates = getResourceRates(withResearch);
+      let totalFoodProdBase = 0;
+      Object.keys(RESOURCES).forEach((id) => {
+        if (RESOURCES[id].category === 'FOOD') {
+          totalFoodProdBase += rates[id]?.perSec || 0;
+        }
+      });
+      const bonusFoodPerSec =
+        totalFoodProdBase * ((roleBonuses['farmer'] || 0) / 100);
+      const { state: settlersProcessed, telemetry } = processSettlersTick(
+        withResearch,
+        dt,
+        bonusFoodPerSec,
+        Math.random,
+        roleBonuses,
+      );
+      const { candidate, radioTimer } = updateRadio(settlersProcessed, dt);
+      const nextSeconds = (settlersProcessed.gameTime?.seconds || 0) + dt;
+      const computedYear = getYear({
+        ...settlersProcessed,
+        gameTime: { ...settlersProcessed.gameTime, seconds: nextSeconds },
+      });
+      let year = settlersProcessed.gameTime?.year || 1;
+      let settlers = settlersProcessed.population.settlers;
+      if (computedYear > year) {
+        const diff = computedYear - year;
+        year = computedYear;
+        settlers = settlers.map((s: any) => ({
+          ...s,
+          ageDays: (s.ageDays || 0) + diff * DAYS_PER_YEAR,
+        }));
+      }
+      return {
+        ...settlersProcessed,
+        population: { ...settlersProcessed.population, settlers, candidate },
+        colony: { ...settlersProcessed.colony, radioTimer },
+        gameTime: { seconds: nextSeconds, year },
+        meta: {
+          ...settlersProcessed.meta,
+          telemetry: {
+            ...settlersProcessed.meta?.telemetry,
+            settlers: telemetry,
+          },
+        },
+      };
+    });
+  }, 1000);
+}

--- a/src/state/prepareLoadedState.ts
+++ b/src/state/prepareLoadedState.ts
@@ -1,0 +1,82 @@
+import { defaultState } from './defaultState.js';
+import { getYear, initSeasons, SECONDS_PER_DAY } from '../engine/time.js';
+import { computeRoleBonuses } from '../engine/settlers.js';
+import { applyOfflineProgress } from '../engine/production.js';
+import { createLogEntry } from '../utils/log.js';
+import { RESOURCES } from '../data/resources.js';
+import { formatAmount } from '../utils/format.js';
+import { buildInitialPowerTypeOrder } from '../engine/power.js';
+
+/* eslint-disable-next-line react-refresh/only-export-components */
+export function prepareLoadedState(loaded: any) {
+  const cloned = structuredClone(loaded || {});
+  const gameTime =
+    typeof cloned.gameTime === 'number'
+      ? { seconds: cloned.gameTime }
+      : cloned.gameTime || { seconds: 0 };
+  const base = structuredClone(defaultState);
+  base.version = cloned.version ?? base.version;
+  base.gameTime = { ...base.gameTime, ...gameTime };
+  base.meta = { ...base.meta, ...cloned.meta, seasons: initSeasons() };
+  base.ui = { ...base.ui, ...cloned.ui };
+  base.resources = { ...base.resources, ...cloned.resources };
+  base.buildings = { ...base.buildings, ...cloned.buildings };
+  base.powerTypeOrder = buildInitialPowerTypeOrder(cloned.powerTypeOrder || []);
+  base.research = { ...base.research, ...cloned.research };
+  base.population = { ...base.population, ...cloned.population };
+  if (Array.isArray(cloned.population?.settlers)) {
+    base.population.settlers = cloned.population.settlers.map((s: any) => ({
+      ...s,
+    }));
+  }
+  base.colony = { ...base.colony, ...cloned.colony };
+  if (Array.isArray(cloned.log)) {
+    base.log = [...cloned.log];
+  }
+  base.lastSaved = cloned.lastSaved ?? base.lastSaved;
+  const prevYear = base.gameTime.year || getYear(base);
+  base.gameTime.year = prevYear;
+  const now = Date.now();
+  const elapsed = Math.floor((now - (cloned.lastSaved || now)) / 1000);
+  if (elapsed > 0) {
+    const bonuses = computeRoleBonuses(base.population?.settlers || []);
+    const { state: progressed, gains } = applyOfflineProgress(
+      base,
+      elapsed,
+      bonuses,
+    );
+    const offlineLogs = Object.entries(gains).map(([res, amt]) =>
+      createLogEntry(
+        `Gained ${formatAmount(amt)} ${RESOURCES[res].name} while offline`,
+        now,
+      ),
+    );
+    const secondsAfter = (progressed.gameTime?.seconds || 0) + elapsed;
+    const yearAfter = getYear({
+      ...progressed,
+      gameTime: { ...progressed.gameTime, seconds: secondsAfter },
+    });
+    const settlers = progressed.population.settlers.map((s: any) => ({
+      ...s,
+      ageDays: (s.ageDays || 0) + elapsed / SECONDS_PER_DAY,
+    }));
+    const show = Object.keys(gains).length > 0;
+    const log = [...offlineLogs, ...(progressed.log || [])].slice(0, 100);
+    return {
+      ...progressed,
+      population: { ...progressed.population, settlers },
+      gameTime: { seconds: secondsAfter, year: yearAfter },
+      ui: {
+        ...progressed.ui,
+        offlineProgress: show ? { elapsed, gains } : null,
+      },
+      log,
+      lastSaved: now,
+    };
+  }
+  return {
+    ...base,
+    gameTime: { ...base.gameTime, year: prevYear },
+    lastSaved: now,
+  };
+}


### PR DESCRIPTION
## Summary
- move `prepareLoadedState` to dedicated module
- extract game tick, autosave, and UI callbacks into custom hooks
- streamline `GameProvider` to compose new hooks

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 11 files)*
- `npm run typecheck` *(fails: TS2345, TS7053, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689b675810b083319bc7ecfa5cc356d8