### PR TITLE
Fix CardDescription class name

### DIFF
--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -42,7 +42,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-description"
-      className={cn('fmuted-foreground text-sm', className)}
+      className={cn('text-muted-foreground text-sm', className)}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
- correct typo in CardDescription class name

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 23 files. Run Prettier with --write to fix.)*

------
https://chatgpt.com/codex/tasks/task_e_689bd31da60c83319fcc93824dcb0503