### PR TITLE
chore: use shadcn default theme tokens

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,58 +3,58 @@
 
 @layer base {
   :root {
-    --background: 45.85 20% 99.02%;
-    --foreground: 154 69% 2%;
-    --muted: 124 4.26% 93.57%;
-    --muted-foreground: 124 8% 34%;
-    --popover: 150 40% 98.04%;
-    --popover-foreground: 154 69% 1%;
-    --card: 150 40% 98.04%;
-    --card-foreground: 154 69% 1%;
-    --border: 180 4.87% 94.34%;
-    --input: 180 2.44% 91.96%;
-    --primary: 142.64 26.58% 30.98%;
-    --primary-foreground: 0 0% 100%;
-    --secondary: 79.25 40.18% 73%;
-    --secondary-foreground: 79.29 93.22% 22.69%;
-    --accent: 66.14 56.98% 67.82%;
-    --accent-foreground: 66.38 42.92% 29.6%;
-    --destructive: 1 93% 40%;
-    --destructive-foreground: 0 0% 100%;
-    --ring: 154 26% 31%;
-    --chart-1: 154 26% 31%;
-    --chart-2: 124 26% 31%;
-    --chart-3: 184 26% 31%;
-    --chart-4: 124 26% 34%;
-    --chart-5: 154 29% 31%;
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --ring: 222.2 84% 4.9%;
     --radius: 0.5rem;
+    --chart-1: 12 76% 61%;
+    --chart-2: 173 58% 39%;
+    --chart-3: 197 37% 24%;
+    --chart-4: 43 74% 66%;
+    --chart-5: 27 87% 67%;
   }
 
   .dark {
-    --background: 81.92 49% 4%;
-    --foreground: 154 26% 97%;
-    --muted: 99.96 10.73% 15%;
-    --muted-foreground: 124 8% 66%;
-    --popover: 90 17.65% 14%;
-    --popover-foreground: 154 26% 98%;
-    --card: 95.45 16.67% 14%;
-    --card-foreground: 154 26% 98%;
-    --border: 154 1.86% 18%;
-    --input: 154 1.63% 18%;
-    --primary: 154 26% 31%;
-    --primary-foreground: 0 0% 100%;
-    --secondary: 106.72 16.97% 40.99%;
-    --secondary-foreground: 106.29 0% 100%;
-    --accent: 66.38 32.18% 37.83%;
-    --accent-foreground: 0 0% 100%;
-    --destructive: 1 93% 55%;
-    --destructive-foreground: 0 0% 100%;
-    --ring: 154 26% 31%;
-    --chart-1: 154 26% 31%;
-    --chart-2: 124 26% 31%;
-    --chart-3: 184 26% 31%;
-    --chart-4: 124 26% 34%;
-    --chart-5: 154 29% 31%;
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --primary: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 85.7% 97.3%;
+    --ring: 212.7 26.8% 83.9%;
+    --chart-1: 220 70% 50%;
+    --chart-2: 160 60% 45%;
+    --chart-3: 30 80% 55%;
+    --chart-4: 280 65% 60%;
+    --chart-5: 340 75% 55%;
   }
 
   html,
@@ -66,12 +66,9 @@
 
 @layer base {
   * {
-    border-color: hsl(var(--border));
-    outline-color: hsl(var(--ring) / 0.5);
+    @apply border-border;
   }
   body {
-    background-color: hsl(var(--background));
-    color: hsl(var(--foreground));
-    @apply antialiased;
+    @apply bg-background text-foreground antialiased;
   }
 }


### PR DESCRIPTION
## Summary
- replace custom color variables with Shadcn default tokens
- align base layer with Shadcn global styles

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 10 files. Run Prettier with --write to fix.)*

------
https://chatgpt.com/codex/tasks/task_e_689b91373a8483318941f077c7f46756