### PR TITLE
Fix food capacity aggregation

### DIFF
--- a/src/components/useResourceSections.js
+++ b/src/components/useResourceSections.js
@@ -70,7 +70,8 @@ export function useResourceSections(state) {
         0,
       );
       const totalCapacity =
-        state.foodPool?.capacity ?? getCapacity(state, 'potatoes');
+        state.foodPool?.capacity ??
+        foodIds.reduce((sum, id) => sum + getCapacity(state, id), 0);
       const totalNetRate = foodIds.reduce(
         (sum, id) => sum + (netRates[id]?.perSec || 0),
         0,

--- a/src/components/useResourceSections.test.js
+++ b/src/components/useResourceSections.test.js
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useResourceSections } from './useResourceSections.js';
+
+describe('useResourceSections', () => {
+  test('sums capacities of all food resources', () => {
+    const state = {
+      resources: {
+        potatoes: { amount: 100, discovered: true },
+        meat: { amount: 50, discovered: true },
+      },
+      buildings: {},
+      research: { completed: [] },
+      population: { settlers: [] },
+    };
+    const { result } = renderHook((props) => useResourceSections(props), {
+      initialProps: state,
+    });
+    const foodSection = result.current.sections.find((s) => s.title === 'Food');
+    const totalRow = foodSection.items.find((i) => i.id === 'food-total');
+    expect(totalRow.capacity).toBe(450 + 150);
+  });
+});


### PR DESCRIPTION
## Summary
- Sum capacities of all food resources instead of only potatoes
- Add unit test for food capacity aggregation

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 26 files. Run Prettier with --write to fix.)*

------
https://chatgpt.com/codex/tasks/task_e_689bc8e6c3e48331bf43dda8c82edbf9