### PR TITLE
Fix styling and layout with default Shadcn theme

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,9 +27,9 @@ function ActiveView() {
 export default function App() {
   return (
     <GameProvider>
-      <div className="h-screen flex flex-col bg-background text-foreground overflow-hidden">
+      <div className="min-h-screen flex flex-col bg-background text-foreground">
         <TopBar />
-        <div className="flex-1 overflow-hidden">
+        <div className="flex-1">
           <ActiveView />
         </div>
         <BottomDock />

--- a/src/components/BuildingRow.jsx
+++ b/src/components/BuildingRow.jsx
@@ -105,7 +105,6 @@ export default function BuildingRow({ building, completedResearch }) {
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
-                  variant="outline"
                   size="sm"
                   onClick={build}
                   disabled={!canAfford || !unlocked || atMax}
@@ -117,7 +116,6 @@ export default function BuildingRow({ building, completedResearch }) {
             </Tooltip>
           ) : (
             <Button
-              variant="outline"
               size="sm"
               onClick={build}
               disabled={!canAfford || !unlocked || atMax}
@@ -126,7 +124,7 @@ export default function BuildingRow({ building, completedResearch }) {
             </Button>
           )}
           <Button
-            variant="outline"
+            variant="destructive"
             size="sm"
             onClick={demolish}
             disabled={count <= 0}

--- a/src/components/CorruptSaveModal.jsx
+++ b/src/components/CorruptSaveModal.jsx
@@ -28,10 +28,8 @@ export default function CorruptSaveModal() {
             </DialogDescription>
           </DialogHeader>
           <DialogFooter className="flex justify-end gap-2">
-            <Button variant="outline" onClick={retryLoad}>
-              Retry
-            </Button>
-            <Button variant="outline" onClick={resetGame}>
+            <Button onClick={retryLoad}>Retry</Button>
+            <Button variant="destructive" onClick={resetGame}>
               Reset
             </Button>
           </DialogFooter>

--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -72,7 +72,6 @@ export default function Drawer() {
             <h2 className="font-semibold mb-2">💾 Save/Load</h2>
             <div className="flex gap-2">
               <Button
-                variant="outline"
                 size="sm"
                 onClick={() => {
                   exportSaveFile(state);
@@ -87,11 +86,7 @@ export default function Drawer() {
               >
                 Save
               </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => fileInput.current?.click()}
-              >
+              <Button size="sm" onClick={() => fileInput.current?.click()}>
                 Load
               </Button>
               <Input
@@ -105,7 +100,7 @@ export default function Drawer() {
           </section>
           <section>
             <h2 className="font-semibold mb-2">🧹 Reset</h2>
-            <Button variant="outline" size="sm" onClick={resetGame}>
+            <Button variant="destructive" size="sm" onClick={resetGame}>
               Reset colony
             </Button>
           </section>

--- a/src/components/OfflineProgressModal.jsx
+++ b/src/components/OfflineProgressModal.jsx
@@ -37,9 +37,7 @@ export default function OfflineProgressModal() {
             ))}
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={dismissOfflineModal}>
-              Continue
-            </Button>
+            <Button onClick={dismissOfflineModal}>Continue</Button>
           </DialogFooter>
         </DialogContent>
       )}

--- a/src/components/PowerPriorityModal.jsx
+++ b/src/components/PowerPriorityModal.jsx
@@ -96,12 +96,14 @@ export default function PowerPriorityModal({ onClose }) {
             );
           })}
         </ul>
-        <div className="text-center text-xs muted-foreground mt-2">LOW PRIORITY</div>
+        <div className="text-center text-xs muted-foreground mt-2">
+          LOW PRIORITY
+        </div>
         <DialogFooter className="mt-4 flex justify-end gap-2">
-          <Button variant="outline" size="sm" onClick={onClose}>
+          <Button variant="secondary" size="sm" onClick={onClose}>
             Cancel
           </Button>
-          <Button variant="outline" size="sm" onClick={save}>
+          <Button size="sm" onClick={save}>
             Save
           </Button>
         </DialogFooter>

--- a/src/index.css
+++ b/src/index.css
@@ -4,58 +4,48 @@
 
 @layer base {
   :root {
-      --background: 42 48% 100%;
-      --foreground: 42 80% 2%;
-      --muted: 12 11% 87%;
-      --muted-foreground: 12 5% 80%;
-      --popover: 42 48% 100%;
-      --popover-foreground: 42 65% 5%;
-      --card: 0 0% 99%;
-      --card-foreground: 42 70% 3%;
-      --border: 42 12% 80%;
-      --input: 42 12% 93%;
-      --primary: 42 15% 18%;
-      --primary-foreground: 42 11% 90%;
-      --secondary: 12 11% 21%;
-      --secondary-foreground: 12 11% 81%;
-      --accent: 72 11% 21%;
-      --accent-foreground: 72 11% 81%;
-      --destructive: 4 91% 40%;
-      --destructive-foreground: 0 0% 100%;
-      --ring: 42 11% 21%;
-      --chart-1: 42 11% 21%;
-      --chart-2: 12 11% 21%;
-      --chart-3: 72 11% 21%;
-      --chart-4: 12 11% 24%;
-      --chart-5: 42 14% 21%;
-      --radius: 0.5rem;
+    --background: 0 0% 100%;
+    --foreground: 240 10% 3.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 240 10% 3.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 240 10% 3.9%;
+    --primary: 240 5.9% 10%;
+    --primary-foreground: 0 0% 98%;
+    --secondary: 240 4.8% 95.9%;
+    --secondary-foreground: 240 5.9% 10%;
+    --muted: 240 4.8% 95.9%;
+    --muted-foreground: 240 3.8% 46.1%;
+    --accent: 240 4.8% 95.9%;
+    --accent-foreground: 240 5.9% 10%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 240 5.9% 90%;
+    --input: 240 5.9% 90%;
+    --ring: 240 5.9% 10%;
+    --radius: 0.5rem;
   }
 
   .dark {
-      --background: 42 37% 2%;
-      --foreground: 42 60% 98%;
-      --muted: 12 11% 13%;
-      --muted-foreground: 42 8% 80%;
-      --popover: 42 37% 2%;
-      --popover-foreground: 42 32% 98%;
-      --card: 42 37% 3%;
-      --card-foreground: 42 50% 99%;
-      --border: 42 12% 12%;
-      --input: 42 12% 11%;
-      --primary: 42 15% 25%;
-      --primary-foreground: 42 11% 92%;
-      --secondary: 12 11% 21%;
-      --secondary-foreground: 12 11% 81%;
-      --accent: 72 11% 21%;
-      --accent-foreground: 72 11% 81%;
-      --destructive: 4 91% 46%;
-      --destructive-foreground: 0 0% 100%;
-      --ring: 42 11% 21%;
-      --chart-1: 42 11% 21%;
-      --chart-2: 12 11% 21%;
-      --chart-3: 72 11% 21%;
-      --chart-4: 12 11% 24%;
-      --chart-5: 42 14% 21%;
+    --background: 240 10% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 240 10% 3.9%;
+    --card-foreground: 0 0% 98%;
+    --popover: 240 10% 3.9%;
+    --popover-foreground: 0 0% 98%;
+    --primary: 0 0% 98%;
+    --primary-foreground: 240 5.9% 10%;
+    --secondary: 240 3.7% 15.9%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 240 3.7% 15.9%;
+    --muted-foreground: 240 5% 64.9%;
+    --accent: 240 3.7% 15.9%;
+    --accent-foreground: 0 0% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 240 3.7% 15.9%;
+    --input: 240 3.7% 15.9%;
+    --ring: 240 4.9% 83.9%;
   }
 
   html,

--- a/src/views/BaseView.jsx
+++ b/src/views/BaseView.jsx
@@ -14,10 +14,10 @@ export default function BaseView() {
 
   return (
     <div className="h-full flex flex-col md:flex-row md:space-x-6 overflow-y-auto md:overflow-hidden">
-      <div className="p-4 pb-20 md:w-64 md:flex-shrink-0 md:overflow-y-auto">
+      <div className="pb-24 md:w-64 md:flex-shrink-0">
         <ResourceSidebar />
       </div>
-      <div className="flex-1 p-4 space-y-6 pb-20 md:overflow-y-auto">
+      <div className="flex-1 p-4 space-y-6 pb-24 md:overflow-y-auto">
         <CandidateBox />
         <ProductionSection
           productionGroups={productionGroups}


### PR DESCRIPTION
## Summary
- Reset Tailwind theme variables to Shadcn defaults and adopt dark mode with white buttons
- Clean up layout padding, remove resource panel scrollbar, and ensure bottom dock is visible
- Use filled buttons for primary actions and destructive styles for dangerous actions

## Testing
- `npm test`
- `npm run lint` *(warnings: Code style issues found in 16 files. Run Prettier with --write to fix.)*

------
https://chatgpt.com/codex/tasks/task_e_689bc4a2ec2c833191db03f7ad7b1029