### PR TITLE
Improve UI spacing and contrast

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,7 +27,7 @@ function ActiveView() {
 export default function App() {
   return (
     <GameProvider>
-      <div className="h-screen flex flex-col bg-background text-foreground overflow-hidden">
+      <div className="min-h-screen flex flex-col bg-background text-foreground">
         <TopBar />
         <div className="flex-1 overflow-hidden">
           <ActiveView />

--- a/src/components/BuildingRow.jsx
+++ b/src/components/BuildingRow.jsx
@@ -105,7 +105,6 @@ export default function BuildingRow({ building, completedResearch }) {
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
-                  variant="outline"
                   size="sm"
                   onClick={build}
                   disabled={!canAfford || !unlocked || atMax}
@@ -117,7 +116,6 @@ export default function BuildingRow({ building, completedResearch }) {
             </Tooltip>
           ) : (
             <Button
-              variant="outline"
               size="sm"
               onClick={build}
               disabled={!canAfford || !unlocked || atMax}
@@ -126,7 +124,7 @@ export default function BuildingRow({ building, completedResearch }) {
             </Button>
           )}
           <Button
-            variant="outline"
+            variant="destructive"
             size="sm"
             onClick={demolish}
             disabled={count <= 0}

--- a/src/index.css
+++ b/src/index.css
@@ -4,58 +4,58 @@
 
 @layer base {
   :root {
-      --background: 42 48% 100%;
-      --foreground: 42 80% 2%;
-      --muted: 12 11% 87%;
-      --muted-foreground: 12 5% 80%;
-      --popover: 42 48% 100%;
-      --popover-foreground: 42 65% 5%;
-      --card: 0 0% 99%;
-      --card-foreground: 42 70% 3%;
-      --border: 42 12% 80%;
-      --input: 42 12% 93%;
-      --primary: 42 15% 18%;
-      --primary-foreground: 42 11% 90%;
-      --secondary: 12 11% 21%;
-      --secondary-foreground: 12 11% 81%;
-      --accent: 72 11% 21%;
-      --accent-foreground: 72 11% 81%;
-      --destructive: 4 91% 40%;
-      --destructive-foreground: 0 0% 100%;
-      --ring: 42 11% 21%;
-      --chart-1: 42 11% 21%;
-      --chart-2: 12 11% 21%;
-      --chart-3: 72 11% 21%;
-      --chart-4: 12 11% 24%;
-      --chart-5: 42 14% 21%;
-      --radius: 0.5rem;
+    --background: 42 48% 96%;
+    --foreground: 42 80% 5%;
+    --muted: 12 11% 90%;
+    --muted-foreground: 12 5% 40%;
+    --popover: 42 48% 96%;
+    --popover-foreground: 42 65% 5%;
+    --card: 0 0% 100%;
+    --card-foreground: 42 70% 7%;
+    --border: 42 12% 85%;
+    --input: 42 12% 95%;
+    --primary: 42 30% 25%;
+    --primary-foreground: 42 11% 98%;
+    --secondary: 12 11% 21%;
+    --secondary-foreground: 12 11% 81%;
+    --accent: 72 11% 21%;
+    --accent-foreground: 72 11% 81%;
+    --destructive: 4 91% 40%;
+    --destructive-foreground: 0 0% 100%;
+    --ring: 42 11% 21%;
+    --chart-1: 42 11% 21%;
+    --chart-2: 12 11% 21%;
+    --chart-3: 72 11% 21%;
+    --chart-4: 12 11% 24%;
+    --chart-5: 42 14% 21%;
+    --radius: 0.5rem;
   }
 
   .dark {
-      --background: 42 37% 2%;
-      --foreground: 42 60% 98%;
-      --muted: 12 11% 13%;
-      --muted-foreground: 42 8% 80%;
-      --popover: 42 37% 2%;
-      --popover-foreground: 42 32% 98%;
-      --card: 42 37% 3%;
-      --card-foreground: 42 50% 99%;
-      --border: 42 12% 12%;
-      --input: 42 12% 11%;
-      --primary: 42 15% 25%;
-      --primary-foreground: 42 11% 92%;
-      --secondary: 12 11% 21%;
-      --secondary-foreground: 12 11% 81%;
-      --accent: 72 11% 21%;
-      --accent-foreground: 72 11% 81%;
-      --destructive: 4 91% 46%;
-      --destructive-foreground: 0 0% 100%;
-      --ring: 42 11% 21%;
-      --chart-1: 42 11% 21%;
-      --chart-2: 12 11% 21%;
-      --chart-3: 72 11% 21%;
-      --chart-4: 12 11% 24%;
-      --chart-5: 42 14% 21%;
+    --background: 42 37% 4%;
+    --foreground: 42 60% 97%;
+    --muted: 12 11% 18%;
+    --muted-foreground: 42 8% 70%;
+    --popover: 42 37% 4%;
+    --popover-foreground: 42 32% 97%;
+    --card: 42 37% 6%;
+    --card-foreground: 42 50% 98%;
+    --border: 42 12% 20%;
+    --input: 42 12% 18%;
+    --primary: 42 20% 30%;
+    --primary-foreground: 42 11% 92%;
+    --secondary: 12 11% 21%;
+    --secondary-foreground: 12 11% 81%;
+    --accent: 72 11% 21%;
+    --accent-foreground: 72 11% 81%;
+    --destructive: 4 91% 46%;
+    --destructive-foreground: 0 0% 100%;
+    --ring: 42 11% 21%;
+    --chart-1: 42 11% 21%;
+    --chart-2: 12 11% 21%;
+    --chart-3: 72 11% 21%;
+    --chart-4: 12 11% 24%;
+    --chart-5: 42 14% 21%;
   }
 
   html,

--- a/src/views/BaseView.jsx
+++ b/src/views/BaseView.jsx
@@ -14,10 +14,10 @@ export default function BaseView() {
 
   return (
     <div className="h-full flex flex-col md:flex-row md:space-x-6 overflow-y-auto md:overflow-hidden">
-      <div className="p-4 pb-20 md:w-64 md:flex-shrink-0 md:overflow-y-auto">
+      <div className="px-2 pb-20 md:w-64 md:flex-shrink-0">
         <ResourceSidebar />
       </div>
-      <div className="flex-1 p-4 space-y-6 pb-20 md:overflow-y-auto">
+      <div className="flex-1 px-2 space-y-6 pb-20 md:overflow-y-auto">
         <CandidateBox />
         <ProductionSection
           productionGroups={productionGroups}

--- a/src/views/ExpeditionsView.jsx
+++ b/src/views/ExpeditionsView.jsx
@@ -1,3 +1,3 @@
 export default function ExpeditionsView() {
-  return <div className="h-full overflow-y-auto p-4 pb-20">Coming soon</div>;
+  return <div className="h-full overflow-y-auto px-2 pb-20">Coming soon</div>;
 }

--- a/src/views/PopulationView.jsx
+++ b/src/views/PopulationView.jsx
@@ -38,7 +38,7 @@ export default function PopulationView() {
   const bonuses = computeRoleBonuses(settlers);
 
   return (
-    <div className="h-full p-4 pb-20 overflow-y-auto space-y-4">
+    <div className="h-full px-2 pb-20 overflow-y-auto space-y-4">
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
         <Card className="text-center">
           <CardHeader className="p-0">

--- a/src/views/ResearchView.jsx
+++ b/src/views/ResearchView.jsx
@@ -13,7 +13,7 @@ export default function ResearchView() {
   const remaining = node ? Math.max(node.timeSec - progress, 0) : 0;
   const pct = node ? Math.min(progress / node.timeSec, 1) : 0;
   return (
-    <div className="h-full p-4 pb-20 flex flex-col gap-4">
+    <div className="h-full px-2 pb-20 flex flex-col gap-4">
       {current && node && (
         <Card>
           <CardHeader>


### PR DESCRIPTION
## Summary
- lighten theme colors for better background and text contrast
- remove nested padding and extra scrollbars on views
- show bottom dock fully and enhance build/demolish button styles

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 18 files)*

------
https://chatgpt.com/codex/tasks/task_e_689bc24b43d883319d4985847400c20c