### PR TITLE
Rebalance early game economy

### DIFF
--- a/reports/economy/20250812224454/CHANGELOG.md
+++ b/reports/economy/20250812224454/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+## Buildings
+- buildings.potatoField.costBase.wood 15→17 – PBT@1 too fast
+- buildings.potatoField.costGrowth 1.15→1.13 – PBT@50 too high
+- buildings.huntersHut.outputsPerSecBase.meat 0.15→0.19 – PBT@1 too slow
+- buildings.huntersHut.seasonProfile.winter 0.8→0.6 – winter pressure
+- buildings.loggingCamp.outputsPerSecBase.wood 0.25→0.3 – PBT@1 too slow
+- buildings.loggingCamp.costGrowth 1.15→1.13 – PBT@50 too high
+- buildings.scrapyard.costGrowth 1.15→1.13 – PBT@50 too high
+- buildings.quarry.outputsPerSecBase.stone 0.08→0.104 – PBT@1 too slow
+- buildings.quarry.costGrowth 1.15→1.13 – PBT@50 too high
+- buildings.sawmill.costBase {wood:40, scrap:15, stone:10}→{48,18,12} – PBT@1 too fast
+- buildings.sawmill.costGrowth 1.15→1.13 – PBT@50 too high
+- buildings.metalWorkshop.costGrowth 1.15→1.13 – PBT@50 too high
+- buildings.school.outputsPerSecBase.science 0.5→0.45 and costBase {25,10,10}→{30,12,12} – PBT@1 too fast
+- buildings.school.costGrowth 1.15→1.13 – PBT@50 too high
+- buildings.woodGenerator.costGrowth 1.15→1.13 – PBT@50 too high
+- buildings.radio.costBase +planks:20 – tie to industry
+- buildings.foodStorage.costGrowth 1.15→1.2 – storage growth
+- buildings.rawStorage.costGrowth 1.15→1.2 – storage growth
+- buildings.rawStorage.capacityAdd.scrap 120→90 – storage buffer
+- buildings.materialsDepot.costGrowth 1.15→1.2 – storage growth
+- buildings.materialsDepot.capacityAdd.planks 150→300, metalParts 60→240 – storage buffer
+- buildings.battery.costGrowth 1.15→1.2 – storage growth
+- buildings.battery.capacityAdd.power 40→600 – storage buffer
+
+## Resources
+- resources.potatoes.startingCapacity 300→450 – 10m buffer
+- resources.meat.startingCapacity 300→150 – storage tightening
+- resources.wood.startingCapacity 100→150 – 10m buffer
+- resources.stone.startingCapacity 100→80 – storage tightening
+- resources.scrap.startingCapacity 100→80 – storage tightening
+
+## Research
+- research.hunting1 cost 35→50, time 45→90 – timing
+- research.radio cost 120→150, time 180→240 – mid-tier timing
+- research.woodworking1 cost 50→60, time 70→90 – timing
+- research.salvaging1 cost 50→60, time 70→90 – timing
+- research.woodworking2 cost 110→140, time 180→240 – mid-tier timing
+- research.salvaging2 cost 110→140, time 180→240 – mid-tier timing
+- research.logistics2 cost 120→150, time 210→270 – mid-tier timing
+- Added research.hunting2 (+10% FOOD output) – food boost
+- Added research.industryProduction (+10% construction materials output) – industry boost
+
+## Balance
+- ROLE_BONUS_PER_SETTLER now 0.02*level up to 0.2 +0.01*(level-10) – normalize role bonuses
+
+## Settlement
+- RADIO_BASE_SECONDS 60→120 – slower settler inflow
+
+## Tests
+- Updated tests for new hunter output and research timing
+

--- a/reports/economy/20250812224454/baseline.json
+++ b/reports/economy/20250812224454/baseline.json
@@ -1,0 +1,450 @@
+{
+  "meta": {
+    "analyzed": 15,
+    "season": "average",
+    "weights": {
+      "wood": 1,
+      "stone": 1.3,
+      "scrap": 2.2,
+      "planks": 4,
+      "metalParts": 6,
+      "power": 1,
+      "potatoes": 0.9,
+      "meat": 1.4,
+      "science": 2.5
+    },
+    "targets": [
+      1,
+      10,
+      50
+    ],
+    "thresholds": {
+      "generators": {
+        "pbt1": [
+          60,
+          120
+        ],
+        "pbt10": [
+          180,
+          480
+        ],
+        "pbt50": [
+          900,
+          2700
+        ]
+      },
+      "converters": {
+        "pbt1": [
+          90,
+          150
+        ],
+        "pbt10": [
+          240,
+          600
+        ],
+        "pbt50": [
+          1200,
+          3600
+        ]
+      }
+    },
+    "outliers": {
+      "tooFast": 4,
+      "tooSlow": 15
+    }
+  },
+  "buildings": [
+    {
+      "id": "potatoField",
+      "category": "Food",
+      "type": "production",
+      "growth": 1.15,
+      "pbt": {
+        "1": 57.34767025089605,
+        "10": 202.62843488649938,
+        "50": 54040.62126642771
+      },
+      "outputs": {
+        "potatoes": 0.375
+      },
+      "inputs": {}
+    },
+    {
+      "id": "huntersHut",
+      "category": "Food",
+      "type": "production",
+      "growth": 1.15,
+      "pbt": {
+        "1": 268.1704260651629,
+        "10": 955.3884711779449,
+        "50": 252713.7844611529
+      },
+      "outputs": {
+        "meat": 0.15
+      },
+      "inputs": {}
+    },
+    {
+      "id": "loggingCamp",
+      "category": "Raw Materials",
+      "type": "production",
+      "growth": 1.15,
+      "pbt": {
+        "1": 138.94736842105263,
+        "10": 490.9473684210527,
+        "50": 130934.73684210528
+      },
+      "outputs": {
+        "wood": 0.25
+      },
+      "inputs": {}
+    },
+    {
+      "id": "scrapyard",
+      "category": "Raw Materials",
+      "type": "production",
+      "growth": 1.15,
+      "pbt": {
+        "1": 71.77033492822966,
+        "10": 257.17703349282294,
+        "50": 67631.57894736841
+      },
+      "outputs": {
+        "scrap": 0.08
+      },
+      "inputs": {}
+    },
+    {
+      "id": "quarry",
+      "category": "Raw Materials",
+      "type": "production",
+      "growth": 1.15,
+      "pbt": {
+        "1": 313.7651821862348,
+        "10": 1119.4331983805669,
+        "50": 295682.18623481784
+      },
+      "outputs": {
+        "stone": 0.08
+      },
+      "inputs": {}
+    },
+    {
+      "id": "sawmill",
+      "category": "Construction Materials",
+      "type": "processing",
+      "growth": 1.15,
+      "pbt": {
+        "1": 71.66666666666667,
+        "10": 253.6666666666667,
+        "50": 67534.33333333333
+      },
+      "outputs": {
+        "planks": 0.5
+      },
+      "inputs": {
+        "wood": 0.8
+      }
+    },
+    {
+      "id": "metalWorkshop",
+      "category": "Construction Materials",
+      "type": "processing",
+      "growth": 1.15,
+      "pbt": {
+        "1": 98.02631578947367,
+        "10": 348.6842105263157,
+        "50": 92375.7894736842
+      },
+      "outputs": {
+        "metalParts": 0.4
+      },
+      "inputs": {
+        "scrap": 0.4
+      }
+    },
+    {
+      "id": "school",
+      "category": "Science",
+      "type": "production",
+      "growth": 1.15,
+      "pbt": {
+        "1": 48,
+        "10": 171.2,
+        "50": 45233.6
+      },
+      "outputs": {
+        "science": 0.5
+      },
+      "inputs": {}
+    },
+    {
+      "id": "woodGenerator",
+      "category": "Energy",
+      "type": "production",
+      "growth": 1.15,
+      "pbt": {
+        "1": 84,
+        "10": 297.06666666666666,
+        "50": 79156.26666666666
+      },
+      "outputs": {
+        "power": 1
+      },
+      "inputs": {
+        "wood": 0.25
+      }
+    },
+    {
+      "id": "shelter",
+      "category": "Settlement",
+      "type": "production",
+      "growth": 1.8,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    },
+    {
+      "id": "radio",
+      "category": "Utilities",
+      "type": "production",
+      "growth": 1,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {
+        "power": 0.1
+      }
+    },
+    {
+      "id": "foodStorage",
+      "category": "",
+      "type": "storage",
+      "growth": 1.15,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    },
+    {
+      "id": "rawStorage",
+      "category": "",
+      "type": "storage",
+      "growth": 1.15,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    },
+    {
+      "id": "materialsDepot",
+      "category": "",
+      "type": "storage",
+      "growth": 1.15,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    },
+    {
+      "id": "battery",
+      "category": "",
+      "type": "storage",
+      "growth": 1.15,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    }
+  ],
+  "converters": [
+    {
+      "id": "sawmill",
+      "growth": 1.15,
+      "inputs": {
+        "wood": 0.8
+      },
+      "outputs": {
+        "planks": 0.5
+      },
+      "ratio": 2.5,
+      "pbt": {
+        "1": 71.66666666666667,
+        "10": 253.6666666666667,
+        "50": 67534.33333333333
+      },
+      "mode": "all-or-nothing"
+    },
+    {
+      "id": "metalWorkshop",
+      "growth": 1.15,
+      "inputs": {
+        "scrap": 0.4
+      },
+      "outputs": {
+        "metalParts": 0.4
+      },
+      "ratio": 2.7272727272727275,
+      "pbt": {
+        "1": 98.02631578947367,
+        "10": 348.6842105263157,
+        "50": 92375.7894736842
+      },
+      "mode": "all-or-nothing"
+    }
+  ],
+  "storage": [
+    {
+      "id": "foodStorage",
+      "growth": 1.15,
+      "capacity": {
+        "potatoes": 300,
+        "meat": 150
+      }
+    },
+    {
+      "id": "rawStorage",
+      "growth": 1.15,
+      "capacity": {
+        "wood": 200,
+        "stone": 80,
+        "scrap": 120
+      }
+    },
+    {
+      "id": "materialsDepot",
+      "growth": 1.15,
+      "capacity": {
+        "planks": 150,
+        "metalParts": 60
+      }
+    },
+    {
+      "id": "battery",
+      "growth": 1.15,
+      "capacity": {
+        "power": 40
+      }
+    }
+  ],
+  "outliers": {
+    "tooFast": [
+      {
+        "id": "potatoField",
+        "target": 1,
+        "value": 57.34767025089605
+      },
+      {
+        "id": "sawmill",
+        "target": 1,
+        "value": 71.66666666666667
+      },
+      {
+        "id": "school",
+        "target": 1,
+        "value": 48
+      },
+      {
+        "id": "school",
+        "target": 10,
+        "value": 171.2
+      }
+    ],
+    "tooSlow": [
+      {
+        "id": "potatoField",
+        "target": 50,
+        "value": 54040.62126642771
+      },
+      {
+        "id": "huntersHut",
+        "target": 1,
+        "value": 268.1704260651629
+      },
+      {
+        "id": "huntersHut",
+        "target": 10,
+        "value": 955.3884711779449
+      },
+      {
+        "id": "huntersHut",
+        "target": 50,
+        "value": 252713.7844611529
+      },
+      {
+        "id": "loggingCamp",
+        "target": 1,
+        "value": 138.94736842105263
+      },
+      {
+        "id": "loggingCamp",
+        "target": 10,
+        "value": 490.9473684210527
+      },
+      {
+        "id": "loggingCamp",
+        "target": 50,
+        "value": 130934.73684210528
+      },
+      {
+        "id": "scrapyard",
+        "target": 50,
+        "value": 67631.57894736841
+      },
+      {
+        "id": "quarry",
+        "target": 1,
+        "value": 313.7651821862348
+      },
+      {
+        "id": "quarry",
+        "target": 10,
+        "value": 1119.4331983805669
+      },
+      {
+        "id": "quarry",
+        "target": 50,
+        "value": 295682.18623481784
+      },
+      {
+        "id": "sawmill",
+        "target": 50,
+        "value": 67534.33333333333
+      },
+      {
+        "id": "metalWorkshop",
+        "target": 50,
+        "value": 92375.7894736842
+      },
+      {
+        "id": "school",
+        "target": 50,
+        "value": 45233.6
+      },
+      {
+        "id": "woodGenerator",
+        "target": 50,
+        "value": 79156.26666666666
+      }
+    ]
+  }
+}

--- a/reports/economy/20250812224454/baseline.md
+++ b/reports/economy/20250812224454/baseline.md
@@ -1,0 +1,63 @@
+# Economy Report
+
+## Summary
+Analyzed **15** buildings. Season mode: **average**.
+Weights: {"wood":1,"stone":1.3,"scrap":2.2,"planks":4,"metalParts":6,"power":1,"potatoes":0.9,"meat":1.4,"science":2.5}. Targets: 1, 10, 50.
+Outliers – too fast: 4, too slow: 15.
+
+## Buildings
+| id | category | type | growth | PBT@1 | PBT@10 | PBT@50 | out/s (base) | in/s (base) |
+| - | - | - | - | - | - | - | - | - |
+| potatoField | Food | production | 1.15 | 57.35 | 202.63 | 54,040.62 | potatoes:0.375 | - |
+| huntersHut | Food | production | 1.15 | 268.17 | 955.39 | 252,713.78 | meat:0.15 | - |
+| loggingCamp | Raw Materials | production | 1.15 | 138.95 | 490.95 | 130,934.74 | wood:0.25 | - |
+| scrapyard | Raw Materials | production | 1.15 | 71.77 | 257.18 | 67,631.58 | scrap:0.08 | - |
+| quarry | Raw Materials | production | 1.15 | 313.77 | 1,119.43 | 295,682.19 | stone:0.08 | - |
+| sawmill | Construction Materials | processing | 1.15 | 71.67 | 253.67 | 67,534.33 | planks:0.5 | wood:0.8 |
+| metalWorkshop | Construction Materials | processing | 1.15 | 98.03 | 348.68 | 92,375.79 | metalParts:0.4 | scrap:0.4 |
+| school | Science | production | 1.15 | 48 | 171.2 | 45,233.6 | science:0.5 | - |
+| woodGenerator | Energy | production | 1.15 | 84 | 297.07 | 79,156.27 | power:1 | wood:0.25 |
+| shelter | Settlement | production | 1.8 | — | — | — | - | - |
+| radio | Utilities | production | 1 | — | — | — | - | power:0.1 |
+| foodStorage |  | storage | 1.15 | — | — | — | - | - |
+| rawStorage |  | storage | 1.15 | — | — | — | - | - |
+| materialsDepot |  | storage | 1.15 | — | — | — | - | - |
+| battery |  | storage | 1.15 | — | — | — | - | - |
+
+## Converters
+| id | growth | in/s | out/s | ratio(out/in) | PBT@1 | PBT@10 | PBT@50 | mode |
+| - | - | - | - | - | - | - | - | - |
+| sawmill | 1.15 | wood:0.8 | planks:0.5 | 2.5 | 71.67 | 253.67 | 67,534.33 | all-or-nothing |
+| metalWorkshop | 1.15 | scrap:0.4 | metalParts:0.4 | 2.73 | 98.03 | 348.68 | 92,375.79 | all-or-nothing |
+
+## Storage
+| id | growth | +capacity |
+| - | - | - |
+| foodStorage | 1.15 | potatoes:300,meat:150 |
+| rawStorage | 1.15 | wood:200,stone:80,scrap:120 |
+| materialsDepot | 1.15 | planks:150,metalParts:60 |
+| battery | 1.15 | power:40 |
+
+## Outliers
+### Too Fast
+- potatoField @1: 57.35 sec
+- sawmill @1: 71.67 sec
+- school @1: 48 sec
+- school @10: 171.2 sec
+### Too Slow
+- potatoField @50: 54,040.62 sec
+- huntersHut @1: 268.17 sec
+- huntersHut @10: 955.39 sec
+- huntersHut @50: 252,713.78 sec
+- loggingCamp @1: 138.95 sec
+- loggingCamp @10: 490.95 sec
+- loggingCamp @50: 130,934.74 sec
+- scrapyard @50: 67,631.58 sec
+- quarry @1: 313.77 sec
+- quarry @10: 1,119.43 sec
+- quarry @50: 295,682.19 sec
+- sawmill @50: 67,534.33 sec
+- metalWorkshop @50: 92,375.79 sec
+- school @50: 45,233.6 sec
+- woodGenerator @50: 79,156.27 sec
+

--- a/reports/economy/20250812224454/baseline_after.json
+++ b/reports/economy/20250812224454/baseline_after.json
@@ -1,0 +1,425 @@
+{
+  "meta": {
+    "analyzed": 15,
+    "season": "average",
+    "weights": {
+      "wood": 1,
+      "stone": 1.3,
+      "scrap": 2.2,
+      "planks": 4,
+      "metalParts": 6,
+      "power": 1,
+      "potatoes": 0.9,
+      "meat": 1.4,
+      "science": 2.5
+    },
+    "targets": [
+      1,
+      10,
+      50
+    ],
+    "thresholds": {
+      "generators": {
+        "pbt1": [
+          60,
+          120
+        ],
+        "pbt10": [
+          180,
+          480
+        ],
+        "pbt50": [
+          900,
+          2700
+        ]
+      },
+      "converters": {
+        "pbt1": [
+          90,
+          150
+        ],
+        "pbt10": [
+          240,
+          600
+        ],
+        "pbt50": [
+          1200,
+          3600
+        ]
+      }
+    },
+    "outliers": {
+      "tooFast": 1,
+      "tooSlow": 13
+    }
+  },
+  "buildings": [
+    {
+      "id": "potatoField",
+      "category": "Food",
+      "type": "production",
+      "growth": 1.13,
+      "pbt": {
+        "1": 64.99402628434886,
+        "10": 198.80525686977296,
+        "50": 25924.970131421742
+      },
+      "outputs": {
+        "potatoes": 0.375
+      },
+      "inputs": {}
+    },
+    {
+      "id": "huntersHut",
+      "category": "Food",
+      "type": "production",
+      "growth": 1.15,
+      "pbt": {
+        "1": 223.47535505430244,
+        "10": 796.1570593149542,
+        "50": 210594.8203842941
+      },
+      "outputs": {
+        "meat": 0.19
+      },
+      "inputs": {}
+    },
+    {
+      "id": "loggingCamp",
+      "category": "Raw Materials",
+      "type": "production",
+      "growth": 1.13,
+      "pbt": {
+        "1": 115.78947368421053,
+        "10": 355.08771929824564,
+        "50": 46192.2807017544
+      },
+      "outputs": {
+        "wood": 0.3
+      },
+      "inputs": {}
+    },
+    {
+      "id": "scrapyard",
+      "category": "Raw Materials",
+      "type": "production",
+      "growth": 1.13,
+      "pbt": {
+        "1": 71.77033492822966,
+        "10": 221.2918660287081,
+        "50": 28630.382775119615
+      },
+      "outputs": {
+        "scrap": 0.08
+      },
+      "inputs": {}
+    },
+    {
+      "id": "quarry",
+      "category": "Raw Materials",
+      "type": "production",
+      "growth": 1.13,
+      "pbt": {
+        "1": 241.35783245094993,
+        "10": 748.9878542510123,
+        "50": 96286.20367486766
+      },
+      "outputs": {
+        "stone": 0.104
+      },
+      "inputs": {}
+    },
+    {
+      "id": "sawmill",
+      "category": "Construction Materials",
+      "type": "processing",
+      "growth": 1.13,
+      "pbt": {
+        "1": 86,
+        "10": 261.75000000000006,
+        "50": 34305.083333333336
+      },
+      "outputs": {
+        "planks": 0.5
+      },
+      "inputs": {
+        "wood": 0.8
+      }
+    },
+    {
+      "id": "metalWorkshop",
+      "category": "Construction Materials",
+      "type": "processing",
+      "growth": 1.13,
+      "pbt": {
+        "1": 98.02631578947367,
+        "10": 299.67105263157896,
+        "50": 39102.697368421046
+      },
+      "outputs": {
+        "metalParts": 0.4
+      },
+      "inputs": {
+        "scrap": 0.4
+      }
+    },
+    {
+      "id": "school",
+      "category": "Science",
+      "type": "production",
+      "growth": 1.13,
+      "pbt": {
+        "1": 64,
+        "10": 196,
+        "50": 25530.222222222223
+      },
+      "outputs": {
+        "science": 0.45
+      },
+      "inputs": {}
+    },
+    {
+      "id": "woodGenerator",
+      "category": "Energy",
+      "type": "production",
+      "growth": 1.13,
+      "pbt": {
+        "1": 84,
+        "10": 255.0666666666667,
+        "50": 33507.6
+      },
+      "outputs": {
+        "power": 1
+      },
+      "inputs": {
+        "wood": 0.25
+      }
+    },
+    {
+      "id": "shelter",
+      "category": "Settlement",
+      "type": "production",
+      "growth": 1.8,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    },
+    {
+      "id": "radio",
+      "category": "Utilities",
+      "type": "production",
+      "growth": 1,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {
+        "power": 0.1
+      }
+    },
+    {
+      "id": "foodStorage",
+      "category": "",
+      "type": "storage",
+      "growth": 1.2,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    },
+    {
+      "id": "rawStorage",
+      "category": "",
+      "type": "storage",
+      "growth": 1.2,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    },
+    {
+      "id": "materialsDepot",
+      "category": "",
+      "type": "storage",
+      "growth": 1.2,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    },
+    {
+      "id": "battery",
+      "category": "",
+      "type": "storage",
+      "growth": 1.2,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    }
+  ],
+  "converters": [
+    {
+      "id": "sawmill",
+      "growth": 1.13,
+      "inputs": {
+        "wood": 0.8
+      },
+      "outputs": {
+        "planks": 0.5
+      },
+      "ratio": 2.5,
+      "pbt": {
+        "1": 86,
+        "10": 261.75000000000006,
+        "50": 34305.083333333336
+      },
+      "mode": "all-or-nothing"
+    },
+    {
+      "id": "metalWorkshop",
+      "growth": 1.13,
+      "inputs": {
+        "scrap": 0.4
+      },
+      "outputs": {
+        "metalParts": 0.4
+      },
+      "ratio": 2.7272727272727275,
+      "pbt": {
+        "1": 98.02631578947367,
+        "10": 299.67105263157896,
+        "50": 39102.697368421046
+      },
+      "mode": "all-or-nothing"
+    }
+  ],
+  "storage": [
+    {
+      "id": "foodStorage",
+      "growth": 1.2,
+      "capacity": {
+        "potatoes": 300,
+        "meat": 150
+      }
+    },
+    {
+      "id": "rawStorage",
+      "growth": 1.2,
+      "capacity": {
+        "wood": 200,
+        "stone": 80,
+        "scrap": 90
+      }
+    },
+    {
+      "id": "materialsDepot",
+      "growth": 1.2,
+      "capacity": {
+        "planks": 300,
+        "metalParts": 240
+      }
+    },
+    {
+      "id": "battery",
+      "growth": 1.2,
+      "capacity": {
+        "power": 600
+      }
+    }
+  ],
+  "outliers": {
+    "tooFast": [
+      {
+        "id": "sawmill",
+        "target": 1,
+        "value": 86
+      }
+    ],
+    "tooSlow": [
+      {
+        "id": "potatoField",
+        "target": 50,
+        "value": 25924.970131421742
+      },
+      {
+        "id": "huntersHut",
+        "target": 1,
+        "value": 223.47535505430244
+      },
+      {
+        "id": "huntersHut",
+        "target": 10,
+        "value": 796.1570593149542
+      },
+      {
+        "id": "huntersHut",
+        "target": 50,
+        "value": 210594.8203842941
+      },
+      {
+        "id": "loggingCamp",
+        "target": 50,
+        "value": 46192.2807017544
+      },
+      {
+        "id": "scrapyard",
+        "target": 50,
+        "value": 28630.382775119615
+      },
+      {
+        "id": "quarry",
+        "target": 1,
+        "value": 241.35783245094993
+      },
+      {
+        "id": "quarry",
+        "target": 10,
+        "value": 748.9878542510123
+      },
+      {
+        "id": "quarry",
+        "target": 50,
+        "value": 96286.20367486766
+      },
+      {
+        "id": "sawmill",
+        "target": 50,
+        "value": 34305.083333333336
+      },
+      {
+        "id": "metalWorkshop",
+        "target": 50,
+        "value": 39102.697368421046
+      },
+      {
+        "id": "school",
+        "target": 50,
+        "value": 25530.222222222223
+      },
+      {
+        "id": "woodGenerator",
+        "target": 50,
+        "value": 33507.6
+      }
+    ]
+  }
+}

--- a/reports/economy/20250812224454/baseline_after.md
+++ b/reports/economy/20250812224454/baseline_after.md
@@ -1,0 +1,58 @@
+# Economy Report
+
+## Summary
+Analyzed **15** buildings. Season mode: **average**.
+Weights: {"wood":1,"stone":1.3,"scrap":2.2,"planks":4,"metalParts":6,"power":1,"potatoes":0.9,"meat":1.4,"science":2.5}. Targets: 1, 10, 50.
+Outliers – too fast: 1, too slow: 13.
+
+## Buildings
+| id | category | type | growth | PBT@1 | PBT@10 | PBT@50 | out/s (base) | in/s (base) |
+| - | - | - | - | - | - | - | - | - |
+| potatoField | Food | production | 1.13 | 64.99 | 198.81 | 25,924.97 | potatoes:0.375 | - |
+| huntersHut | Food | production | 1.15 | 223.48 | 796.16 | 210,594.82 | meat:0.19 | - |
+| loggingCamp | Raw Materials | production | 1.13 | 115.79 | 355.09 | 46,192.28 | wood:0.3 | - |
+| scrapyard | Raw Materials | production | 1.13 | 71.77 | 221.29 | 28,630.38 | scrap:0.08 | - |
+| quarry | Raw Materials | production | 1.13 | 241.36 | 748.99 | 96,286.2 | stone:0.104 | - |
+| sawmill | Construction Materials | processing | 1.13 | 86 | 261.75 | 34,305.08 | planks:0.5 | wood:0.8 |
+| metalWorkshop | Construction Materials | processing | 1.13 | 98.03 | 299.67 | 39,102.7 | metalParts:0.4 | scrap:0.4 |
+| school | Science | production | 1.13 | 64 | 196 | 25,530.22 | science:0.45 | - |
+| woodGenerator | Energy | production | 1.13 | 84 | 255.07 | 33,507.6 | power:1 | wood:0.25 |
+| shelter | Settlement | production | 1.8 | — | — | — | - | - |
+| radio | Utilities | production | 1 | — | — | — | - | power:0.1 |
+| foodStorage |  | storage | 1.2 | — | — | — | - | - |
+| rawStorage |  | storage | 1.2 | — | — | — | - | - |
+| materialsDepot |  | storage | 1.2 | — | — | — | - | - |
+| battery |  | storage | 1.2 | — | — | — | - | - |
+
+## Converters
+| id | growth | in/s | out/s | ratio(out/in) | PBT@1 | PBT@10 | PBT@50 | mode |
+| - | - | - | - | - | - | - | - | - |
+| sawmill | 1.13 | wood:0.8 | planks:0.5 | 2.5 | 86 | 261.75 | 34,305.08 | all-or-nothing |
+| metalWorkshop | 1.13 | scrap:0.4 | metalParts:0.4 | 2.73 | 98.03 | 299.67 | 39,102.7 | all-or-nothing |
+
+## Storage
+| id | growth | +capacity |
+| - | - | - |
+| foodStorage | 1.2 | potatoes:300,meat:150 |
+| rawStorage | 1.2 | wood:200,stone:80,scrap:90 |
+| materialsDepot | 1.2 | planks:300,metalParts:240 |
+| battery | 1.2 | power:600 |
+
+## Outliers
+### Too Fast
+- sawmill @1: 86 sec
+### Too Slow
+- potatoField @50: 25,924.97 sec
+- huntersHut @1: 223.48 sec
+- huntersHut @10: 796.16 sec
+- huntersHut @50: 210,594.82 sec
+- loggingCamp @50: 46,192.28 sec
+- scrapyard @50: 28,630.38 sec
+- quarry @1: 241.36 sec
+- quarry @10: 748.99 sec
+- quarry @50: 96,286.2 sec
+- sawmill @50: 34,305.08 sec
+- metalWorkshop @50: 39,102.7 sec
+- school @50: 25,530.22 sec
+- woodGenerator @50: 33,507.6 sec
+

--- a/reports/economy/20250812224454/per-season.md
+++ b/reports/economy/20250812224454/per-season.md
@@ -1,0 +1,40 @@
+# Economy Report
+
+## Summary
+Analyzed **15** buildings. Season mode: **all**.
+Weights: {"wood":1,"stone":1.3,"scrap":2.2,"planks":4,"metalParts":6,"power":1,"potatoes":0.9,"meat":1.4,"science":2.5}. Targets: 1, 10, 50.
+Outliers – too fast: 0, too slow: 0.
+
+## Buildings
+| id | category | type | growth | PBT@1[spring] | PBT@1[summer] | PBT@1[autumn] | PBT@1[winter] | PBT@10[spring] | PBT@10[summer] | PBT@10[autumn] | PBT@10[winter] | PBT@50[spring] | PBT@50[summer] | PBT@50[autumn] | PBT@50[winter] | out/s (base) | in/s (base) |
+| - | - | - | - | - | - | - | - | - | - | - | - | - | - | - | - | - | - |
+| potatoField | Food | production | 1.15 | 35.56 | 44.44 | 52.29 | — | 125.63 | 157.04 | 184.75 | — | 33,505.19 | 41,881.48 | 49,272.33 | — | potatoes:0.375 | - |
+| huntersHut | Food | production | 1.15 | 231.6 | 254.76 | 283.07 | 318.45 | 825.11 | 907.62 | 1,008.47 | 1,134.52 | 218,252.81 | 240,078.1 | 266,753.44 | 300,097.62 | meat:0.15 | - |
+| loggingCamp | Raw Materials | production | 1.15 | 120 | 132 | 146.67 | 165 | 424 | 466.4 | 518.22 | 583 | 113,080 | 124,388 | 138,208.89 | 155,485 | wood:0.25 | - |
+| scrapyard | Raw Materials | production | 1.15 | 61.98 | 68.18 | 75.76 | 85.23 | 222.11 | 244.32 | 271.46 | 305.4 | 58,409.09 | 64,250 | 71,388.89 | 80,312.5 | scrap:0.08 | - |
+| quarry | Raw Materials | production | 1.15 | 270.98 | 298.08 | 331.2 | 372.6 | 966.78 | 1,063.46 | 1,181.62 | 1,329.33 | 255,361.89 | 280,898.08 | 312,108.97 | 351,122.6 | stone:0.08 | - |
+| sawmill | Construction Materials | processing | 1.15 | 71.67 | 71.67 | 71.67 | 71.67 | 253.67 | 253.67 | 253.67 | 253.67 | 67,534.33 | 67,534.33 | 67,534.33 | 67,534.33 | planks:0.5 | wood:0.8 |
+| metalWorkshop | Construction Materials | processing | 1.15 | 98.03 | 98.03 | 98.03 | 98.03 | 348.68 | 348.68 | 348.68 | 348.68 | 92,375.79 | 92,375.79 | 92,375.79 | 92,375.79 | metalParts:0.4 | scrap:0.4 |
+| school | Science | production | 1.15 | 48 | 48 | 48 | 48 | 171.2 | 171.2 | 171.2 | 171.2 | 45,233.6 | 45,233.6 | 45,233.6 | 45,233.6 | science:0.5 | - |
+| woodGenerator | Energy | production | 1.15 | 84 | 84 | 84 | 84 | 297.07 | 297.07 | 297.07 | 297.07 | 79,156.27 | 79,156.27 | 79,156.27 | 79,156.27 | power:1 | wood:0.25 |
+| shelter | Settlement | production | 1.8 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+| radio | Utilities | production | 1 | — | — | — | — | — | — | — | — | — | — | — | — | - | power:0.1 |
+| foodStorage |  | storage | 1.15 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+| rawStorage |  | storage | 1.15 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+| materialsDepot |  | storage | 1.15 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+| battery |  | storage | 1.15 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+
+## Converters
+| id | growth | in/s | out/s | ratio(out/in) | PBT@1 | PBT@10 | PBT@50 | mode |
+| - | - | - | - | - | - | - | - | - |
+| sawmill | 1.15 | wood:0.8 | planks:0.5 | 2.5 | — | — | — | all-or-nothing |
+| metalWorkshop | 1.15 | scrap:0.4 | metalParts:0.4 | 2.73 | — | — | — | all-or-nothing |
+
+## Storage
+| id | growth | +capacity |
+| - | - | - |
+| foodStorage | 1.15 | potatoes:300,meat:150 |
+| rawStorage | 1.15 | wood:200,stone:80,scrap:120 |
+| materialsDepot | 1.15 | planks:150,metalParts:60 |
+| battery | 1.15 | power:40 |
+

--- a/reports/economy/20250812224454/per-season_after.md
+++ b/reports/economy/20250812224454/per-season_after.md
@@ -1,0 +1,40 @@
+# Economy Report
+
+## Summary
+Analyzed **15** buildings. Season mode: **all**.
+Weights: {"wood":1,"stone":1.3,"scrap":2.2,"planks":4,"metalParts":6,"power":1,"potatoes":0.9,"meat":1.4,"science":2.5}. Targets: 1, 10, 50.
+Outliers – too fast: 0, too slow: 0.
+
+## Buildings
+| id | category | type | growth | PBT@1[spring] | PBT@1[summer] | PBT@1[autumn] | PBT@1[winter] | PBT@10[spring] | PBT@10[summer] | PBT@10[autumn] | PBT@10[winter] | PBT@50[spring] | PBT@50[summer] | PBT@50[autumn] | PBT@50[winter] | out/s (base) | in/s (base) |
+| - | - | - | - | - | - | - | - | - | - | - | - | - | - | - | - | - | - |
+| potatoField | Food | production | 1.13 | 40.3 | 50.37 | 59.26 | — | 123.26 | 154.07 | 181.26 | — | 16,073.48 | 20,091.85 | 23,637.47 | — | potatoes:0.375 | - |
+| huntersHut | Food | production | 1.15 | 182.84 | 201.13 | 223.48 | 335.21 | 651.4 | 716.54 | 796.16 | 1,194.24 | 172,304.85 | 189,535.34 | 210,594.82 | 315,892.23 | meat:0.19 | - |
+| loggingCamp | Raw Materials | production | 1.13 | 100 | 110 | 122.22 | 137.5 | 306.67 | 337.33 | 374.81 | 421.67 | 39,893.33 | 43,882.67 | 48,758.52 | 54,853.33 | wood:0.3 | - |
+| scrapyard | Raw Materials | production | 1.13 | 61.98 | 68.18 | 75.76 | 85.23 | 191.12 | 210.23 | 233.59 | 262.78 | 24,726.24 | 27,198.86 | 30,220.96 | 33,998.58 | scrap:0.08 | - |
+| quarry | Raw Materials | production | 1.13 | 208.45 | 229.29 | 254.77 | 286.61 | 646.85 | 711.54 | 790.6 | 889.42 | 83,156.27 | 91,471.89 | 101,635.44 | 114,339.87 | stone:0.104 | - |
+| sawmill | Construction Materials | processing | 1.13 | 86 | 86 | 86 | 86 | 261.75 | 261.75 | 261.75 | 261.75 | 34,305.08 | 34,305.08 | 34,305.08 | 34,305.08 | planks:0.5 | wood:0.8 |
+| metalWorkshop | Construction Materials | processing | 1.13 | 98.03 | 98.03 | 98.03 | 98.03 | 299.67 | 299.67 | 299.67 | 299.67 | 39,102.7 | 39,102.7 | 39,102.7 | 39,102.7 | metalParts:0.4 | scrap:0.4 |
+| school | Science | production | 1.13 | 64 | 64 | 64 | 64 | 196 | 196 | 196 | 196 | 25,530.22 | 25,530.22 | 25,530.22 | 25,530.22 | science:0.45 | - |
+| woodGenerator | Energy | production | 1.13 | 84 | 84 | 84 | 84 | 255.07 | 255.07 | 255.07 | 255.07 | 33,507.6 | 33,507.6 | 33,507.6 | 33,507.6 | power:1 | wood:0.25 |
+| shelter | Settlement | production | 1.8 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+| radio | Utilities | production | 1 | — | — | — | — | — | — | — | — | — | — | — | — | - | power:0.1 |
+| foodStorage |  | storage | 1.2 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+| rawStorage |  | storage | 1.2 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+| materialsDepot |  | storage | 1.2 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+| battery |  | storage | 1.2 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+
+## Converters
+| id | growth | in/s | out/s | ratio(out/in) | PBT@1 | PBT@10 | PBT@50 | mode |
+| - | - | - | - | - | - | - | - | - |
+| sawmill | 1.13 | wood:0.8 | planks:0.5 | 2.5 | — | — | — | all-or-nothing |
+| metalWorkshop | 1.13 | scrap:0.4 | metalParts:0.4 | 2.73 | — | — | — | all-or-nothing |
+
+## Storage
+| id | growth | +capacity |
+| - | - | - |
+| foodStorage | 1.2 | potatoes:300,meat:150 |
+| rawStorage | 1.2 | wood:200,stone:80,scrap:90 |
+| materialsDepot | 1.2 | planks:300,metalParts:240 |
+| battery | 1.2 | power:600 |
+

--- a/reports/economy/20250812224454/winter.md
+++ b/reports/economy/20250812224454/winter.md
@@ -1,0 +1,61 @@
+# Economy Report
+
+## Summary
+Analyzed **15** buildings. Season mode: **winter**.
+Weights: {"wood":1,"stone":1.3,"scrap":2.2,"planks":4,"metalParts":6,"power":1,"potatoes":0.9,"meat":1.4,"science":2.5}. Targets: 1, 10, 50.
+Outliers – too fast: 3, too slow: 14.
+
+## Buildings
+| id | category | type | growth | PBT@1 | PBT@10 | PBT@50 | out/s (base) | in/s (base) |
+| - | - | - | - | - | - | - | - | - |
+| potatoField | Food | production | 1.15 | — | — | — | potatoes:0.375 | - |
+| huntersHut | Food | production | 1.15 | 318.45 | 1,134.52 | 300,097.62 | meat:0.15 | - |
+| loggingCamp | Raw Materials | production | 1.15 | 165 | 583 | 155,485 | wood:0.25 | - |
+| scrapyard | Raw Materials | production | 1.15 | 85.23 | 305.4 | 80,312.5 | scrap:0.08 | - |
+| quarry | Raw Materials | production | 1.15 | 372.6 | 1,329.33 | 351,122.6 | stone:0.08 | - |
+| sawmill | Construction Materials | processing | 1.15 | 71.67 | 253.67 | 67,534.33 | planks:0.5 | wood:0.8 |
+| metalWorkshop | Construction Materials | processing | 1.15 | 98.03 | 348.68 | 92,375.79 | metalParts:0.4 | scrap:0.4 |
+| school | Science | production | 1.15 | 48 | 171.2 | 45,233.6 | science:0.5 | - |
+| woodGenerator | Energy | production | 1.15 | 84 | 297.07 | 79,156.27 | power:1 | wood:0.25 |
+| shelter | Settlement | production | 1.8 | — | — | — | - | - |
+| radio | Utilities | production | 1 | — | — | — | - | power:0.1 |
+| foodStorage |  | storage | 1.15 | — | — | — | - | - |
+| rawStorage |  | storage | 1.15 | — | — | — | - | - |
+| materialsDepot |  | storage | 1.15 | — | — | — | - | - |
+| battery |  | storage | 1.15 | — | — | — | - | - |
+
+## Converters
+| id | growth | in/s | out/s | ratio(out/in) | PBT@1 | PBT@10 | PBT@50 | mode |
+| - | - | - | - | - | - | - | - | - |
+| sawmill | 1.15 | wood:0.8 | planks:0.5 | 2.5 | 71.67 | 253.67 | 67,534.33 | all-or-nothing |
+| metalWorkshop | 1.15 | scrap:0.4 | metalParts:0.4 | 2.73 | 98.03 | 348.68 | 92,375.79 | all-or-nothing |
+
+## Storage
+| id | growth | +capacity |
+| - | - | - |
+| foodStorage | 1.15 | potatoes:300,meat:150 |
+| rawStorage | 1.15 | wood:200,stone:80,scrap:120 |
+| materialsDepot | 1.15 | planks:150,metalParts:60 |
+| battery | 1.15 | power:40 |
+
+## Outliers
+### Too Fast
+- sawmill @1: 71.67 sec
+- school @1: 48 sec
+- school @10: 171.2 sec
+### Too Slow
+- huntersHut @1: 318.45 sec
+- huntersHut @10: 1,134.52 sec
+- huntersHut @50: 300,097.62 sec
+- loggingCamp @1: 165 sec
+- loggingCamp @10: 583 sec
+- loggingCamp @50: 155,485 sec
+- scrapyard @50: 80,312.5 sec
+- quarry @1: 372.6 sec
+- quarry @10: 1,329.33 sec
+- quarry @50: 351,122.6 sec
+- sawmill @50: 67,534.33 sec
+- metalWorkshop @50: 92,375.79 sec
+- school @50: 45,233.6 sec
+- woodGenerator @50: 79,156.27 sec
+

--- a/reports/economy/20250812224454/winter_after.md
+++ b/reports/economy/20250812224454/winter_after.md
@@ -1,0 +1,58 @@
+# Economy Report
+
+## Summary
+Analyzed **15** buildings. Season mode: **winter**.
+Weights: {"wood":1,"stone":1.3,"scrap":2.2,"planks":4,"metalParts":6,"power":1,"potatoes":0.9,"meat":1.4,"science":2.5}. Targets: 1, 10, 50.
+Outliers – too fast: 1, too slow: 13.
+
+## Buildings
+| id | category | type | growth | PBT@1 | PBT@10 | PBT@50 | out/s (base) | in/s (base) |
+| - | - | - | - | - | - | - | - | - |
+| potatoField | Food | production | 1.13 | — | — | — | potatoes:0.375 | - |
+| huntersHut | Food | production | 1.15 | 335.21 | 1,194.24 | 315,892.23 | meat:0.19 | - |
+| loggingCamp | Raw Materials | production | 1.13 | 137.5 | 421.67 | 54,853.33 | wood:0.3 | - |
+| scrapyard | Raw Materials | production | 1.13 | 85.23 | 262.78 | 33,998.58 | scrap:0.08 | - |
+| quarry | Raw Materials | production | 1.13 | 286.61 | 889.42 | 114,339.87 | stone:0.104 | - |
+| sawmill | Construction Materials | processing | 1.13 | 86 | 261.75 | 34,305.08 | planks:0.5 | wood:0.8 |
+| metalWorkshop | Construction Materials | processing | 1.13 | 98.03 | 299.67 | 39,102.7 | metalParts:0.4 | scrap:0.4 |
+| school | Science | production | 1.13 | 64 | 196 | 25,530.22 | science:0.45 | - |
+| woodGenerator | Energy | production | 1.13 | 84 | 255.07 | 33,507.6 | power:1 | wood:0.25 |
+| shelter | Settlement | production | 1.8 | — | — | — | - | - |
+| radio | Utilities | production | 1 | — | — | — | - | power:0.1 |
+| foodStorage |  | storage | 1.2 | — | — | — | - | - |
+| rawStorage |  | storage | 1.2 | — | — | — | - | - |
+| materialsDepot |  | storage | 1.2 | — | — | — | - | - |
+| battery |  | storage | 1.2 | — | — | — | - | - |
+
+## Converters
+| id | growth | in/s | out/s | ratio(out/in) | PBT@1 | PBT@10 | PBT@50 | mode |
+| - | - | - | - | - | - | - | - | - |
+| sawmill | 1.13 | wood:0.8 | planks:0.5 | 2.5 | 86 | 261.75 | 34,305.08 | all-or-nothing |
+| metalWorkshop | 1.13 | scrap:0.4 | metalParts:0.4 | 2.73 | 98.03 | 299.67 | 39,102.7 | all-or-nothing |
+
+## Storage
+| id | growth | +capacity |
+| - | - | - |
+| foodStorage | 1.2 | potatoes:300,meat:150 |
+| rawStorage | 1.2 | wood:200,stone:80,scrap:90 |
+| materialsDepot | 1.2 | planks:300,metalParts:240 |
+| battery | 1.2 | power:600 |
+
+## Outliers
+### Too Fast
+- sawmill @1: 86 sec
+### Too Slow
+- huntersHut @1: 335.21 sec
+- huntersHut @10: 1,194.24 sec
+- huntersHut @50: 315,892.23 sec
+- loggingCamp @1: 137.5 sec
+- loggingCamp @50: 54,853.33 sec
+- scrapyard @50: 33,998.58 sec
+- quarry @1: 286.61 sec
+- quarry @10: 889.42 sec
+- quarry @50: 114,339.87 sec
+- sawmill @50: 34,305.08 sec
+- metalWorkshop @50: 39,102.7 sec
+- school @50: 25,530.22 sec
+- woodGenerator @50: 33,507.6 sec
+

--- a/src/data/balance.js
+++ b/src/data/balance.js
@@ -13,8 +13,8 @@ export function XP_TIME_TO_NEXT_LEVEL_SECONDS(level) {
 }
 
 export function ROLE_BONUS_PER_SETTLER(level) {
-  if (level <= 10) return 0.1 * level;
-  return 1.0 + 0.05 * (level - 10);
+  if (level <= 10) return 0.02 * level; // changed: 0.1*level→0.02*level
+  return 0.2 + 0.01 * (level - 10); // changed: 1+0.05*(level-10)→0.2+0.01*(level-10)
 }
 
 export function FOOD_VARIETY_BONUS(count) {

--- a/src/data/buildings.js
+++ b/src/data/buildings.js
@@ -7,8 +7,8 @@ export const BUILDINGS = [
     type: 'production',
     category: 'Food',
     outputsPerSecBase: { potatoes: 0.375 },
-    costBase: { wood: 15 },
-    costGrowth: 1.15,
+    costBase: { wood: 17 }, // changed: 15→17
+    costGrowth: 1.13, // changed: 1.15→1.13
     refund: 0.5,
     description: 'Reliable staple crop. Strongly affected by seasons.',
   },
@@ -18,11 +18,11 @@ export const BUILDINGS = [
     type: 'production',
     category: 'Food',
     requiresResearch: 'hunting1',
-    outputsPerSecBase: { meat: 0.15 },
+    outputsPerSecBase: { meat: 0.19 }, // changed: 0.15→0.19
     costBase: { wood: 25, scrap: 10, stone: 5 },
     costGrowth: 1.15,
     refund: 0.5,
-    seasonProfile: { spring: 1.1, summer: 1.0, autumn: 0.9, winter: 0.8 },
+    seasonProfile: { spring: 1.1, summer: 1.0, autumn: 0.9, winter: 0.6 }, // changed: winter 0.8→0.6
     description:
       'Hunts for meat year-round; less affected by seasons than crops.',
   },
@@ -31,9 +31,9 @@ export const BUILDINGS = [
     name: 'Logging Camp',
     type: 'production',
     category: 'Raw Materials',
-    outputsPerSecBase: { wood: 0.25 },
+    outputsPerSecBase: { wood: 0.3 }, // changed: 0.25→0.3
     costBase: { scrap: 15 },
-    costGrowth: 1.15,
+    costGrowth: 1.13, // changed: 1.15→1.13
     refund: 0.5,
     description: 'Steady wood income. Slight weather impact.',
   },
@@ -44,7 +44,7 @@ export const BUILDINGS = [
     category: 'Raw Materials',
     outputsPerSecBase: { scrap: 0.08 },
     costBase: { wood: 12 },
-    costGrowth: 1.15,
+    costGrowth: 1.13, // changed: 1.15→1.13
     refund: 0.5,
     description: 'Collects scrap from nearby ruins.',
   },
@@ -53,9 +53,9 @@ export const BUILDINGS = [
     name: 'Quarry',
     type: 'production',
     category: 'Raw Materials',
-    outputsPerSecBase: { stone: 0.08 },
+    outputsPerSecBase: { stone: 0.104 }, // changed: 0.08→0.104
     costBase: { wood: 20, scrap: 5 },
-    costGrowth: 1.15,
+    costGrowth: 1.13, // changed: 1.15→1.13
     refund: 0.5,
     description: 'Extracts stone slowly but steadily.',
   },
@@ -67,8 +67,8 @@ export const BUILDINGS = [
     requiresResearch: 'industry1',
     inputsPerSecBase: { wood: 0.8 },
     outputsPerSecBase: { planks: 0.5 },
-    costBase: { wood: 40, scrap: 15, stone: 10 },
-    costGrowth: 1.15,
+    costBase: { wood: 48, scrap: 18, stone: 12 }, // changed: wood 40→48, scrap 15→18, stone 10→12
+    costGrowth: 1.13, // changed: 1.15→1.13
     refund: 0.5,
     seasonProfile: 'constant',
     description: 'Converts wood into planks.',
@@ -82,7 +82,7 @@ export const BUILDINGS = [
     inputsPerSecBase: { scrap: 0.4 },
     outputsPerSecBase: { metalParts: 0.4 },
     costBase: { wood: 30, scrap: 30, stone: 10, planks: 10 },
-    costGrowth: 1.15,
+    costGrowth: 1.13, // changed: 1.15→1.13
     refund: 0.5,
     seasonProfile: 'constant',
     description: 'Processes scrap into metal parts.',
@@ -92,9 +92,9 @@ export const BUILDINGS = [
     name: 'School',
     type: 'production',
     category: 'Science',
-    outputsPerSecBase: { science: 0.5 },
-    costBase: { wood: 25, scrap: 10, stone: 10 },
-    costGrowth: 1.15,
+    outputsPerSecBase: { science: 0.45 }, // changed: 0.5→0.45
+    costBase: { wood: 30, scrap: 12, stone: 12 }, // changed: wood 25→30, scrap 10→12, stone 10→12
+    costGrowth: 1.13, // changed: 1.15→1.13
     refund: 0.5,
     description: 'Provides basic education and generates science.',
   },
@@ -106,7 +106,7 @@ export const BUILDINGS = [
     outputsPerSecBase: { power: 1 },
     inputsPerSecBase: { wood: 0.25 },
     costBase: { wood: 50, stone: 10 },
-    costGrowth: 1.15,
+    costGrowth: 1.13, // changed: 1.15→1.13
     refund: 0.5,
     requiresResearch: 'basicEnergy',
     description:
@@ -131,7 +131,7 @@ export const BUILDINGS = [
     requiresResearch: 'radio',
     requiresPower: true,
     inputsPerSecBase: { power: 0.1 },
-    costBase: { wood: 80, scrap: 40, stone: 20 },
+    costBase: { wood: 80, scrap: 40, stone: 20, planks: 20 }, // changed: +planks 20
     costGrowth: 1,
     refund: 0.5,
     maxCount: 1,
@@ -142,7 +142,7 @@ export const BUILDINGS = [
     name: 'Granary',
     type: 'storage',
     costBase: { wood: 20, scrap: 5, stone: 5 },
-    costGrowth: 1.15,
+    costGrowth: 1.2, // changed: 1.15→1.2
     refund: 0.5,
     capacityAdd: { potatoes: 300, meat: 150 },
     description: 'Increases storage for harvested crops.',
@@ -152,9 +152,9 @@ export const BUILDINGS = [
     name: 'Warehouse',
     type: 'storage',
     costBase: { wood: 25, scrap: 10, stone: 10 },
-    costGrowth: 1.15,
+    costGrowth: 1.2, // changed: 1.15→1.2
     refund: 0.5,
-    capacityAdd: { wood: 200, stone: 80, scrap: 120 },
+    capacityAdd: { wood: 200, stone: 80, scrap: 90 }, // changed: scrap 120→90
     description: 'Increases storage for wood, stone and scrap.',
   },
   {
@@ -163,9 +163,9 @@ export const BUILDINGS = [
     type: 'storage',
     requiresResearch: 'industry1',
     costBase: { wood: 25, scrap: 10, stone: 5 },
-    costGrowth: 1.15,
+    costGrowth: 1.2, // changed: 1.15→1.2
     refund: 0.5,
-    capacityAdd: { planks: 150, metalParts: 60 },
+    capacityAdd: { planks: 300, metalParts: 240 }, // changed: planks 150→300, metalParts 60→240
     description: 'Stores processed construction materials.',
   },
   {
@@ -173,9 +173,9 @@ export const BUILDINGS = [
     name: 'Battery',
     type: 'storage',
     costBase: { wood: 40, stone: 20 },
-    costGrowth: 1.15,
+    costGrowth: 1.2, // changed: 1.15→1.2
     refund: 0.5,
-    capacityAdd: { power: 40 },
+    capacityAdd: { power: 600 }, // changed: 40→600
     requiresResearch: 'basicEnergy',
     description: 'Allows storing more generated Power.',
   },

--- a/src/data/research.js
+++ b/src/data/research.js
@@ -38,8 +38,8 @@ export const RESEARCH = [
     name: 'Hunting I',
     type: 'unlock',
     shortDesc: 'Unlocks hunting for supplemental food.',
-    cost: { science: 35 },
-    timeSec: 45,
+    cost: { science: 50 }, // changed: 35→50
+    timeSec: 90, // changed: 45→90
     prereqs: [],
     unlocks: { buildings: ['huntersHut'], resources: ['meat'] },
     row: 1,
@@ -50,8 +50,8 @@ export const RESEARCH = [
     name: 'Radio',
     type: 'unlock',
     shortDesc: 'Unlocks radio broadcasts to attract settlers.',
-    cost: { science: 120 },
-    timeSec: 180,
+    cost: { science: 150 }, // changed: 120→150
+    timeSec: 240, // changed: 180→240
     prereqs: ['industry1', 'basicEnergy'],
     unlocks: { buildings: ['radio'] },
     row: 1,
@@ -62,8 +62,8 @@ export const RESEARCH = [
     name: 'Woodworking I',
     type: 'efficiency',
     shortDesc: '+5% to wood and derived planks.',
-    cost: { science: 50 },
-    timeSec: 70,
+    cost: { science: 60 }, // changed: 50→60
+    timeSec: 90, // changed: 70→90
     prereqs: ['industry1'],
     effects: [{ category: 'WOOD', percent: 0.05, type: 'output' }],
     row: 1,
@@ -73,8 +73,8 @@ export const RESEARCH = [
     name: 'Salvaging I',
     type: 'efficiency',
     shortDesc: '+5% to scrap and derived metal parts.',
-    cost: { science: 50 },
-    timeSec: 70,
+    cost: { science: 60 }, // changed: 50→60
+    timeSec: 90, // changed: 70→90
     prereqs: ['industry1'],
     effects: [{ category: 'SCRAP', percent: 0.05, type: 'output' }],
     row: 1,
@@ -112,8 +112,8 @@ export const RESEARCH = [
     name: 'Woodworking II',
     type: 'efficiency',
     shortDesc: 'Additional +5% to wood and planks.',
-    cost: { science: 110 },
-    timeSec: 180,
+    cost: { science: 140 }, // changed: 110→140
+    timeSec: 240, // changed: 180→240
     prereqs: ['woodworking1', 'industry2'],
     effects: [{ category: 'WOOD', percent: 0.05, type: 'output' }],
     row: 3,
@@ -123,8 +123,8 @@ export const RESEARCH = [
     name: 'Salvaging II',
     type: 'efficiency',
     shortDesc: 'Additional +5% to scrap and metal parts.',
-    cost: { science: 110 },
-    timeSec: 180,
+    cost: { science: 140 }, // changed: 110→140
+    timeSec: 240, // changed: 180→240
     prereqs: ['salvaging1', 'industry2'],
     effects: [{ category: 'SCRAP', percent: 0.05, type: 'output' }],
     row: 3,
@@ -135,14 +135,36 @@ export const RESEARCH = [
     type: 'efficiency',
     shortDesc:
       'Additional +5% storage capacity for raw materials and construction materials.',
-    cost: { science: 120 },
-    timeSec: 210,
+    cost: { science: 150 }, // changed: 120→150
+    timeSec: 270, // changed: 210→270
     prereqs: ['logistics1', 'industry2'],
     effects: [
       { category: 'RAW', percent: 0.05, type: 'storage' },
       { category: 'CONSTRUCTION_MATERIALS', percent: 0.05, type: 'storage' },
     ],
     row: 3,
+  },
+  {
+    id: 'hunting2',
+    name: 'Hunting II',
+    type: 'efficiency',
+    shortDesc: '+10% to all food outputs.',
+    cost: { science: 130 },
+    timeSec: 240,
+    prereqs: ['hunting1'],
+    effects: [{ category: 'FOOD', percent: 0.1, type: 'output' }],
+    row: 2,
+  },
+  {
+    id: 'industryProduction',
+    name: 'Industry Production',
+    type: 'efficiency',
+    shortDesc: '+10% output for construction materials.',
+    cost: { science: 130 },
+    timeSec: 240,
+    prereqs: ['industry1'],
+    effects: [{ category: 'CONSTRUCTION_MATERIALS', percent: 0.1, type: 'output' }],
+    row: 2,
   },
 ];
 

--- a/src/data/resources.js
+++ b/src/data/resources.js
@@ -5,7 +5,7 @@ export const RESOURCES = {
     icon: '🥔',
     category: 'FOOD',
     startingAmount: 0,
-    startingCapacity: 300,
+    startingCapacity: 450, // changed: 300→450
   },
   meat: {
     id: 'meat',
@@ -13,7 +13,7 @@ export const RESOURCES = {
     icon: '🍖',
     category: 'FOOD',
     startingAmount: 0,
-    startingCapacity: 300,
+    startingCapacity: 150, // changed: 300→150
     unit: '',
   },
   wood: {
@@ -22,7 +22,7 @@ export const RESOURCES = {
     icon: '🪵',
     category: 'RAW',
     startingAmount: 0,
-    startingCapacity: 100,
+    startingCapacity: 150, // changed: 100→150
   },
   stone: {
     id: 'stone',
@@ -30,7 +30,7 @@ export const RESOURCES = {
     icon: '🪨',
     category: 'RAW',
     startingAmount: 0,
-    startingCapacity: 100,
+    startingCapacity: 80, // changed: 100→80
   },
   scrap: {
     id: 'scrap',
@@ -38,7 +38,7 @@ export const RESOURCES = {
     icon: '♻️',
     category: 'RAW',
     startingAmount: 0,
-    startingCapacity: 100,
+    startingCapacity: 80, // changed: 100→80
   },
   planks: {
     id: 'planks',

--- a/src/data/settlement.js
+++ b/src/data/settlement.js
@@ -1,3 +1,3 @@
-export const RADIO_BASE_SECONDS = 60;
+export const RADIO_BASE_SECONDS = 120; // changed: 60→120
 export const SHELTER_MAX = 5;
 export const SHELTER_COST_GROWTH = 1.8;

--- a/src/dev/__tests__/economyMath.test.ts
+++ b/src/dev/__tests__/economyMath.test.ts
@@ -45,7 +45,7 @@ describe('economyMath helpers', () => {
     );
     const huntersHut = BUILDINGS.find((b) => b.id === 'huntersHut');
     expect(huntersHut).toBeDefined();
-    expect(seasonMultiplier(huntersHut!, 'winter', seasons)).toBeCloseTo(0.8);
+    expect(seasonMultiplier(huntersHut!, 'winter', seasons)).toBeCloseTo(0.6); // changed: 0.8→0.6
   });
 
   it('seasonMultiplier constant profile returns 1', () => {

--- a/src/engine/__tests__/economy.test.js
+++ b/src/engine/__tests__/economy.test.js
@@ -73,6 +73,6 @@ describe('economy basics', () => {
     state.gameTime.seconds = SEASON_DURATION * 3;
     state.buildings.huntersHut = { count: 1 };
     const next = processTick(state, 1);
-    expect(next.resources.meat.amount).toBeCloseTo(0.15 * 0.8, 5);
+    expect(next.resources.meat.amount).toBeCloseTo(0.19 * 0.6, 5); // changed: 0.15*0.8→0.19*0.6
   });
 });

--- a/src/engine/__tests__/research.test.js
+++ b/src/engine/__tests__/research.test.js
@@ -54,7 +54,7 @@ describe('research engine', () => {
     }));
     let s = startResearch(state, 'industry1');
     const bonuses = computeRoleBonuses(state.population.settlers);
-    s = processResearchTick(s, 12, bonuses);
+    s = processResearchTick(s, 40, bonuses); // changed: 12→40
     expect(s.research.current).not.toBe(null);
     s = processResearchTick(s, 1, bonuses);
     expect(s.research.current).toBe(null);


### PR DESCRIPTION
## Summary
- tune generator and processor costs, outputs, and growth for saner payback times
- tighten storage and starting capacities; add plank cost to radio
- normalize research pacing and role bonuses, add modest food/industry research nodes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bc37de6d48331a4be8768a42a4af4