### PR TITLE
refactor: use shadcn components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "apocalypse-idle",
       "version": "0.0.0",
       "dependencies": {
+        "@radix-ui/react-accordion": "^1.1.1",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -1295,6 +1296,67 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
       "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-accordion": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.11.tgz",
+      "integrity": "sha512-l3W5D54emV2ues7jjeG1xcyN7S3jnK3zE2zHqgn0CmMsy9lNJwmgcrmaxS+7ipw15FAivzKNzH3d5EcGoFKw0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collapsible": "1.1.11",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.11.tgz",
+      "integrity": "sha512-2qrRsVGSCYasSz1RFOorXwl0H7g7J1frQtgpQgYrt+MOidtPAINHn9CPovQXb83r8ahapdx3Tu0fa/pdFFSdPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.1.7",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-accordion": "^1.1.1",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.12",
     "@tailwindcss/vite": "^4.1.11",

--- a/src/components/Accordion.jsx
+++ b/src/components/Accordion.jsx
@@ -1,25 +1,37 @@
-import React, { useState } from 'react';
+import React from 'react'
+import * as AccordionPrimitive from '@radix-ui/react-accordion'
+import { ChevronDownIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Accordion, AccordionItem, AccordionContent } from './ui/accordion'
 
-export default function Accordion({
+export default function GameAccordion({
   title,
   children,
   defaultOpen = false,
   action,
 }) {
-  const [open, setOpen] = useState(defaultOpen);
   return (
-    <div className="border-b border-border">
-      <div className="flex items-center justify-between p-2">
-        <button
-          className="flex-1 flex items-center justify-between"
-          onClick={() => setOpen(!open)}
-        >
-          <span>{title}</span>
-          <span>{open ? '-' : '+'}</span>
-        </button>
-        {action && <div className="ml-2">{action}</div>}
-      </div>
-      {open && <div className="p-2 space-y-2">{children}</div>}
-    </div>
-  );
+    <Accordion
+      type="single"
+      collapsible
+      defaultValue={defaultOpen ? 'item' : undefined}
+    >
+      <AccordionItem value="item">
+        <AccordionPrimitive.Header className="flex items-center">
+          <AccordionPrimitive.Trigger
+            className={cn(
+              'flex flex-1 items-center justify-between px-2 py-2 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180'
+            )}
+          >
+            <span>{title}</span>
+            <ChevronDownIcon className="h-4 w-4 shrink-0 transition-transform duration-200" />
+          </AccordionPrimitive.Trigger>
+          {action && <div className="ml-2">{action}</div>}
+        </AccordionPrimitive.Header>
+        <AccordionContent>
+          <div className="space-y-2">{children}</div>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  )
 }

--- a/src/components/BottomDock.jsx
+++ b/src/components/BottomDock.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useGame } from '../state/useGame.ts';
+import { Tabs, TabsList, TabsTrigger } from './ui/tabs';
 
 const tabs = [
   { id: 'base', icon: '🏠', label: 'Base' },
@@ -12,23 +13,23 @@ export default function BottomDock() {
   const { state, setActiveTab } = useGame();
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-20 flex border-t border-border bg-card">
-      {tabs.map((t) => (
-        <button
-          key={t.id}
-          onClick={() => setActiveTab(t.id)}
-          aria-label={t.label}
-          aria-current={state.ui.activeTab === t.id ? 'page' : undefined}
-          className={`flex-1 py-2 text-xl ${
-            state.ui.activeTab === t.id
-              ? 'text-foreground bg-muted font-semibold'
-              : 'text-muted'
-          }`}
-        >
-          {t.icon}
-          <span className="sr-only">{t.label}</span>
-        </button>
-      ))}
-    </nav>
+    <Tabs
+      value={state.ui.activeTab}
+      onValueChange={setActiveTab}
+      className="fixed bottom-0 left-0 right-0 z-20"
+    >
+      <TabsList className="w-full grid grid-cols-4 rounded-none border-t bg-card p-0">
+        {tabs.map((t) => (
+          <TabsTrigger
+            key={t.id}
+            value={t.id}
+            className="flex flex-col py-2 text-xl"
+          >
+            <span aria-hidden="true">{t.icon}</span>
+            <span className="sr-only">{t.label}</span>
+          </TabsTrigger>
+        ))}
+      </TabsList>
+    </Tabs>
   );
 }

--- a/src/components/BottomDock.test.jsx
+++ b/src/components/BottomDock.test.jsx
@@ -5,7 +5,7 @@ import BottomDock from './BottomDock.jsx';
 import { GameContext } from '../state/useGame.ts';
 
 describe('BottomDock accessibility', () => {
-  it('announces accessible labels for buttons', () => {
+  it('announces accessible labels for tabs', () => {
     const contextValue = {
       state: { ui: { activeTab: 'base' } },
       setActiveTab: vi.fn(),
@@ -18,13 +18,13 @@ describe('BottomDock accessibility', () => {
 
     const labels = ['Base', 'Population', 'Research', 'Expeditions'];
     labels.forEach((name) => {
-      expect(screen.getByRole('button', { name })).toBeTruthy();
+      expect(screen.getByRole('tab', { name })).toBeTruthy();
     });
 
-    const baseButton = screen.getByRole('button', { name: 'Base' });
-    expect(baseButton.getAttribute('aria-current')).toBe('page');
+    const baseTab = screen.getByRole('tab', { name: 'Base' });
+    expect(baseTab.getAttribute('aria-selected')).toBe('true');
 
-    const popButton = screen.getByRole('button', { name: 'Population' });
-    expect(popButton.hasAttribute('aria-current')).toBe(false);
+    const popTab = screen.getByRole('tab', { name: 'Population' });
+    expect(popTab.getAttribute('aria-selected')).toBe('false');
   });
 });

--- a/src/components/CandidateBox.tsx
+++ b/src/components/CandidateBox.tsx
@@ -4,6 +4,13 @@ import { SKILL_LABELS } from '../data/roles.js';
 import { RADIO_BASE_SECONDS } from '../data/settlement.js';
 import { candidateToSettler } from '../engine/candidates.js';
 import { Button } from './Button';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from './ui/card';
 
 interface Skill {
   level: number;
@@ -52,21 +59,25 @@ export default function CandidateBox(): JSX.Element | null {
     .join(', ');
 
   return (
-    <div className="p-4 border border-border bg-card rounded space-y-2">
-      <div className="font-semibold">A new settler has arrived!</div>
-      <div className="text-sm">
-        {candidate.firstName} {candidate.lastName} •{' '}
-        {candidate.sex === 'M' ? 'Male' : 'Female'} • Age {candidate.age}
-      </div>
-      <div className="text-xs text-muted">{skills || 'No skills'}</div>
-      <div className="space-x-2">
-        <Button variant="outline" size="sm" onClick={accept}>
-          Accept
-        </Button>
-        <Button variant="outline" size="sm" onClick={reject}>
-          Reject
-        </Button>
-      </div>
-    </div>
+    <Card>
+      <CardHeader>
+        <CardTitle>A new settler has arrived!</CardTitle>
+        <CardDescription>
+          {candidate.firstName} {candidate.lastName} •{' '}
+          {candidate.sex === 'M' ? 'Male' : 'Female'} • Age {candidate.age}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <div className="text-xs text-muted">{skills || 'No skills'}</div>
+        <div className="space-x-2">
+          <Button variant="outline" size="sm" onClick={accept}>
+            Accept
+          </Button>
+          <Button variant="outline" size="sm" onClick={reject}>
+            Reject
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/components/PowerPriorityModal.jsx
+++ b/src/components/PowerPriorityModal.jsx
@@ -6,6 +6,13 @@ import {
   getPoweredConsumerTypeIds,
 } from '../engine/power.js';
 import { Button } from './Button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from './ui/dialog';
 
 export default function PowerPriorityModal({ onClose }) {
   const { state, setState } = useGame();
@@ -43,9 +50,11 @@ export default function PowerPriorityModal({ onClose }) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-card p-4 rounded shadow max-w-md w-full">
-        <h2 className="text-lg mb-2 text-left">Power Priorities</h2>
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Power Priorities</DialogTitle>
+        </DialogHeader>
         <div className="text-center text-xs text-muted">TOP PRIORITY</div>
         <ul className="mt-2 space-y-1 max-h-64 overflow-y-auto">
           {order.map((id, idx) => {
@@ -88,15 +97,15 @@ export default function PowerPriorityModal({ onClose }) {
           })}
         </ul>
         <div className="text-center text-xs text-muted mt-2">LOW PRIORITY</div>
-        <div className="mt-4 flex justify-end gap-2">
+        <DialogFooter className="mt-4 flex justify-end gap-2">
           <Button variant="outline" size="sm" onClick={onClose}>
             Cancel
           </Button>
           <Button variant="outline" size="sm" onClick={save}>
             Save
           </Button>
-        </div>
-      </div>
-    </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/ResourceSidebar.jsx
+++ b/src/components/ResourceSidebar.jsx
@@ -5,6 +5,7 @@ import PowerPriorityModal from './PowerPriorityModal.jsx';
 import ResourceRow from './ResourceRow.jsx';
 import SettlerSection from './SettlerSection.jsx';
 import { useResourceSections } from './useResourceSections.js';
+import { Button } from './Button';
 
 export default function ResourceSidebar() {
   const { state } = useGame();
@@ -23,15 +24,17 @@ export default function ResourceSidebar() {
             ))}
             {g.title === 'Energy' && (
               <div className="pt-2 text-right">
-                <button
-                  className="text-xs text-blue-500 hover:underline"
+                <Button
+                  variant="link"
+                  size="sm"
+                  className="px-0 h-auto text-xs"
                   onClick={(e) => {
                     e.stopPropagation();
                     setShowPowerModal(true);
                   }}
                 >
                   Set priorities
-                </button>
+                </Button>
               </div>
             )}
           </Accordion>

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,0 +1,58 @@
+import * as React from "react"
+import * as AccordionPrimitive from "@radix-ui/react-accordion"
+import { ChevronDownIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Accordion = AccordionPrimitive.Root
+
+const AccordionItem = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <AccordionPrimitive.Item
+    ref={ref}
+    className={cn("border-b", className)}
+    {...props}
+  />
+))
+AccordionItem.displayName = "AccordionItem"
+
+const AccordionTrigger = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Header className="flex">
+    <AccordionPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        "flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronDownIcon className="h-4 w-4 shrink-0 transition-transform duration-200" />
+    </AccordionPrimitive.Trigger>
+  </AccordionPrimitive.Header>
+))
+AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName
+
+const AccordionContent = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Content
+    ref={ref}
+    className={cn(
+      "overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down",
+      className
+    )}
+    {...props}
+  >
+    <div className="pb-4 pt-0">{children}</div>
+  </AccordionPrimitive.Content>
+))
+AccordionContent.displayName = AccordionPrimitive.Content.displayName
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }


### PR DESCRIPTION
## Summary
- replace custom accordion with shadcn accordion
- migrate bottom dock to shadcn tabs
- use shadcn card and dialog in candidate and power priority modals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b82b9fe588331874502567deb833a