### PR TITLE
Improve contrast and navigation layout

### DIFF
--- a/src/components/Accordion.jsx
+++ b/src/components/Accordion.jsx
@@ -29,7 +29,7 @@ export default function GameAccordion({
           {action && <div className="ml-2">{action}</div>}
         </AccordionPrimitive.Header>
         <AccordionContent>
-          <div className="px-4 pb-4 pt-2 space-y-3">{children}</div>
+          <div className="p-2 space-y-2">{children}</div>
         </AccordionContent>
       </AccordionItem>
     </Accordion>

--- a/src/components/BottomDock.jsx
+++ b/src/components/BottomDock.jsx
@@ -18,7 +18,7 @@ export default function BottomDock() {
       onValueChange={setActiveTab}
       className="fixed bottom-0 left-0 right-0 z-50 bg-card shadow-lg"
     >
-      <TabsList className="w-full grid grid-cols-4 rounded-none border-t bg-card p-3">
+      <TabsList className="w-full grid grid-cols-4 rounded-none border-t bg-card p-3 h-16">
         {tabs.map((t) => (
           <TabsTrigger
             key={t.id}

--- a/src/components/BuildingRow.jsx
+++ b/src/components/BuildingRow.jsx
@@ -101,6 +101,14 @@ export default function BuildingRow({ building, completedResearch }) {
           )}
         </div>
         <div className="space-x-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={demolish}
+            disabled={count <= 0}
+          >
+            Demolish
+          </Button>
           {buildTooltip ? (
             <Tooltip>
               <TooltipTrigger asChild>
@@ -123,14 +131,6 @@ export default function BuildingRow({ building, completedResearch }) {
               Build
             </Button>
           )}
-          <Button
-            variant="destructive"
-            size="sm"
-            onClick={demolish}
-            disabled={count <= 0}
-          >
-            Demolish
-          </Button>
         </div>
       </div>
       <div className="text-xs muted-foreground space-y-1">

--- a/src/components/ResourceSidebar.jsx
+++ b/src/components/ResourceSidebar.jsx
@@ -13,7 +13,7 @@ export default function ResourceSidebar() {
   const { sections, settlersInfo, happinessInfo } = useResourceSections(state);
 
   return (
-    <div className="border border-border rounded overflow-hidden bg-card">
+    <div className="border border-border rounded overflow-hidden bg-card p-2 space-y-2">
       {sections.map((g) =>
         g.settlers ? (
           <SettlerSection key={g.title} title={g.title} info={settlersInfo} />

--- a/src/index.css
+++ b/src/index.css
@@ -4,7 +4,7 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
+    --background: 0 0% 96%;
     --foreground: 240 10% 3.9%;
     --card: 0 0% 100%;
     --card-foreground: 240 10% 3.9%;
@@ -27,25 +27,25 @@
   }
 
   .dark {
-    --background: 240 10% 3.9%;
+    --background: 240 5% 10%;
     --foreground: 0 0% 98%;
-    --card: 240 10% 3.9%;
+    --card: 240 5% 14%;
     --card-foreground: 0 0% 98%;
-    --popover: 240 10% 3.9%;
+    --popover: 240 5% 12%;
     --popover-foreground: 0 0% 98%;
     --primary: 0 0% 98%;
     --primary-foreground: 240 5.9% 10%;
-    --secondary: 240 3.7% 15.9%;
+    --secondary: 240 4% 20%;
     --secondary-foreground: 0 0% 98%;
-    --muted: 240 3.7% 15.9%;
-    --muted-foreground: 240 5% 64.9%;
-    --accent: 240 3.7% 15.9%;
+    --muted: 240 4% 20%;
+    --muted-foreground: 240 5% 70%;
+    --accent: 240 4% 20%;
     --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
+    --destructive: 0 62.8% 40%;
     --destructive-foreground: 0 0% 98%;
-    --border: 240 3.7% 15.9%;
-    --input: 240 3.7% 15.9%;
-    --ring: 240 4.9% 83.9%;
+    --border: 240 4% 25%;
+    --input: 240 4% 25%;
+    --ring: 240 5% 70%;
   }
 
   html,

--- a/src/views/BaseView.jsx
+++ b/src/views/BaseView.jsx
@@ -13,11 +13,11 @@ export default function BaseView() {
     useBuildingGroups();
 
   return (
-    <div className="h-full flex flex-col md:flex-row md:space-x-6 overflow-y-auto md:overflow-hidden">
+    <div className="h-full flex flex-col md:flex-row md:space-x-6 overflow-y-auto md:overflow-hidden p-4">
       <div className="pb-24 md:w-64 md:flex-shrink-0">
         <ResourceSidebar />
       </div>
-      <div className="flex-1 p-4 space-y-6 pb-24 md:overflow-y-auto">
+      <div className="flex-1 space-y-6 pb-24 md:overflow-y-auto">
         <CandidateBox />
         <ProductionSection
           productionGroups={productionGroups}

--- a/src/views/PopulationView.jsx
+++ b/src/views/PopulationView.jsx
@@ -42,7 +42,7 @@ export default function PopulationView() {
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
         <Card className="text-center">
           <CardHeader className="p-0">
-            <CardTitle className="text-sm font-normal text-muted">
+            <CardTitle className="text-sm font-normal text-muted-foreground">
               Settlers
             </CardTitle>
           </CardHeader>
@@ -53,7 +53,7 @@ export default function PopulationView() {
         {Object.entries(BONUS_LABELS).map(([role, label]) => (
           <Card key={role} className="text-center">
             <CardHeader className="p-0">
-              <CardTitle className="text-sm font-normal text-muted">
+              <CardTitle className="text-sm font-normal text-muted-foreground">
                 {label} bonus
               </CardTitle>
             </CardHeader>
@@ -102,7 +102,7 @@ export default function PopulationView() {
                 </CardTitle>
               </CardHeader>
               <CardContent className="space-y-2">
-                <div className="flex flex-wrap items-center gap-2 text-sm text-muted">
+                <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
                   <span
                     className={`px-2 py-0.5 rounded text-xs text-white ${
                       s.sex === 'M' ? 'bg-blue-700' : 'bg-pink-700'
@@ -157,7 +157,7 @@ export default function PopulationView() {
           );
         })
       ) : (
-        <div className="text-center text-muted">No survivors</div>
+        <div className="text-center text-muted-foreground">No survivors</div>
       )}
     </div>
   );

--- a/src/views/research/ResearchNode.jsx
+++ b/src/views/research/ResearchNode.jsx
@@ -1,4 +1,5 @@
 import React, { forwardRef } from 'react';
+import { Check } from 'lucide-react';
 import { RESEARCH_MAP } from '../../data/research.js';
 import { RESOURCES } from '../../data/resources.js';
 import { BUILDING_MAP } from '../../data/buildings.js';
@@ -70,7 +71,7 @@ const ResearchNode = forwardRef(({ node, status, reasons, onStart }, ref) => {
       <TooltipTrigger asChild>
         <div
           ref={ref}
-          className={`relative w-64 p-3 border rounded bg-card/50 text-sm flex flex-col gap-1 ${
+          className={`relative w-64 p-3 border rounded bg-card text-sm flex flex-col gap-1 ${
             status === 'completed'
               ? 'opacity-80 border-green-600'
               : status === 'inProgress'
@@ -81,12 +82,12 @@ const ResearchNode = forwardRef(({ node, status, reasons, onStart }, ref) => {
           }`}
         >
           <div className="font-semibold text-base">{node.name}</div>
-          <div className="text-muted">{node.shortDesc}</div>
+          <div className="text-muted-foreground">{node.shortDesc}</div>
           <div className="flex items-center gap-1">
             <span>{RESOURCES.science.icon}</span>
             <span>{formatAmount(cost)}</span>
           </div>
-          <div className="text-xs text-muted">
+          <div className="text-xs text-muted-foreground">
             Research time: {formatTime(node.timeSec)}
           </div>
           {status === 'available' && (
@@ -126,7 +127,9 @@ const ResearchNode = forwardRef(({ node, status, reasons, onStart }, ref) => {
             </div>
           )}
           {status === 'completed' && (
-            <span className="absolute top-1 right-1 text-green-500">✔</span>
+            <span className="absolute top-1 right-1 text-green-500">
+              <Check className="w-4 h-4" />
+            </span>
           )}
         </div>
       </TooltipTrigger>


### PR DESCRIPTION
## Summary
- lighten dark theme and distinguish cards from background
- reorder and restyle demolish button
- pad sidebar and accordions for better alignment
- fix bottom dock height and polish research node styling

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 26 files)*
- `npm run typecheck` *(fails: Type 'undefined' is not assignable to type 'number', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689bc821f48c8331985e6c7f355bc5fb