### PR TITLE
chore: use default shadcn style

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://ui.shadcn.com/schema.json",
-  "style": "new-york",
+  "style": "default",
   "rsc": false,
   "tsx": true,
   "tailwind": {


### PR DESCRIPTION
## Summary
- use default Shadcn style instead of New York theme

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 10 files. Run Prettier with --write to fix.)*

------
https://chatgpt.com/codex/tasks/task_e_689b901f424c8331afa1942eaf97037d