### PR TITLE
refactor: replace custom css with tokens

### DIFF
--- a/docs/component-guidelines.md
+++ b/docs/component-guidelines.md
@@ -1,0 +1,10 @@
+# Component Usage Guidelines
+
+Components should use the project's design tokens and Tailwind utilities to remain consistent and accessible.
+
+- **Use tokens**: Prefer utilities like `bg-background`, `text-foreground`, or `stroke-muted-foreground` instead of hard-coded values.
+- **Avoid custom CSS**: Replace bespoke rules and hex colors with the available tokens or utilities. Inline styles should only express dynamic values.
+- **Accessibility**: Provide ARIA roles and labels and ensure all interactive elements are keyboard navigable with sufficient color contrast.
+- **Semantics**: Favor semantic HTML and keep layouts and spacing driven by utilities.
+
+Following these practices keeps the interface cohesive and easier to maintain.

--- a/src/views/research/ResearchTree.jsx
+++ b/src/views/research/ResearchTree.jsx
@@ -91,9 +91,8 @@ export default function ResearchTree({ onStart }) {
             refX="5"
             refY="3"
             orient="auto"
-            fill="#666"
           >
-            <polygon points="0 0, 6 3, 0 6" />
+            <polygon points="0 0, 6 3, 0 6" className="fill-muted-foreground" />
           </marker>
         </defs>
         {lines.map((l, i) => (
@@ -103,7 +102,7 @@ export default function ResearchTree({ onStart }) {
             y1={l.y1}
             x2={l.x2}
             y2={l.y2}
-            stroke="#666"
+            className="stroke-muted-foreground"
             strokeWidth="2"
             markerEnd="url(#arrowhead)"
           />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -42,10 +42,6 @@ export default {
         md: 'var(--radius-md)',
         lg: 'var(--radius-lg)',
         xl: 'var(--radius-xl)',
-        xl2: '14px',
-      },
-      boxShadow: {
-        card: '0 6px 20px rgba(0,0,0,.25)',
       },
     },
   },


### PR DESCRIPTION
## Summary
- replace hard-coded SVG colors with token utilities
- drop unused Tailwind styles
- document component usage guidelines

## Testing
- `npm run lint` (fails: 19 files need formatting)
- `npm test`
- `npm run build`
- `npx --yes pa11y dist/index.html` (fails: libatk-1.0.so.0 missing)
- `npx --yes @axe-core/cli dist/index.html` (fails: cannot find Chrome binary)


------
https://chatgpt.com/codex/tasks/task_e_689b764e0fe48331b84899d399616a71