### PR TITLE
refactor: switch to shadcn palette

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,7 +27,7 @@ function ActiveView() {
 export default function App() {
   return (
     <GameProvider>
-      <div className="h-screen flex flex-col bg-bg text-ink overflow-hidden">
+      <div className="h-screen flex flex-col bg-background text-foreground overflow-hidden">
         <TopBar />
         <div className="flex-1 overflow-hidden">
           <ActiveView />

--- a/src/components/Accordion.jsx
+++ b/src/components/Accordion.jsx
@@ -8,7 +8,7 @@ export default function Accordion({
 }) {
   const [open, setOpen] = useState(defaultOpen);
   return (
-    <div className="border-b border-stroke">
+    <div className="border-b border-border">
       <div className="flex items-center justify-between p-2">
         <button
           className="flex-1 flex items-center justify-between"

--- a/src/components/BottomDock.jsx
+++ b/src/components/BottomDock.jsx
@@ -12,7 +12,7 @@ export default function BottomDock() {
   const { state, setActiveTab } = useGame();
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-20 flex border-t border-stroke bg-bg2">
+    <nav className="fixed bottom-0 left-0 right-0 z-20 flex border-t border-border bg-card">
       {tabs.map((t) => (
         <button
           key={t.id}
@@ -21,7 +21,7 @@ export default function BottomDock() {
           aria-current={state.ui.activeTab === t.id ? 'page' : undefined}
           className={`flex-1 py-2 text-xl ${
             state.ui.activeTab === t.id
-              ? 'text-ink bg-panel font-semibold'
+              ? 'text-foreground bg-muted font-semibold'
               : 'text-muted'
           }`}
         >

--- a/src/components/BuildingRow.jsx
+++ b/src/components/BuildingRow.jsx
@@ -75,7 +75,7 @@ export default function BuildingRow({ building, completedResearch }) {
   };
 
   return (
-    <div className="p-2 rounded border border-stroke bg-bg2 space-y-1">
+    <div className="p-2 rounded border border-border bg-card space-y-1">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <span>
@@ -163,4 +163,3 @@ export default function BuildingRow({ building, completedResearch }) {
     </div>
   );
 }
-

--- a/src/components/CandidateBox.tsx
+++ b/src/components/CandidateBox.tsx
@@ -24,7 +24,9 @@ export default function CandidateBox(): JSX.Element | null {
 
   const updateAfterDecision = (accepted: boolean): void => {
     setState((prev) => {
-      const newSettler = candidateToSettler(candidate) as typeof prev.population.settlers[number];
+      const newSettler = candidateToSettler(
+        candidate,
+      ) as (typeof prev.population.settlers)[number];
       const settlers = accepted
         ? [...prev.population.settlers, newSettler]
         : prev.population.settlers;
@@ -50,7 +52,7 @@ export default function CandidateBox(): JSX.Element | null {
     .join(', ');
 
   return (
-    <div className="p-4 border border-stroke bg-bg2 rounded space-y-2">
+    <div className="p-4 border border-border bg-card rounded space-y-2">
       <div className="font-semibold">A new settler has arrived!</div>
       <div className="text-sm">
         {candidate.firstName} {candidate.lastName} •{' '}

--- a/src/components/PowerPriorityModal.jsx
+++ b/src/components/PowerPriorityModal.jsx
@@ -44,7 +44,7 @@ export default function PowerPriorityModal({ onClose }) {
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-bg2 p-4 rounded shadow max-w-md w-full">
+      <div className="bg-card p-4 rounded shadow max-w-md w-full">
         <h2 className="text-lg mb-2 text-left">Power Priorities</h2>
         <div className="text-center text-xs text-muted">TOP PRIORITY</div>
         <ul className="mt-2 space-y-1 max-h-64 overflow-y-auto">
@@ -54,7 +54,7 @@ export default function PowerPriorityModal({ onClose }) {
             return (
               <li
                 key={id}
-                className="flex items-center justify-between border border-stroke rounded px-2 py-1"
+                className="flex items-center justify-between border border-border rounded px-2 py-1"
                 draggable
                 onDragStart={onDragStart(idx)}
                 onDragOver={onDragOver(idx)}

--- a/src/components/ProductionSection.jsx
+++ b/src/components/ProductionSection.jsx
@@ -8,7 +8,7 @@ export default function ProductionSection({
   completedResearch = [],
 }) {
   return (
-    <div className="border border-stroke rounded">
+    <div className="border border-border rounded">
       {productionGroups.map((group) => (
         <Accordion key={group.name} title={group.name} defaultOpen>
           {group.buildings.map((b) => (
@@ -32,4 +32,3 @@ export default function ProductionSection({
     </div>
   );
 }
-

--- a/src/components/ResourceSidebar.jsx
+++ b/src/components/ResourceSidebar.jsx
@@ -12,7 +12,7 @@ export default function ResourceSidebar() {
   const { sections, settlersInfo } = useResourceSections(state);
 
   return (
-    <div className="border border-stroke rounded overflow-hidden bg-bg2">
+    <div className="border border-border rounded overflow-hidden bg-card">
       {sections.map((g) =>
         g.settlers ? (
           <SettlerSection key={g.title} title={g.title} info={settlersInfo} />

--- a/src/components/SettlerSection.jsx
+++ b/src/components/SettlerSection.jsx
@@ -20,7 +20,7 @@ export default function SettlerSection({ title, info }) {
       </div>
       <div className="text-xs text-muted mb-1">{radioLine}</div>
       {radioCount > 0 && !candidatePending && powered && (
-        <div className="h-2 bg-stroke rounded mb-1">
+        <div className="h-2 bg-border rounded mb-1">
           <div
             className="h-full bg-green-600 rounded"
             style={{ width: `${progress * 100}%` }}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -20,7 +20,7 @@ export default function TopBar(): JSX.Element {
       : 0;
 
   return (
-    <header className="sticky top-0 z-10 flex items-center justify-between px-4 py-2 border-b border-stroke bg-bg2">
+    <header className="sticky top-0 z-10 flex items-center justify-between px-4 py-2 border-b border-border bg-card">
       <span className="tabular-nums text-xl">Year {time.year}</span>
       <h1 className="font-semibold">Apocalypse Idle</h1>
       <div className="relative flex items-center gap-2">
@@ -38,7 +38,7 @@ export default function TopBar(): JSX.Element {
         </Button>
         {open && (
           <div
-            className="absolute top-full right-0 mt-1 p-2 bg-bg2 border border-stroke rounded text-xs shadow-lg"
+            className="absolute top-full right-0 mt-1 p-2 bg-card border border-border rounded text-xs shadow-lg"
             onMouseEnter={() => setOpen(true)}
             onMouseLeave={() => setOpen(false)}
           >

--- a/src/index.css
+++ b/src/index.css
@@ -1,100 +1,84 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 
-@custom-variant dark (&:is(.dark *));
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
 
-@theme {
-  --color-ink: #e8edf6;
-  --color-muted: #97a3b6;
-  --color-bg: #0b0e14;
-  --color-bg2: #101522;
-  --color-panel: #151b2b;
-  --color-stroke: #232b3d;
-}
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
 
-:root {
-  color-scheme: dark;
-  --radius: 0.625rem;
-  --background: var(--color-bg);
-  --foreground: var(--color-ink);
-  --card: var(--color-panel);
-  --card-foreground: var(--color-ink);
-  --popover: var(--color-panel);
-  --popover-foreground: var(--color-ink);
-  --primary: var(--color-ink);
-  --primary-foreground: var(--color-bg);
-  --secondary: var(--color-bg2);
-  --secondary-foreground: var(--color-ink);
-  --muted: var(--color-bg2);
-  --muted-foreground: var(--color-muted);
-  --accent: var(--color-panel);
-  --accent-foreground: var(--color-ink);
-  --destructive: var(--color-ink);
-  --destructive-foreground: var(--color-bg);
-  --border: var(--color-stroke);
-  --input: var(--color-stroke);
-  --ring: var(--color-stroke);
-}
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
 
-.dark {
-  --background: var(--color-bg);
-  --foreground: var(--color-ink);
-  --card: var(--color-panel);
-  --card-foreground: var(--color-ink);
-  --popover: var(--color-panel);
-  --popover-foreground: var(--color-ink);
-  --primary: var(--color-ink);
-  --primary-foreground: var(--color-bg);
-  --secondary: var(--color-bg2);
-  --secondary-foreground: var(--color-ink);
-  --muted: var(--color-bg2);
-  --muted-foreground: var(--color-muted);
-  --accent: var(--color-panel);
-  --accent-foreground: var(--color-ink);
-  --destructive: var(--color-ink);
-  --destructive-foreground: var(--color-bg);
-  --border: var(--color-stroke);
-  --input: var(--color-stroke);
-  --ring: var(--color-stroke);
-}
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
 
-html,
-body,
-#root {
-  height: 100%;
-}
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
 
-@theme inline {
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-card: var(--card);
-  --color-card-foreground: var(--card-foreground);
-  --color-popover: var(--popover);
-  --color-popover-foreground: var(--popover-foreground);
-  --color-primary: var(--primary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-secondary: var(--secondary);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-muted: var(--muted);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-accent: var(--accent);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-destructive: var(--destructive);
-  --color-destructive-foreground: var(--destructive-foreground);
-  --color-border: var(--border);
-  --color-input: var(--input);
-  --color-ring: var(--ring);
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 222.2 84% 4.9%;
+
+    --radius: 0.5rem;
+  }
+
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+
+    --primary: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 212.7 26.8% 83.9%;
+  }
+
+  html,
+  body,
+  #root {
+    height: 100%;
+  }
 }
 
 @layer base {
   * {
-    @apply border-border outline-ring/50;
+    border-color: hsl(var(--border));
+    outline-color: hsl(var(--ring) / 0.5);
   }
   body {
-    @apply bg-background text-foreground antialiased;
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
+    @apply antialiased;
   }
 }

--- a/src/views/BaseView.jsx
+++ b/src/views/BaseView.jsx
@@ -24,7 +24,7 @@ export default function BaseView() {
           storageBuildings={storageBuildings}
           completedResearch={completedResearch}
         />
-        <div className="border border-stroke rounded">
+        <div className="border border-border rounded">
           <Accordion title="Change Log">
             <EventLog log={state.log} />
           </Accordion>
@@ -33,4 +33,3 @@ export default function BaseView() {
     </div>
   );
 }
-

--- a/src/views/PopulationView.jsx
+++ b/src/views/PopulationView.jsx
@@ -6,18 +6,8 @@ import { XP_TIME_TO_NEXT_LEVEL_SECONDS } from '../data/balance.js';
 import { ROLE_LIST, SKILL_LABELS } from '../data/roles.js';
 import { RESOURCES } from '../data/resources.js';
 import { getSettlerCapacity } from '../state/selectors.js';
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardContent,
-} from '@/components/ui/card';
-import {
-  Tabs,
-  TabsList,
-  TabsTrigger,
-  TabsContent,
-} from '@/components/ui/tabs';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import Accordion from '@/components/Accordion.jsx';
 
 const BONUS_LABELS = ROLE_LIST.reduce((acc, r) => {
@@ -51,7 +41,10 @@ export default function PopulationView() {
             Settlers
           </TabsTrigger>
         </TabsList>
-        <TabsContent value="overview" className="flex-1 overflow-y-auto space-y-4">
+        <TabsContent
+          value="overview"
+          className="flex-1 overflow-y-auto space-y-4"
+        >
           <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
             <Card className="text-center">
               <CardHeader className="p-0">
@@ -103,12 +96,17 @@ export default function PopulationView() {
             filtered.map((s) => {
               const { years, days } = formatAge(s.ageDays);
               const activeSkill = s.skills?.[s.role] || { level: 0, xp: 0 };
-              const threshold = XP_TIME_TO_NEXT_LEVEL_SECONDS(activeSkill.level);
+              const threshold = XP_TIME_TO_NEXT_LEVEL_SECONDS(
+                activeSkill.level,
+              );
               const progress = threshold > 0 ? activeSkill.xp / threshold : 0;
               const badges = Object.entries(s.skills || {})
                 .filter(([, skill]) => skill.level > 0)
                 .map(([role, skill]) => (
-                  <span key={role} className="px-2 py-0.5 bg-bg3 rounded text-xs">
+                  <span
+                    key={role}
+                    className="px-2 py-0.5 bg-card rounded text-xs"
+                  >
                     {SKILL_LABELS[role] || role} {skill.level}
                   </span>
                 ));
@@ -163,7 +161,7 @@ export default function PopulationView() {
                     </div>
                     <div className="space-y-1">
                       <div className="text-sm">Level {activeSkill.level}</div>
-                      <div className="h-2 bg-stroke rounded">
+                      <div className="h-2 bg-border rounded">
                         <div
                           className="h-full bg-green-600 rounded"
                           style={{ width: `${Math.min(progress, 1) * 100}%` }}

--- a/src/views/ResearchView.jsx
+++ b/src/views/ResearchView.jsx
@@ -3,18 +3,8 @@ import ResearchTree from './research/ResearchTree.jsx';
 import { RESEARCH_MAP } from '../data/research.js';
 import { formatTime } from '../utils/time.js';
 import { Button } from '@/components/Button';
-import {
-  Card,
-  CardHeader,
-  CardContent,
-  CardTitle,
-} from '@/components/ui/card';
-import {
-  Tabs,
-  TabsList,
-  TabsTrigger,
-  TabsContent,
-} from '@/components/ui/tabs';
+import { Card, CardHeader, CardContent, CardTitle } from '@/components/ui/card';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 
 export default function ResearchView() {
   const { state, beginResearch, abortResearch } = useGame();
@@ -42,7 +32,7 @@ export default function ResearchView() {
                   <CardTitle>Researching: {node.name}</CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-4">
-                  <div className="h-2 bg-stroke rounded">
+                  <div className="h-2 bg-border rounded">
                     <div
                       className="h-full bg-blue-600 rounded"
                       style={{ width: `${pct * 100}%` }}
@@ -55,8 +45,7 @@ export default function ResearchView() {
                       size="sm"
                       className="border-red-400 text-red-300 hover:bg-red-900/20"
                       onClick={() => {
-                        if (window.confirm('Cancel research?'))
-                          abortResearch();
+                        if (window.confirm('Cancel research?')) abortResearch();
                       }}
                     >
                       Cancel

--- a/src/views/research/ResearchNode.jsx
+++ b/src/views/research/ResearchNode.jsx
@@ -67,14 +67,14 @@ const ResearchNode = forwardRef(({ node, status, reasons, onStart }, ref) => {
   return (
     <div
       ref={ref}
-      className={`relative w-56 p-3 border rounded bg-bg2/50 text-sm flex flex-col gap-1 ${
+      className={`relative w-56 p-3 border rounded bg-card/50 text-sm flex flex-col gap-1 ${
         status === 'completed'
           ? 'opacity-80 border-green-600'
           : status === 'inProgress'
             ? 'border-blue-500'
             : status === 'available'
               ? 'border-blue-300'
-              : 'opacity-50 border-stroke'
+              : 'opacity-50 border-border'
       }`}
       title={tooltip}
     >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,43 +5,44 @@ export default {
   theme: {
     extend: {
       colors: {
-        border: 'var(--color-stroke)',
-        background: 'var(--background)',
-        foreground: 'var(--foreground)',
-        card: {
-          DEFAULT: 'var(--card)',
-          foreground: 'var(--card-foreground)',
-        },
-        popover: {
-          DEFAULT: 'var(--popover)',
-          foreground: 'var(--popover-foreground)',
-        },
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
         primary: {
-          DEFAULT: 'var(--primary)',
-          foreground: 'var(--primary-foreground)',
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
         },
         secondary: {
-          DEFAULT: 'var(--secondary)',
-          foreground: 'var(--secondary-foreground)',
-        },
-        muted: {
-          DEFAULT: 'var(--muted)',
-          foreground: 'var(--muted-foreground)',
-        },
-        accent: {
-          DEFAULT: 'var(--accent)',
-          foreground: 'var(--accent-foreground)',
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
         },
         destructive: {
-          DEFAULT: 'var(--destructive)',
-          foreground: 'var(--destructive-foreground)',
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
         },
       },
       borderRadius: {
-        sm: 'var(--radius-sm)',
-        md: 'var(--radius-md)',
-        lg: 'var(--radius-lg)',
-        xl: 'var(--radius-xl)',
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
       },
     },
   },


### PR DESCRIPTION
## Summary
- replace custom tokens with shadcn globals palette
- map old utility classes to shadcn tokens
- rely on standard shadcn variables in Tailwind config

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 13 files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b7dfedcf083318ab5ffc2a67441e0