### PR TITLE
Refactor game tick logic into helpers with tests

### DIFF
--- a/src/state/hooks/__tests__/useGameTick.test.ts
+++ b/src/state/hooks/__tests__/useGameTick.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../engine/production.js', () => ({
+  processTick: vi.fn(),
+}));
+vi.mock('../../../engine/research.js', () => ({
+  processResearchTick: vi.fn(),
+}));
+vi.mock('../../../engine/settlers.js', () => ({
+  processSettlersTick: vi.fn(),
+  computeRoleBonuses: vi.fn(),
+}));
+vi.mock('../../selectors.js', () => ({
+  getResourceRates: vi.fn(),
+}));
+vi.mock('../../../data/resources.js', () => ({
+  RESOURCES: {},
+}));
+vi.mock('../../../engine/radio.js', () => ({
+  updateRadio: vi.fn(),
+}));
+vi.mock('../../../engine/time.js', () => ({
+  getYear: vi.fn(),
+  DAYS_PER_YEAR: 365,
+}));
+
+import { applyProduction, applySettlers, applyYearUpdate } from '../useGameTick';
+import { processTick } from '../../../engine/production.js';
+import { processResearchTick } from '../../../engine/research.js';
+import { processSettlersTick, computeRoleBonuses } from '../../../engine/settlers.js';
+import { getResourceRates } from '../../selectors.js';
+import { updateRadio } from '../../../engine/radio.js';
+import { getYear, DAYS_PER_YEAR } from '../../../engine/time.js';
+import { RESOURCES } from '../../../data/resources.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const key of Object.keys(RESOURCES)) delete (RESOURCES as any)[key];
+});
+
+describe('applyProduction', () => {
+  it('calculates bonuses and bonus food', () => {
+    (computeRoleBonuses as any).mockReturnValue({ farmer: 10, builder: 5 });
+    (processTick as any).mockReturnValue('after');
+    (processResearchTick as any).mockReturnValue('withResearch');
+    (getResourceRates as any).mockReturnValue({
+      potatoes: { perSec: 2 },
+      metal: { perSec: 4 },
+    });
+    (RESOURCES as any).potatoes = { category: 'FOOD' };
+    (RESOURCES as any).metal = { category: 'METAL' };
+
+    const result = applyProduction({ population: { settlers: [] } }, 1);
+
+    expect(processTick).toHaveBeenCalledWith(
+      { population: { settlers: [] } },
+      1,
+      { builder: 5 },
+    );
+    expect(result).toEqual({
+      state: 'withResearch',
+      roleBonuses: { farmer: 10, builder: 5 },
+      bonusFoodPerSec: 0.2,
+    });
+  });
+});
+
+describe('applySettlers', () => {
+  it('processes settlers tick', () => {
+    (processSettlersTick as any).mockReturnValue({
+      state: 'settlersProcessed',
+      telemetry: 'tele',
+    });
+    const rng = () => 0.5;
+    const result = applySettlers('withResearch', 1, 0.2, { farmer: 10 }, rng);
+    expect(processSettlersTick).toHaveBeenCalledWith(
+      'withResearch',
+      1,
+      0.2,
+      rng,
+      { farmer: 10 },
+    );
+    expect(result).toEqual({ state: 'settlersProcessed', telemetry: 'tele' });
+  });
+});
+
+describe('applyYearUpdate', () => {
+  it('updates year and ages settlers', () => {
+    (updateRadio as any).mockReturnValue({
+      candidate: 'cand',
+      radioTimer: 5,
+    });
+    (getYear as any).mockReturnValue(2);
+    const state = {
+      gameTime: { seconds: 0, year: 1 },
+      population: { settlers: [{ id: 1, ageDays: 0 }] },
+      colony: {},
+      meta: {},
+    };
+    const telemetry = { some: 'data' };
+    const result = applyYearUpdate(state as any, 10, telemetry);
+    expect(result.population).toMatchObject({
+      settlers: [{ id: 1, ageDays: DAYS_PER_YEAR }],
+      candidate: 'cand',
+    });
+    expect(result.colony.radioTimer).toBe(5);
+    expect(result.gameTime).toEqual({ seconds: 10, year: 2 });
+    expect(result.meta?.telemetry?.settlers).toBe(telemetry);
+  });
+});
+

--- a/src/state/hooks/useGameTick.ts
+++ b/src/state/hooks/useGameTick.ts
@@ -11,59 +11,78 @@ import {
 import { updateRadio } from '../../engine/radio.js';
 import { getYear, DAYS_PER_YEAR } from '../../engine/time.js';
 
+export function applyProduction(prev: any, dt: number) {
+  const roleBonuses = computeRoleBonuses(prev.population?.settlers || []);
+  const productionBonuses = { ...roleBonuses };
+  delete productionBonuses.farmer;
+  const afterTick = processTick(prev, dt, productionBonuses);
+  const withResearch = processResearchTick(afterTick, dt, roleBonuses);
+  const rates = getResourceRates(withResearch);
+  let totalFoodProdBase = 0;
+  Object.keys(RESOURCES).forEach((id) => {
+    if (RESOURCES[id].category === 'FOOD') {
+      totalFoodProdBase += rates[id]?.perSec || 0;
+    }
+  });
+  const bonusFoodPerSec =
+    totalFoodProdBase * ((roleBonuses['farmer'] || 0) / 100);
+  return { state: withResearch, roleBonuses, bonusFoodPerSec };
+}
+
+export function applySettlers(
+  state: any,
+  dt: number,
+  bonusFoodPerSec: number,
+  roleBonuses: any,
+  rng = Math.random,
+) {
+  return processSettlersTick(state, dt, bonusFoodPerSec, rng, roleBonuses);
+}
+
+export function applyYearUpdate(state: any, dt: number, telemetry: any) {
+  const { candidate, radioTimer } = updateRadio(state, dt);
+  const nextSeconds = (state.gameTime?.seconds || 0) + dt;
+  const computedYear = getYear({
+    ...state,
+    gameTime: { ...state.gameTime, seconds: nextSeconds },
+  });
+  let year = state.gameTime?.year || 1;
+  let settlers = state.population.settlers;
+  if (computedYear > year) {
+    const diff = computedYear - year;
+    year = computedYear;
+    settlers = settlers.map((s: any) => ({
+      ...s,
+      ageDays: (s.ageDays || 0) + diff * DAYS_PER_YEAR,
+    }));
+  }
+  return {
+    ...state,
+    population: { ...state.population, settlers, candidate },
+    colony: { ...state.colony, radioTimer },
+    gameTime: { seconds: nextSeconds, year },
+    meta: {
+      ...state.meta,
+      telemetry: {
+        ...state.meta?.telemetry,
+        settlers: telemetry,
+      },
+    },
+  };
+}
+
 export default function useGameTick(setState: Dispatch<SetStateAction<any>>) {
   useGameLoop((dt) => {
     setState((prev) => {
-      const roleBonuses = computeRoleBonuses(prev.population?.settlers || []);
-      const productionBonuses = { ...roleBonuses };
-      delete productionBonuses.farmer;
-      const afterTick = processTick(prev, dt, productionBonuses);
-      const withResearch = processResearchTick(afterTick, dt, roleBonuses);
-      const rates = getResourceRates(withResearch);
-      let totalFoodProdBase = 0;
-      Object.keys(RESOURCES).forEach((id) => {
-        if (RESOURCES[id].category === 'FOOD') {
-          totalFoodProdBase += rates[id]?.perSec || 0;
-        }
-      });
-      const bonusFoodPerSec =
-        totalFoodProdBase * ((roleBonuses['farmer'] || 0) / 100);
-      const { state: settlersProcessed, telemetry } = processSettlersTick(
+      const { state: withResearch, roleBonuses, bonusFoodPerSec } =
+        applyProduction(prev, dt);
+      const { state: settlersProcessed, telemetry } = applySettlers(
         withResearch,
         dt,
         bonusFoodPerSec,
-        Math.random,
         roleBonuses,
       );
-      const { candidate, radioTimer } = updateRadio(settlersProcessed, dt);
-      const nextSeconds = (settlersProcessed.gameTime?.seconds || 0) + dt;
-      const computedYear = getYear({
-        ...settlersProcessed,
-        gameTime: { ...settlersProcessed.gameTime, seconds: nextSeconds },
-      });
-      let year = settlersProcessed.gameTime?.year || 1;
-      let settlers = settlersProcessed.population.settlers;
-      if (computedYear > year) {
-        const diff = computedYear - year;
-        year = computedYear;
-        settlers = settlers.map((s: any) => ({
-          ...s,
-          ageDays: (s.ageDays || 0) + diff * DAYS_PER_YEAR,
-        }));
-      }
-      return {
-        ...settlersProcessed,
-        population: { ...settlersProcessed.population, settlers, candidate },
-        colony: { ...settlersProcessed.colony, radioTimer },
-        gameTime: { seconds: nextSeconds, year },
-        meta: {
-          ...settlersProcessed.meta,
-          telemetry: {
-            ...settlersProcessed.meta?.telemetry,
-            settlers: telemetry,
-          },
-        },
-      };
+      return applyYearUpdate(settlersProcessed, dt, telemetry);
     });
   }, 1000);
 }


### PR DESCRIPTION
## Summary
- extract production processing into `applyProduction`
- add `applySettlers` and `applyYearUpdate` helpers
- cover new helpers with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bd335f02c83319e3cc1c605fd6ccf