### PR TITLE
Improve UI contrast and layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,7 +27,7 @@ function ActiveView() {
 export default function App() {
   return (
     <GameProvider>
-      <div className="h-screen flex flex-col bg-background text-foreground overflow-hidden">
+      <div className="h-screen flex flex-col bg-background text-foreground">
         <TopBar />
         <div className="flex-1 overflow-hidden">
           <ActiveView />

--- a/src/components/BottomDock.jsx
+++ b/src/components/BottomDock.jsx
@@ -16,7 +16,7 @@ export default function BottomDock() {
     <Tabs
       value={state.ui.activeTab}
       onValueChange={setActiveTab}
-      className="fixed bottom-0 left-0 right-0 z-50 bg-card shadow-lg"
+      className="fixed bottom-0 left-0 right-0 z-50 bg-card shadow-lg pb-2"
     >
       <TabsList className="w-full grid grid-cols-4 rounded-none border-t bg-card p-3">
         {tabs.map((t) => (

--- a/src/components/BuildingRow.jsx
+++ b/src/components/BuildingRow.jsx
@@ -105,7 +105,6 @@ export default function BuildingRow({ building, completedResearch }) {
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
-                  variant="outline"
                   size="sm"
                   onClick={build}
                   disabled={!canAfford || !unlocked || atMax}
@@ -117,7 +116,6 @@ export default function BuildingRow({ building, completedResearch }) {
             </Tooltip>
           ) : (
             <Button
-              variant="outline"
               size="sm"
               onClick={build}
               disabled={!canAfford || !unlocked || atMax}
@@ -126,7 +124,7 @@ export default function BuildingRow({ building, completedResearch }) {
             </Button>
           )}
           <Button
-            variant="outline"
+            variant="destructive"
             size="sm"
             onClick={demolish}
             disabled={count <= 0}
@@ -135,7 +133,7 @@ export default function BuildingRow({ building, completedResearch }) {
           </Button>
         </div>
       </div>
-      <div className="text-xs muted-foreground space-y-1">
+      <div className="text-xs text-muted-foreground space-y-1">
         <div>{building.description}</div>
         <div>
           Cost:{' '}

--- a/src/components/CandidateBox.tsx
+++ b/src/components/CandidateBox.tsx
@@ -14,7 +14,9 @@ import {
   CardFooter,
 } from './ui/card';
 
-interface Skill { level: number; }
+interface Skill {
+  level: number;
+}
 interface Candidate {
   firstName: string;
   lastName: string;
@@ -30,8 +32,12 @@ export default function CandidateBox(): JSX.Element | null {
 
   const updateAfterDecision = (accepted: boolean): void => {
     setState((prev) => {
-      const newSettler = candidateToSettler(candidate) as (typeof prev.population.settlers)[number];
-      const settlers = accepted ? [...prev.population.settlers, newSettler] : prev.population.settlers;
+      const newSettler = candidateToSettler(
+        candidate,
+      ) as (typeof prev.population.settlers)[number];
+      const settlers = accepted
+        ? [...prev.population.settlers, newSettler]
+        : prev.population.settlers;
       return {
         ...prev,
         population: { ...prev.population, settlers, candidate: null },
@@ -54,15 +60,15 @@ export default function CandidateBox(): JSX.Element | null {
         <CardTitle>A new settler has arrived!</CardTitle>
         <CardDescription className="text-sm">
           {candidate.firstName} {candidate.lastName}
-          <span className="px-2 muted-foreground">·</span>
+          <span className="px-2 text-muted-foreground">·</span>
           {candidate.sex === 'M' ? 'Male' : 'Female'}
-          <span className="px-2 muted-foreground">·</span>
+          <span className="px-2 text-muted-foreground">·</span>
           Age {candidate.age}
         </CardDescription>
       </CardHeader>
 
       <CardContent className="space-y-2">
-        <div className="text-xs muted-foreground">
+        <div className="text-xs text-muted-foreground">
           {skills || 'No notable skills'}
         </div>
       </CardContent>

--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -62,17 +62,16 @@ export default function Drawer() {
         <div className="p-6 space-y-8">
           <section>
             <h2 className="font-semibold mb-2">📊 Statistics</h2>
-            <p className="text-sm muted-foreground">Coming soon</p>
+            <p className="text-sm text-muted-foreground">Coming soon</p>
           </section>
           <section>
             <h2 className="font-semibold mb-2">⚙️ Settings</h2>
-            <p className="text-sm muted-foreground">Coming soon</p>
+            <p className="text-sm text-muted-foreground">Coming soon</p>
           </section>
           <section>
             <h2 className="font-semibold mb-2">💾 Save/Load</h2>
             <div className="flex gap-2">
               <Button
-                variant="outline"
                 size="sm"
                 onClick={() => {
                   exportSaveFile(state);
@@ -88,7 +87,7 @@ export default function Drawer() {
                 Save
               </Button>
               <Button
-                variant="outline"
+                variant="secondary"
                 size="sm"
                 onClick={() => fileInput.current?.click()}
               >
@@ -105,7 +104,7 @@ export default function Drawer() {
           </section>
           <section>
             <h2 className="font-semibold mb-2">🧹 Reset</h2>
-            <Button variant="outline" size="sm" onClick={resetGame}>
+            <Button variant="destructive" size="sm" onClick={resetGame}>
               Reset colony
             </Button>
           </section>

--- a/src/components/EventLog.jsx
+++ b/src/components/EventLog.jsx
@@ -10,7 +10,7 @@ export default function EventLog({ log = [] }) {
           <ul className="text-sm space-y-1">
             {log.map((entry) => (
               <li key={entry.id}>
-                <span className="muted-foreground mr-2">
+                <span className="text-muted-foreground mr-2">
                   {new Date(entry.time).toLocaleString()}
                 </span>
                 {entry.text}

--- a/src/components/PowerPriorityModal.jsx
+++ b/src/components/PowerPriorityModal.jsx
@@ -55,7 +55,9 @@ export default function PowerPriorityModal({ onClose }) {
         <DialogHeader>
           <DialogTitle>Power Priorities</DialogTitle>
         </DialogHeader>
-        <div className="text-center text-xs muted-foreground">TOP PRIORITY</div>
+        <div className="text-center text-xs text-muted-foreground">
+          TOP PRIORITY
+        </div>
         <ul className="mt-2 space-y-1 max-h-64 overflow-y-auto">
           {order.map((id, idx) => {
             const b = BUILDING_MAP[id];
@@ -74,7 +76,9 @@ export default function PowerPriorityModal({ onClose }) {
                   <span>{b?.name || id}</span>
                 </div>
                 <div className="flex items-center gap-1">
-                  <span className="text-xs muted-foreground">x{count}</span>
+                  <span className="text-xs text-muted-foreground">
+                    x{count}
+                  </span>
                   <Button
                     variant="outline"
                     size="sm"
@@ -96,12 +100,14 @@ export default function PowerPriorityModal({ onClose }) {
             );
           })}
         </ul>
-        <div className="text-center text-xs muted-foreground mt-2">LOW PRIORITY</div>
+        <div className="text-center text-xs text-muted-foreground mt-2">
+          LOW PRIORITY
+        </div>
         <DialogFooter className="mt-4 flex justify-end gap-2">
-          <Button variant="outline" size="sm" onClick={onClose}>
+          <Button variant="secondary" size="sm" onClick={onClose}>
             Cancel
           </Button>
-          <Button variant="outline" size="sm" onClick={save}>
+          <Button size="sm" onClick={save}>
             Save
           </Button>
         </DialogFooter>

--- a/src/components/ResourceRow.jsx
+++ b/src/components/ResourceRow.jsx
@@ -21,7 +21,9 @@ export default function ResourceRow({
           {formatAmount(amount)}
           {capacity != null && ` / ${formatAmount(capacity)}`}
         </span>
-        {rate != null && <span className="text-xs muted-foreground">{rate}</span>}
+        {rate != null && (
+          <span className="text-xs text-muted-foreground">{rate}</span>
+        )}
       </span>
     </li>
   );

--- a/src/components/ResourceSidebar.jsx
+++ b/src/components/ResourceSidebar.jsx
@@ -6,6 +6,7 @@ import ResourceRow from './ResourceRow.jsx';
 import SettlerSection from './SettlerSection.jsx';
 import { useResourceSections } from './useResourceSections.js';
 import { Button } from './Button';
+import { ScrollArea } from './ui/scroll-area';
 
 export default function ResourceSidebar() {
   const { state } = useGame();
@@ -13,7 +14,7 @@ export default function ResourceSidebar() {
   const { sections, settlersInfo, happinessInfo } = useResourceSections(state);
 
   return (
-    <div className="border border-border rounded overflow-hidden bg-card">
+    <ScrollArea className="border border-border rounded bg-card">
       {sections.map((g) =>
         g.settlers ? (
           <SettlerSection key={g.title} title={g.title} info={settlersInfo} />
@@ -67,6 +68,6 @@ export default function ResourceSidebar() {
       {showPowerModal && (
         <PowerPriorityModal onClose={() => setShowPowerModal(false)} />
       )}
-    </div>
+    </ScrollArea>
   );
 }

--- a/src/components/SettlerSection.jsx
+++ b/src/components/SettlerSection.jsx
@@ -18,7 +18,7 @@ export default function SettlerSection({ title, info }) {
       <div className={`text-sm mb-1 ${color}`}>
         Settlers {total}/{capacity}
       </div>
-      <div className="text-xs muted-foreground mb-1">{radioLine}</div>
+      <div className="text-xs text-muted-foreground mb-1">{radioLine}</div>
       {radioCount > 0 && !candidatePending && powered && (
         <div className="h-2 bg-border rounded mb-1">
           <div

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -42,7 +42,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-description"
-      className={cn('fmuted-foreground text-sm', className)}
+      className={cn('text-muted-foreground text-sm', className)}
       {...props}
     />
   );
@@ -63,11 +63,7 @@ function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
 
 function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
   return (
-    <div
-      data-slot="card-content"
-      className={cn('p-5', className)}
-      {...props}
-    />
+    <div data-slot="card-content" className={cn('p-5', className)} {...props} />
   );
 }
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -67,7 +67,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
             <span className="sr-only">Close</span>
@@ -121,7 +121,7 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn('muted-foreground text-sm', className)}
+      className={cn('text-muted-foreground text-sm', className)}
       {...props}
     />
   );

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -121,7 +121,7 @@ function SheetDescription({
   return (
     <SheetPrimitive.Description
       data-slot="sheet-description"
-      className={cn('muted-foreground text-sm', className)}
+      className={cn('text-muted-foreground text-sm', className)}
       {...props}
     />
   );

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import * as TabsPrimitive from "@radix-ui/react-tabs"
+import * as React from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function Tabs({
   className,
@@ -10,10 +10,10 @@ function Tabs({
   return (
     <TabsPrimitive.Root
       data-slot="tabs"
-      className={cn("flex flex-col gap-2", className)}
+      className={cn('flex flex-col gap-2', className)}
       {...props}
     />
-  )
+  );
 }
 
 function TabsList({
@@ -24,12 +24,12 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "bg-muted muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
-        className
+        'bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function TabsTrigger({
@@ -40,12 +40,12 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function TabsContent({
@@ -55,10 +55,10 @@ function TabsContent({
   return (
     <TabsPrimitive.Content
       data-slot="tabs-content"
-      className={cn("flex-1 outline-none", className)}
+      className={cn('flex-1 outline-none', className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Tabs, TabsList, TabsTrigger, TabsContent }
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/src/index.css
+++ b/src/index.css
@@ -4,58 +4,58 @@
 
 @layer base {
   :root {
-      --background: 42 48% 100%;
-      --foreground: 42 80% 2%;
-      --muted: 12 11% 87%;
-      --muted-foreground: 12 5% 80%;
-      --popover: 42 48% 100%;
-      --popover-foreground: 42 65% 5%;
-      --card: 0 0% 99%;
-      --card-foreground: 42 70% 3%;
-      --border: 42 12% 80%;
-      --input: 42 12% 93%;
-      --primary: 42 15% 18%;
-      --primary-foreground: 42 11% 90%;
-      --secondary: 12 11% 21%;
-      --secondary-foreground: 12 11% 81%;
-      --accent: 72 11% 21%;
-      --accent-foreground: 72 11% 81%;
-      --destructive: 4 91% 40%;
-      --destructive-foreground: 0 0% 100%;
-      --ring: 42 11% 21%;
-      --chart-1: 42 11% 21%;
-      --chart-2: 12 11% 21%;
-      --chart-3: 72 11% 21%;
-      --chart-4: 12 11% 24%;
-      --chart-5: 42 14% 21%;
-      --radius: 0.5rem;
+    --background: 42 48% 100%;
+    --foreground: 42 80% 2%;
+    --muted: 12 11% 87%;
+    --muted-foreground: 12 5% 40%;
+    --popover: 42 48% 100%;
+    --popover-foreground: 42 65% 5%;
+    --card: 0 0% 100%;
+    --card-foreground: 42 70% 3%;
+    --border: 42 12% 80%;
+    --input: 42 12% 93%;
+    --primary: 42 15% 18%;
+    --primary-foreground: 42 11% 90%;
+    --secondary: 12 11% 21%;
+    --secondary-foreground: 12 11% 81%;
+    --accent: 72 11% 21%;
+    --accent-foreground: 72 11% 81%;
+    --destructive: 4 91% 40%;
+    --destructive-foreground: 0 0% 100%;
+    --ring: 42 11% 21%;
+    --chart-1: 42 11% 21%;
+    --chart-2: 12 11% 21%;
+    --chart-3: 72 11% 21%;
+    --chart-4: 12 11% 24%;
+    --chart-5: 42 14% 21%;
+    --radius: 0.5rem;
   }
 
   .dark {
-      --background: 42 37% 2%;
-      --foreground: 42 60% 98%;
-      --muted: 12 11% 13%;
-      --muted-foreground: 42 8% 80%;
-      --popover: 42 37% 2%;
-      --popover-foreground: 42 32% 98%;
-      --card: 42 37% 3%;
-      --card-foreground: 42 50% 99%;
-      --border: 42 12% 12%;
-      --input: 42 12% 11%;
-      --primary: 42 15% 25%;
-      --primary-foreground: 42 11% 92%;
-      --secondary: 12 11% 21%;
-      --secondary-foreground: 12 11% 81%;
-      --accent: 72 11% 21%;
-      --accent-foreground: 72 11% 81%;
-      --destructive: 4 91% 46%;
-      --destructive-foreground: 0 0% 100%;
-      --ring: 42 11% 21%;
-      --chart-1: 42 11% 21%;
-      --chart-2: 12 11% 21%;
-      --chart-3: 72 11% 21%;
-      --chart-4: 12 11% 24%;
-      --chart-5: 42 14% 21%;
+    --background: 42 37% 2%;
+    --foreground: 42 60% 98%;
+    --muted: 12 11% 13%;
+    --muted-foreground: 42 8% 70%;
+    --popover: 42 37% 2%;
+    --popover-foreground: 42 32% 98%;
+    --card: 42 37% 8%;
+    --card-foreground: 42 50% 99%;
+    --border: 42 12% 12%;
+    --input: 42 12% 11%;
+    --primary: 42 15% 25%;
+    --primary-foreground: 42 11% 92%;
+    --secondary: 12 11% 21%;
+    --secondary-foreground: 12 11% 81%;
+    --accent: 72 11% 21%;
+    --accent-foreground: 72 11% 81%;
+    --destructive: 4 91% 46%;
+    --destructive-foreground: 0 0% 100%;
+    --ring: 42 11% 21%;
+    --chart-1: 42 11% 21%;
+    --chart-2: 12 11% 21%;
+    --chart-3: 72 11% 21%;
+    --chart-4: 12 11% 24%;
+    --chart-5: 42 14% 21%;
   }
 
   html,


### PR DESCRIPTION
## Summary
- lighten card backgrounds and darken muted text for better contrast
- fix button variants and muted text styling across components
- wrap resource sidebar in ScrollArea and adjust bottom dock padding

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 12 files)*
- `npx eslint .` *(fails: 46 errors, 2 warnings)*
- `npm run typecheck` *(fails: multiple TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_689bc24b43d883319d4985847400c20c