### PR TITLE
Improve contrast and spacing for key UI surfaces

### DIFF
--- a/src/components/Accordion.jsx
+++ b/src/components/Accordion.jsx
@@ -1,8 +1,8 @@
-import React from 'react'
-import * as AccordionPrimitive from '@radix-ui/react-accordion'
-import { ChevronDownIcon } from 'lucide-react'
-import { cn } from '@/lib/utils'
-import { Accordion, AccordionItem, AccordionContent } from './ui/accordion'
+import React from 'react';
+import * as AccordionPrimitive from '@radix-ui/react-accordion';
+import { ChevronDownIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Accordion, AccordionItem, AccordionContent } from './ui/accordion';
 
 export default function GameAccordion({
   title,
@@ -17,10 +17,10 @@ export default function GameAccordion({
       defaultValue={defaultOpen ? 'item' : undefined}
     >
       <AccordionItem value="item">
-        <AccordionPrimitive.Header className="flex items-center">
+        <AccordionPrimitive.Header className="flex items-center bg-card">
           <AccordionPrimitive.Trigger
             className={cn(
-              'flex flex-1 items-center justify-between px-2 py-2 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180'
+              'flex flex-1 items-center justify-between px-4 py-4 font-medium transition-all hover:bg-muted/50 [&[data-state=open]>svg]:rotate-180',
             )}
           >
             <span>{title}</span>
@@ -29,9 +29,9 @@ export default function GameAccordion({
           {action && <div className="ml-2">{action}</div>}
         </AccordionPrimitive.Header>
         <AccordionContent>
-          <div className="space-y-2">{children}</div>
+          <div className="px-4 pb-4 pt-2 space-y-3">{children}</div>
         </AccordionContent>
       </AccordionItem>
     </Accordion>
-  )
+  );
 }

--- a/src/components/BottomDock.jsx
+++ b/src/components/BottomDock.jsx
@@ -16,14 +16,14 @@ export default function BottomDock() {
     <Tabs
       value={state.ui.activeTab}
       onValueChange={setActiveTab}
-      className="fixed bottom-0 left-0 right-0 z-50 bg-card"
+      className="fixed bottom-0 left-0 right-0 z-50 bg-card shadow-lg"
     >
-      <TabsList className="w-full grid grid-cols-4 rounded-none border-t bg-card p-0">
+      <TabsList className="w-full grid grid-cols-4 rounded-none border-t bg-card p-2">
         {tabs.map((t) => (
           <TabsTrigger
             key={t.id}
             value={t.id}
-            className="flex flex-col py-2 text-xl"
+            className="flex flex-col py-3 text-xl"
           >
             <span aria-hidden="true">{t.icon}</span>
             <span className="sr-only">{t.label}</span>

--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -58,7 +58,7 @@ export default function Drawer() {
       }}
     >
       <SheetContent side="right" className="w-64">
-        <div className="p-4 space-y-6">
+        <div className="p-6 space-y-8">
           <section>
             <h2 className="font-semibold mb-2">📊 Statistics</h2>
             <p className="text-sm text-muted">Coming soon</p>

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -12,7 +12,7 @@ const AccordionItem = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AccordionPrimitive.Item
     ref={ref}
-    className={cn('border-b', className)}
+    className={cn('border-b bg-card', className)}
     {...props}
   />
 ));
@@ -22,11 +22,11 @@ const AccordionTrigger = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
 >(({ className, children, ...props }, ref) => (
-  <AccordionPrimitive.Header className="flex">
+  <AccordionPrimitive.Header className="flex bg-card">
     <AccordionPrimitive.Trigger
       ref={ref}
       className={cn(
-        'flex flex-1 items-center justify-between px-2 py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180',
+        'flex flex-1 items-center justify-between px-4 py-5 font-medium transition-all hover:bg-muted/50 [&[data-state=open]>svg]:rotate-180',
         className,
       )}
       {...props}
@@ -45,12 +45,12 @@ const AccordionContent = React.forwardRef<
   <AccordionPrimitive.Content
     ref={ref}
     className={cn(
-      'overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down',
+      'bg-card overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down',
       className,
     )}
     {...props}
   >
-    <div className="px-2 pb-4 pt-0">{children}</div>
+    <div className="px-4 pb-6 pt-0">{children}</div>
   </AccordionPrimitive.Content>
 ));
 AccordionContent.displayName = AccordionPrimitive.Content.displayName;

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,84 +1,84 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Card({ className, ...props }: React.ComponentProps<"div">) {
+function Card({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
-        className
+        'bg-card text-card-foreground flex flex-col gap-8 rounded-xl border py-8 shadow-sm',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-header"
       className={cn(
-        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
-        className
+        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-8 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-8',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-title"
-      className={cn("leading-none font-semibold", className)}
+      className={cn('leading-none font-semibold', className)}
       {...props}
     />
-  )
+  );
 }
 
-function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn('text-muted-foreground text-sm', className)}
       {...props}
     />
-  )
+  );
 }
 
-function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-action"
       className={cn(
-        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
-        className
+        'col-start-2 row-span-2 row-start-1 self-start justify-self-end',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-content"
-      className={cn("px-6", className)}
+      className={cn('px-8', className)}
       {...props}
     />
-  )
+  );
 }
 
-function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-footer"
-      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      className={cn('flex items-center px-8 [.border-t]:pt-8', className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -89,4 +89,4 @@ export {
   CardAction,
   CardDescription,
   CardContent,
-}
+};

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -58,7 +58,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'bg-card data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          'bg-card data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-6 rounded-lg border p-8 shadow-lg duration-200 sm:max-w-lg',
           className,
         )}
         {...props}
@@ -82,7 +82,7 @@ function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="dialog-header"
-      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      className={cn('flex flex-col gap-4 text-center sm:text-left', className)}
       {...props}
     />
   );
@@ -93,7 +93,7 @@ function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       data-slot="dialog-footer"
       className={cn(
-        'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
+        'flex flex-col-reverse gap-4 sm:flex-row sm:justify-end',
         className,
       )}
       {...props}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -58,7 +58,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          'bg-card data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+          'bg-card data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
           side === 'right' &&
             'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm',
           side === 'left' &&
@@ -85,7 +85,7 @@ function SheetHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="sheet-header"
-      className={cn('flex flex-col gap-1.5 p-4', className)}
+      className={cn('flex flex-col gap-2 p-6', className)}
       {...props}
     />
   );
@@ -95,7 +95,7 @@ function SheetFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="sheet-footer"
-      className={cn('mt-auto flex flex-col gap-2 p-4', className)}
+      className={cn('mt-auto flex flex-col gap-4 p-6', className)}
       {...props}
     />
   );

--- a/src/index.css
+++ b/src/index.css
@@ -33,14 +33,14 @@
   .dark {
     --background: 81.92 49% 4%;
     --foreground: 154 26% 97%;
-    --muted: 99.96 10.73% 10.65%;
+    --muted: 99.96 10.73% 15%;
     --muted-foreground: 124 8% 66%;
-    --popover: 90 17.65% 6.67%;
+    --popover: 90 17.65% 14%;
     --popover-foreground: 154 26% 98%;
-    --card: 95.45 16.67% 6.81%;
+    --card: 95.45 16.67% 14%;
     --card-foreground: 154 26% 98%;
-    --border: 154 1.86% 9.82%;
-    --input: 154 1.63% 13.12%;
+    --border: 154 1.86% 18%;
+    --input: 154 1.63% 18%;
     --primary: 154 26% 31%;
     --primary-foreground: 0 0% 100%;
     --secondary: 106.72 16.97% 40.99%;


### PR DESCRIPTION
## Summary
- lighten dark theme card and popover colors for stronger contrast
- give cards, accordions, drawer and dialogs padded card backgrounds
- pad and shade bottom dock for better readability

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 10 files. Run Prettier with --write to fix.)*

------
https://chatgpt.com/codex/tasks/task_e_689b877fcb5c833193f5231b8f052bca