### PR TITLE
refactor: replace html elements with shadcn components

### DIFF
--- a/src/components/BuildingRow.jsx
+++ b/src/components/BuildingRow.jsx
@@ -8,6 +8,7 @@ import { formatAmount } from '../utils/format.js';
 import { clampResource, demolishBuilding } from '../engine/production.js';
 import { RESEARCH_MAP } from '../data/research.js';
 import { Button } from './Button';
+import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip';
 
 export default function BuildingRow({ building, completedResearch }) {
   const { state, setState } = useGame();
@@ -74,6 +75,15 @@ export default function BuildingRow({ building, completedResearch }) {
     setState((prev) => demolishBuilding(prev, building.id));
   };
 
+  const buildTooltip = !unlocked
+    ? `Requires: ${
+        RESEARCH_MAP[building.requiresResearch]?.name ||
+        building.requiresResearch
+      }`
+    : atMax
+      ? `Max ${building.maxCount}`
+      : null;
+
   return (
     <div className="p-2 rounded border border-border bg-card space-y-1">
       <div className="flex items-center justify-between">
@@ -91,24 +101,30 @@ export default function BuildingRow({ building, completedResearch }) {
           )}
         </div>
         <div className="space-x-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={build}
-            disabled={!canAfford || !unlocked || atMax}
-            title={
-              !unlocked
-                ? `Requires: ${
-                    RESEARCH_MAP[building.requiresResearch]?.name ||
-                    building.requiresResearch
-                  }`
-                : atMax
-                  ? `Max ${building.maxCount}`
-                  : undefined
-            }
-          >
-            Build
-          </Button>
+          {buildTooltip ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={build}
+                  disabled={!canAfford || !unlocked || atMax}
+                >
+                  Build
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{buildTooltip}</TooltipContent>
+            </Tooltip>
+          ) : (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={build}
+              disabled={!canAfford || !unlocked || atMax}
+            >
+              Build
+            </Button>
+          )}
           <Button
             variant="outline"
             size="sm"

--- a/src/components/EventLog.jsx
+++ b/src/components/EventLog.jsx
@@ -1,19 +1,24 @@
 import React from 'react';
 import { ScrollArea } from './ui/scroll-area';
+import { Card, CardContent } from './ui/card';
 
 export default function EventLog({ log = [] }) {
   return (
-    <ScrollArea className="h-40">
-      <ul className="text-sm space-y-1">
-        {log.map((entry) => (
-          <li key={entry.id}>
-            <span className="text-muted mr-2">
-              {new Date(entry.time).toLocaleString()}
-            </span>
-            {entry.text}
-          </li>
-        ))}
-      </ul>
-    </ScrollArea>
+    <Card className="h-40">
+      <CardContent className="h-full p-0">
+        <ScrollArea className="h-full px-4">
+          <ul className="text-sm space-y-1">
+            {log.map((entry) => (
+              <li key={entry.id}>
+                <span className="text-muted mr-2">
+                  {new Date(entry.time).toLocaleString()}
+                </span>
+                {entry.text}
+              </li>
+            ))}
+          </ul>
+        </ScrollArea>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/components/ResourceRow.jsx
+++ b/src/components/ResourceRow.jsx
@@ -11,7 +11,7 @@ export default function ResourceRow({
   tooltip,
 }) {
   const content = (
-    <div className="flex items-center justify-between text-sm tabular-nums">
+    <li className="flex items-center justify-between text-sm tabular-nums">
       <span className="flex items-center gap-1">
         {icon && <span>{icon}</span>}
         <span>{name}</span>
@@ -23,7 +23,7 @@ export default function ResourceRow({
         </span>
         {rate != null && <span className="text-xs text-muted">{rate}</span>}
       </span>
-    </div>
+    </li>
   );
 
   if (!tooltip) return content;

--- a/src/components/ResourceSidebar.jsx
+++ b/src/components/ResourceSidebar.jsx
@@ -41,9 +41,11 @@ export default function ResourceSidebar() {
           </Accordion>
         ) : (
           <Accordion key={g.title} title={g.title} defaultOpen={g.defaultOpen}>
-            {g.items.map((r) => (
-              <ResourceRow key={r.id} {...r} />
-            ))}
+            <ul className="space-y-1">
+              {g.items.map((r) => (
+                <ResourceRow key={r.id} {...r} />
+              ))}
+            </ul>
             {g.title === 'Energy' && (
               <div className="pt-2 text-right">
                 <Button

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,42 +1,33 @@
-import { useState } from 'react';
 import type { JSX } from 'react';
 import { getSeasonModifiers, getTimeBreakdown } from '../engine/time.js';
 import { useGame } from '../state/useGame.ts';
 import { Button } from './Button';
+import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip';
 
 export default function TopBar(): JSX.Element {
   const { state, toggleDrawer } = useGame();
   const time = getTimeBreakdown(state);
   const modifiers: Record<string, number> = getSeasonModifiers(state);
-  const [open, setOpen] = useState<boolean>(false);
   const labels: Record<string, string> = { FOOD: 'Food', RAW: 'Raw' };
 
   return (
     <header className="sticky top-0 z-10 flex items-center justify-between px-4 py-2 border-b border-border bg-card">
       <span className="tabular-nums text-xl">Year {time.year}</span>
-      <div className="relative flex items-center gap-2">
-        <Button
-          variant="ghost"
-          className="text-xl tabular-nums px-0"
-          onClick={() => setOpen((o) => !o)}
-          onMouseEnter={() => setOpen(true)}
-          onMouseLeave={() => setOpen(false)}
-        >
-          {time.season.icon} {time.season.label}, Day {time.day}
-        </Button>
-        {open && (
-          <div
-            className="absolute top-full right-0 mt-1 p-2 bg-card border border-border rounded text-xs shadow-lg"
-            onMouseEnter={() => setOpen(true)}
-            onMouseLeave={() => setOpen(false)}
-          >
+      <div className="flex items-center gap-2">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="ghost" className="text-xl tabular-nums px-0">
+              {time.season.icon} {time.season.label}, Day {time.day}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
             {Object.entries(modifiers).map(([key, val]) => (
               <div key={key} className="whitespace-nowrap">
                 {labels[key] || key} x{val.toFixed(2)}
               </div>
             ))}
-          </div>
-        )}
+          </TooltipContent>
+        </Tooltip>
         <Button
           variant="outline"
           size="sm"

--- a/src/views/research/ResearchNode.jsx
+++ b/src/views/research/ResearchNode.jsx
@@ -5,6 +5,7 @@ import { BUILDING_MAP } from '../../data/buildings.js';
 import { formatAmount } from '../../utils/format.js';
 import { formatTime } from '../../utils/time.js';
 import { Button } from '@/components/Button';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 
 function buildTooltip(node) {
   const lines = [];
@@ -65,68 +66,72 @@ const ResearchNode = forwardRef(({ node, status, reasons, onStart }, ref) => {
   const tooltip = buildTooltip(node);
   const cost = node.cost?.science || 0;
   return (
-    <div
-      ref={ref}
-      className={`relative w-64 p-3 border rounded bg-card/50 text-sm flex flex-col gap-1 ${
-        status === 'completed'
-          ? 'opacity-80 border-green-600'
-          : status === 'inProgress'
-            ? 'border-blue-500'
-            : status === 'available'
-              ? 'border-blue-300'
-              : 'opacity-50 border-border'
-      }`}
-      title={tooltip}
-    >
-      <div className="font-semibold text-base">{node.name}</div>
-      <div className="text-muted">{node.shortDesc}</div>
-      <div className="flex items-center gap-1">
-        <span>{RESOURCES.science.icon}</span>
-        <span>{formatAmount(cost)}</span>
-      </div>
-      <div className="text-xs text-muted">
-        Research time: {formatTime(node.timeSec)}
-      </div>
-      {status === 'available' && (
-        <Button
-          variant="outline"
-          size="sm"
-          className="mt-1 border-blue-400 text-blue-200 hover:bg-blue-900/20"
-          onClick={() => onStart(node.id)}
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          ref={ref}
+          className={`relative w-64 p-3 border rounded bg-card/50 text-sm flex flex-col gap-1 ${
+            status === 'completed'
+              ? 'opacity-80 border-green-600'
+              : status === 'inProgress'
+                ? 'border-blue-500'
+                : status === 'available'
+                  ? 'border-blue-300'
+                  : 'opacity-50 border-border'
+          }`}
         >
-          Start
-        </Button>
-      )}
-      {status === 'locked' && (
-        <div className="mt-1">
-          <Button variant="outline" size="sm" disabled>
-            Locked
-          </Button>
-          <div className="mt-1 space-y-1 text-xs text-red-400">
-            {reasons.missingPrereqs?.length > 0 && (
-              <div>Require: {reasons.missingPrereqs.join(', ')}</div>
-            )}
-            {reasons.missingMilestones?.length > 0 && (
-              <div>
-                {reasons.missingMilestones.map((m) => `${m}`).join(', ')}
-              </div>
-            )}
-            {reasons.needScience > 0 && (
-              <div>Need {formatAmount(reasons.needScience)} more</div>
-            )}
+          <div className="font-semibold text-base">{node.name}</div>
+          <div className="text-muted">{node.shortDesc}</div>
+          <div className="flex items-center gap-1">
+            <span>{RESOURCES.science.icon}</span>
+            <span>{formatAmount(cost)}</span>
           </div>
+          <div className="text-xs text-muted">
+            Research time: {formatTime(node.timeSec)}
+          </div>
+          {status === 'available' && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="mt-1 border-blue-400 text-blue-200 hover:bg-blue-900/20"
+              onClick={() => onStart(node.id)}
+            >
+              Start
+            </Button>
+          )}
+          {status === 'locked' && (
+            <div className="mt-1">
+              <Button variant="outline" size="sm" disabled>
+                Locked
+              </Button>
+              <div className="mt-1 space-y-1 text-xs text-red-400">
+                {reasons.missingPrereqs?.length > 0 && (
+                  <div>Require: {reasons.missingPrereqs.join(', ')}</div>
+                )}
+                {reasons.missingMilestones?.length > 0 && (
+                  <div>
+                    {reasons.missingMilestones.map((m) => `${m}`).join(', ')}
+                  </div>
+                )}
+                {reasons.needScience > 0 && (
+                  <div>Need {formatAmount(reasons.needScience)} more</div>
+                )}
+              </div>
+            </div>
+          )}
+          {status === 'inProgress' && (
+            <div className="mt-1 text-blue-400 flex items-center gap-1">
+              <span className="w-3 h-3 border-2 border-blue-400 border-t-transparent rounded-full animate-spin" />
+              In Progress
+            </div>
+          )}
+          {status === 'completed' && (
+            <span className="absolute top-1 right-1 text-green-500">✔</span>
+          )}
         </div>
-      )}
-      {status === 'inProgress' && (
-        <div className="mt-1 text-blue-400 flex items-center gap-1">
-          <span className="w-3 h-3 border-2 border-blue-400 border-t-transparent rounded-full animate-spin" />
-          In Progress
-        </div>
-      )}
-      {status === 'completed' && (
-        <span className="absolute top-1 right-1 text-green-500">✔</span>
-      )}
-    </div>
+      </TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
   );
 });
 


### PR DESCRIPTION
## Summary
- style event log with Card and ScrollArea
- convert resource rows to list items and use tooltips
- replace manual HTML tooltips with Shadcn Tooltip in BuildingRow, ResearchNode, and TopBar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ba2a239cc83318e44b8724c56af58