### PR TITLE
Use shadcn overlays for modals and drawer

### DIFF
--- a/src/components/CorruptSaveModal.jsx
+++ b/src/components/CorruptSaveModal.jsx
@@ -1,23 +1,42 @@
 import { useGame } from '../state/useGame.ts';
 import { Button } from './Button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from './ui/dialog';
 
 export default function CorruptSaveModal() {
   const { loadError, retryLoad, resetGame } = useGame();
-  if (!loadError) return null;
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="bg-bg2 p-4 rounded border border-stroke max-w-sm w-full space-y-4">
-        <h2 className="font-semibold text-lg">Save Load Failed</h2>
-        <p>Your save data appears corrupted.</p>
-        <div className="flex justify-end gap-2">
-          <Button variant="outline" onClick={retryLoad}>
-            Retry
-          </Button>
-          <Button variant="outline" onClick={resetGame}>
-            Reset
-          </Button>
-        </div>
-      </div>
-    </div>
+    <Dialog
+      open={loadError}
+      onOpenChange={(open) => {
+        if (!open) retryLoad();
+      }}
+    >
+      {loadError && (
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Save Load Failed</DialogTitle>
+            <DialogDescription>
+              Your save data appears corrupted.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="flex justify-end gap-2">
+            <Button variant="outline" onClick={retryLoad}>
+              Retry
+            </Button>
+            <Button variant="outline" onClick={resetGame}>
+              Reset
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      )}
+    </Dialog>
   );
 }

--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -3,6 +3,7 @@ import { useGame } from '../state/useGame.ts';
 import { exportSaveFile, load } from '../engine/persistence.js';
 import { createLogEntry } from '../utils/log.js';
 import { Button } from './Button';
+import { Sheet, SheetContent } from './ui/sheet';
 
 export default function Drawer() {
   const { state, toggleDrawer, setState, resetGame } = useGame();
@@ -50,14 +51,13 @@ export default function Drawer() {
   };
 
   return (
-    <>
-      <div
-        className={`fixed inset-0 bg-black/50 transition-opacity z-40 ${state.ui.drawerOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
-        onClick={toggleDrawer}
-      />
-      <aside
-        className={`fixed top-0 bottom-0 right-0 w-64 bg-bg2 border-l border-stroke z-50 transform transition-transform ${state.ui.drawerOpen ? 'translate-x-0' : 'translate-x-full'}`}
-      >
+    <Sheet
+      open={state.ui.drawerOpen}
+      onOpenChange={(open) => {
+        if (open !== state.ui.drawerOpen) toggleDrawer();
+      }}
+    >
+      <SheetContent side="right" className="w-64">
         <div className="p-4 space-y-6">
           <section>
             <h2 className="font-semibold mb-2">📊 Statistics</h2>
@@ -109,7 +109,7 @@ export default function Drawer() {
             </Button>
           </section>
         </div>
-      </aside>
-    </>
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/src/components/OfflineProgressModal.jsx
+++ b/src/components/OfflineProgressModal.jsx
@@ -1,29 +1,48 @@
 import { useGame } from '../state/useGame.ts';
 import { formatTime } from '../utils/time.js';
 import { Button } from './Button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from './ui/dialog';
 
 export default function OfflineProgressModal() {
   const { state, dismissOfflineModal } = useGame();
   const info = state.ui.offlineProgress;
-  if (!info) return null;
 
-  const { elapsed, gains } = info;
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="bg-bg2 p-4 rounded border border-stroke max-w-sm w-full space-y-4">
-        <h2 className="font-semibold text-lg">While you were away...</h2>
-        <p>You were gone for {formatTime(elapsed)}</p>
-        <div className="space-y-1">
-          {Object.entries(gains).map(([res, amt]) => (
-            <div key={res}>
-              {res}: {Math.floor(amt)}
-            </div>
-          ))}
-        </div>
-        <Button variant="outline" onClick={dismissOfflineModal}>
-          Continue
-        </Button>
-      </div>
-    </div>
+    <Dialog
+      open={!!info}
+      onOpenChange={(open) => {
+        if (!open) dismissOfflineModal();
+      }}
+    >
+      {info && (
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>While you were away...</DialogTitle>
+            <DialogDescription>
+              You were gone for {formatTime(info.elapsed)}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-1">
+            {Object.entries(info.gains).map(([res, amt]) => (
+              <div key={res}>
+                {res}: {Math.floor(amt)}
+              </div>
+            ))}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={dismissOfflineModal}>
+              Continue
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      )}
+    </Dialog>
   );
 }


### PR DESCRIPTION
## Summary
- replace offline progress and corrupt save modals with shadcn dialogs
- convert drawer into shadcn sheet for consistent overlay behavior
- ensure overlays close on escape or backdrop click

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b6ffc40948331abd737d3f96be562