### PR TITLE
refactor: centralize button component

### DIFF
--- a/src/components/BuildingRow.jsx
+++ b/src/components/BuildingRow.jsx
@@ -7,6 +7,7 @@ import { getCapacity } from '../state/selectors.js';
 import { formatAmount } from '../utils/format.js';
 import { clampResource, demolishBuilding } from '../engine/production.js';
 import { RESEARCH_MAP } from '../data/research.js';
+import { Button } from './Button';
 
 export default function BuildingRow({ building, completedResearch }) {
   const { state, setState } = useGame();
@@ -90,8 +91,9 @@ export default function BuildingRow({ building, completedResearch }) {
           )}
         </div>
         <div className="space-x-2">
-          <button
-            className="px-2 py-1 border border-stroke rounded disabled:opacity-50"
+          <Button
+            variant="outline"
+            size="sm"
             onClick={build}
             disabled={!canAfford || !unlocked || atMax}
             title={
@@ -106,14 +108,15 @@ export default function BuildingRow({ building, completedResearch }) {
             }
           >
             Build
-          </button>
-          <button
-            className="px-2 py-1 border border-stroke rounded disabled:opacity-50"
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
             onClick={demolish}
             disabled={count <= 0}
           >
             Demolish
-          </button>
+          </Button>
         </div>
       </div>
       <div className="text-xs text-muted space-y-1">

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,10 @@
+import type { ComponentProps } from 'react';
+import { Button as ShadcnButton } from './ui/button';
+
+export type ButtonProps = ComponentProps<typeof ShadcnButton>;
+
+export function Button(props: ButtonProps) {
+  return <ShadcnButton {...props} />;
+}
+
+export default Button;

--- a/src/components/CandidateBox.tsx
+++ b/src/components/CandidateBox.tsx
@@ -3,6 +3,7 @@ import { useGame } from '../state/useGame.ts';
 import { SKILL_LABELS } from '../data/roles.js';
 import { RADIO_BASE_SECONDS } from '../data/settlement.js';
 import { candidateToSettler } from '../engine/candidates.js';
+import { Button } from './Button';
 
 interface Skill {
   level: number;
@@ -57,18 +58,12 @@ export default function CandidateBox(): JSX.Element | null {
       </div>
       <div className="text-xs text-muted">{skills || 'No skills'}</div>
       <div className="space-x-2">
-        <button
-          className="px-2 py-1 border border-stroke rounded"
-          onClick={accept}
-        >
+        <Button variant="outline" size="sm" onClick={accept}>
           Accept
-        </button>
-        <button
-          className="px-2 py-1 border border-stroke rounded"
-          onClick={reject}
-        >
+        </Button>
+        <Button variant="outline" size="sm" onClick={reject}>
           Reject
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/components/CorruptSaveModal.jsx
+++ b/src/components/CorruptSaveModal.jsx
@@ -1,4 +1,5 @@
 import { useGame } from '../state/useGame.ts';
+import { Button } from './Button';
 
 export default function CorruptSaveModal() {
   const { loadError, retryLoad, resetGame } = useGame();
@@ -9,18 +10,12 @@ export default function CorruptSaveModal() {
         <h2 className="font-semibold text-lg">Save Load Failed</h2>
         <p>Your save data appears corrupted.</p>
         <div className="flex justify-end gap-2">
-          <button
-            className="px-4 py-2 rounded border border-stroke"
-            onClick={retryLoad}
-          >
+          <Button variant="outline" onClick={retryLoad}>
             Retry
-          </button>
-          <button
-            className="px-4 py-2 rounded border border-stroke"
-            onClick={resetGame}
-          >
+          </Button>
+          <Button variant="outline" onClick={resetGame}>
             Reset
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import { useGame } from '../state/useGame.ts';
 import { exportSaveFile, load } from '../engine/persistence.js';
 import { createLogEntry } from '../utils/log.js';
+import { Button } from './Button';
 
 export default function Drawer() {
   const { state, toggleDrawer, setState, resetGame } = useGame();
@@ -69,8 +70,9 @@ export default function Drawer() {
           <section>
             <h2 className="font-semibold mb-2">💾 Save/Load</h2>
             <div className="flex gap-2">
-              <button
-                className="px-2 py-1 rounded border border-stroke"
+              <Button
+                variant="outline"
+                size="sm"
                 onClick={() => {
                   exportSaveFile(state);
                   setState((prev) => ({
@@ -83,13 +85,14 @@ export default function Drawer() {
                 }}
               >
                 Save
-              </button>
-              <button
-                className="px-2 py-1 rounded border border-stroke"
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
                 onClick={() => fileInput.current?.click()}
               >
                 Load
-              </button>
+              </Button>
               <input
                 ref={fileInput}
                 type="file"
@@ -101,12 +104,9 @@ export default function Drawer() {
           </section>
           <section>
             <h2 className="font-semibold mb-2">🧹 Reset</h2>
-            <button
-              className="px-2 py-1 rounded border border-stroke"
-              onClick={resetGame}
-            >
+            <Button variant="outline" size="sm" onClick={resetGame}>
               Reset colony
-            </button>
+            </Button>
           </section>
         </div>
       </aside>

--- a/src/components/OfflineProgressModal.jsx
+++ b/src/components/OfflineProgressModal.jsx
@@ -1,5 +1,6 @@
 import { useGame } from '../state/useGame.ts';
 import { formatTime } from '../utils/time.js';
+import { Button } from './Button';
 
 export default function OfflineProgressModal() {
   const { state, dismissOfflineModal } = useGame();
@@ -19,12 +20,9 @@ export default function OfflineProgressModal() {
             </div>
           ))}
         </div>
-        <button
-          className="px-4 py-2 rounded border border-stroke"
-          onClick={dismissOfflineModal}
-        >
+        <Button variant="outline" onClick={dismissOfflineModal}>
           Continue
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/components/PowerPriorityModal.jsx
+++ b/src/components/PowerPriorityModal.jsx
@@ -5,6 +5,7 @@ import {
   buildInitialPowerTypeOrder,
   getPoweredConsumerTypeIds,
 } from '../engine/power.js';
+import { Button } from './Button';
 
 export default function PowerPriorityModal({ onClose }) {
   const { state, setState } = useGame();
@@ -65,18 +66,22 @@ export default function PowerPriorityModal({ onClose }) {
                 </div>
                 <div className="flex items-center gap-1">
                   <span className="text-xs text-muted">x{count}</span>
-                  <button
-                    className="text-xs px-1 border rounded"
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="text-xs px-1"
                     onClick={() => move(idx, idx - 1)}
                   >
                     ↑
-                  </button>
-                  <button
-                    className="text-xs px-1 border rounded"
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="text-xs px-1"
                     onClick={() => move(idx, idx + 1)}
                   >
                     ↓
-                  </button>
+                  </Button>
                 </div>
               </li>
             );
@@ -84,15 +89,12 @@ export default function PowerPriorityModal({ onClose }) {
         </ul>
         <div className="text-center text-xs text-muted mt-2">LOW PRIORITY</div>
         <div className="mt-4 flex justify-end gap-2">
-          <button
-            className="px-2 py-1 border rounded text-sm"
-            onClick={onClose}
-          >
+          <Button variant="outline" size="sm" onClick={onClose}>
             Cancel
-          </button>
-          <button className="px-2 py-1 border rounded text-sm" onClick={save}>
+          </Button>
+          <Button variant="outline" size="sm" onClick={save}>
             Save
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { JSX } from 'react';
 import { getSeasonModifiers, getTimeBreakdown } from '../engine/time.js';
 import { useGame } from '../state/useGame.ts';
+import { Button } from './Button';
 
 export default function TopBar(): JSX.Element {
   const { state, toggleDrawer } = useGame();
@@ -26,14 +27,15 @@ export default function TopBar(): JSX.Element {
         <span className="tabular-nums text-sm">
           Avg Happiness: {avgHappiness}%
         </span>
-        <button
-          className="text-xl tabular-nums"
+        <Button
+          variant="ghost"
+          className="text-xl tabular-nums px-0"
           onClick={() => setOpen((o) => !o)}
           onMouseEnter={() => setOpen(true)}
           onMouseLeave={() => setOpen(false)}
         >
           {time.season.icon} {time.season.label}, Day {time.day}
-        </button>
+        </Button>
         {open && (
           <div
             className="absolute top-full right-0 mt-1 p-2 bg-bg2 border border-stroke rounded text-xs shadow-lg"
@@ -47,12 +49,14 @@ export default function TopBar(): JSX.Element {
             ))}
           </div>
         )}
-        <button
-          className="text-xl px-2 py-1 rounded border border-stroke"
+        <Button
+          variant="outline"
+          size="sm"
+          className="text-xl px-2"
           onClick={toggleDrawer}
         >
           ☰
-        </button>
+        </Button>
       </div>
     </header>
   );

--- a/src/views/ResearchView.jsx
+++ b/src/views/ResearchView.jsx
@@ -2,6 +2,7 @@ import { useGame } from '../state/useGame.ts';
 import ResearchTree from './research/ResearchTree.jsx';
 import { RESEARCH_MAP } from '../data/research.js';
 import { formatTime } from '../utils/time.js';
+import { Button } from '@/components/Button';
 
 export default function ResearchView() {
   const { state, beginResearch, abortResearch } = useGame();
@@ -26,14 +27,16 @@ export default function ResearchView() {
             </div>
             <div className="flex justify-between items-center text-sm">
               <span>Time remaining: {formatTime(remaining)}</span>
-              <button
-                className="px-2 py-1 border border-red-400 rounded text-red-300 hover:bg-red-900/20"
+              <Button
+                variant="outline"
+                size="sm"
+                className="border-red-400 text-red-300 hover:bg-red-900/20"
                 onClick={() => {
                   if (window.confirm('Cancel research?')) abortResearch();
                 }}
               >
                 Cancel
-              </button>
+              </Button>
             </div>
           </div>
         ) : (

--- a/src/views/research/ResearchNode.jsx
+++ b/src/views/research/ResearchNode.jsx
@@ -4,6 +4,7 @@ import { RESOURCES } from '../../data/resources.js';
 import { BUILDING_MAP } from '../../data/buildings.js';
 import { formatAmount } from '../../utils/format.js';
 import { formatTime } from '../../utils/time.js';
+import { Button } from '@/components/Button';
 
 function buildTooltip(node) {
   const lines = [];
@@ -87,18 +88,20 @@ const ResearchNode = forwardRef(({ node, status, reasons, onStart }, ref) => {
         Research time: {formatTime(node.timeSec)}
       </div>
       {status === 'available' && (
-        <button
-          className="mt-1 px-2 py-1 border border-blue-400 rounded text-blue-200 hover:bg-blue-900/20"
+        <Button
+          variant="outline"
+          size="sm"
+          className="mt-1 border-blue-400 text-blue-200 hover:bg-blue-900/20"
           onClick={() => onStart(node.id)}
         >
           Start
-        </button>
+        </Button>
       )}
       {status === 'locked' && (
         <div className="mt-1">
-          <button className="px-2 py-1 border rounded opacity-50 cursor-not-allowed">
+          <Button variant="outline" size="sm" disabled>
             Locked
-          </button>
+          </Button>
           <div className="mt-1 space-y-1 text-xs text-red-400">
             {reasons.missingPrereqs?.length > 0 && (
               <div>Require: {reasons.missingPrereqs.join(', ')}</div>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
+import { fileURLToPath, URL } from 'node:url';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath, URL } from 'node:url';
 
 export default defineConfig({
   test: {
     environment: 'jsdom',
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
   },
 });


### PR DESCRIPTION
## Summary
- add Button wrapper around shadcn button
- use shared Button in Drawer, TopBar, modals and related components
- configure Vite and Vitest aliases for `@`

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_689b6ae3d5248331a9c7963f5c11186f