### PR TITLE
refactor: centralize deep cloning

### DIFF
--- a/src/engine/__tests__/economy.test.js
+++ b/src/engine/__tests__/economy.test.js
@@ -3,12 +3,11 @@ import { processTick, demolishBuilding } from '../production.js';
 import { defaultState } from '../../state/defaultState.js';
 import { BUILDING_MAP, getBuildingCost } from '../../data/buildings.js';
 import { SEASON_DURATION } from '../time.js';
-
-const clone = (obj) => structuredClone(obj);
+import { deepClone } from '../../utils/clone.ts';
 
 describe('economy basics', () => {
   test('spring potato field output', () => {
-    const state = clone(defaultState);
+    const state = deepClone(defaultState);
     state.buildings.potatoField.count = 1;
     const next = processTick(state, 1);
     const potatoes = next.resources.potatoes.amount;
@@ -16,7 +15,7 @@ describe('economy basics', () => {
   });
 
   test('demolition refunds half last cost', () => {
-    const state = clone(defaultState);
+    const state = deepClone(defaultState);
     state.buildings.potatoField.count = 2;
     const after = demolishBuilding(state, 'potatoField');
     const blueprint = BUILDING_MAP['potatoField'];
@@ -28,7 +27,7 @@ describe('economy basics', () => {
   });
 
   test('sawmill processes wood into planks when inputs available', () => {
-    const state = clone(defaultState);
+    const state = deepClone(defaultState);
     state.resources.wood.amount = 10;
     state.buildings.loggingCamp.count = 0;
     state.buildings.sawmill = { count: 1 };
@@ -38,7 +37,7 @@ describe('economy basics', () => {
   });
 
   test('sawmill halts without enough wood', () => {
-    const state = clone(defaultState);
+    const state = deepClone(defaultState);
     state.resources.wood.amount = 0.5;
     state.buildings.loggingCamp.count = 0;
     state.buildings.sawmill = { count: 1 };
@@ -48,7 +47,7 @@ describe('economy basics', () => {
   });
 
   test('removing last required building unassigns settlers', () => {
-    const state = clone(defaultState);
+    const state = deepClone(defaultState);
     state.buildings.potatoField.count = 1;
     state.population = {
       settlers: [
@@ -69,7 +68,7 @@ describe('economy basics', () => {
   });
 
   test("hunter's hut produces meat in winter", () => {
-    const state = clone(defaultState);
+    const state = deepClone(defaultState);
     state.gameTime.seconds = SEASON_DURATION * 3;
     state.buildings.huntersHut = { count: 1 };
     const next = processTick(state, 1);

--- a/src/engine/__tests__/power.test.js
+++ b/src/engine/__tests__/power.test.js
@@ -1,12 +1,11 @@
 import { describe, test, expect } from 'vitest';
 import { processTick } from '../production.js';
 import { defaultState } from '../../state/defaultState.js';
-
-const clone = (obj) => structuredClone(obj);
+import { deepClone } from '../../utils/clone.ts';
 
 describe('power shortages', () => {
   test('buildings go offline when power runs out and recover when restored', () => {
-    const state = clone(defaultState);
+    const state = deepClone(defaultState);
     state.buildings.radio = { count: 1 };
     state.resources.power.amount = 0.15;
     state.resources.power.discovered = true;

--- a/src/engine/__tests__/research.test.js
+++ b/src/engine/__tests__/research.test.js
@@ -8,14 +8,11 @@ import { RESEARCH_MAP } from '../../data/research.js';
 import { defaultState } from '../../state/defaultState.js';
 import { getResearchOutputBonus } from '../../state/selectors.js';
 import { computeRoleBonuses } from '../settlers.js';
-
-function clone(obj) {
-  return structuredClone(obj);
-}
+import { deepClone } from '../../utils/clone.ts';
 
 describe('research engine', () => {
   it('starts and completes research', () => {
-    const state = clone(defaultState);
+    const state = deepClone(defaultState);
     state.resources.science.amount = 80;
     let s = startResearch(state, 'industry1');
     expect(s.research.current.id).toBe('industry1');
@@ -26,7 +23,7 @@ describe('research engine', () => {
   });
 
   it('cancels research with refund', () => {
-    const state = clone(defaultState);
+    const state = deepClone(defaultState);
     state.resources.science.amount = 80;
     let s = startResearch(state, 'industry1');
     s = processResearchTick(s, 10);
@@ -37,14 +34,14 @@ describe('research engine', () => {
   });
 
   it('computes output bonuses from completed research', () => {
-    const state = clone(defaultState);
+    const state = deepClone(defaultState);
     state.research.completed = ['woodworking1', 'woodworking2'];
     const bonus = getResearchOutputBonus(state, 'wood');
     expect(bonus).toBeCloseTo(0.1, 5);
   });
 
   it('scientists speed up research', () => {
-    const state = clone(defaultState);
+    const state = deepClone(defaultState);
     state.resources.science.amount = 80;
     state.population.settlers = Array.from({ length: 4 }).map((_, i) => ({
       id: i,
@@ -61,7 +58,7 @@ describe('research engine', () => {
   });
 
   it('unlocks radio after industry research', () => {
-    const state = clone(defaultState);
+    const state = deepClone(defaultState);
     state.resources.science.amount = 300;
     let s = startResearch(state, 'industry1');
     s = processResearchTick(s, RESEARCH_MAP['industry1'].timeSec);

--- a/src/engine/__tests__/settlers.test.js
+++ b/src/engine/__tests__/settlers.test.js
@@ -5,12 +5,11 @@ import { getResourceRates } from '../../state/selectors.js';
 import { defaultState } from '../../state/defaultState.js';
 import { RESOURCES } from '../../data/resources.js';
 import { BALANCE } from '../../data/balance.js';
-
-const clone = (obj) => structuredClone(obj);
+import { deepClone } from '../../utils/clone.ts';
 
 describe('settlers tick', () => {
   it('keeps potato totals consistent with farming bonus and consumption', () => {
-    const state = clone(defaultState);
+    const state = deepClone(defaultState);
     state.buildings.potatoField.count = 1;
     state.resources.potatoes.amount = 0;
     state.population.settlers = [

--- a/src/engine/persistence.js
+++ b/src/engine/persistence.js
@@ -1,8 +1,6 @@
 import { createLogEntry } from '../utils/log.js';
 import { RADIO_BASE_SECONDS } from '../data/settlement.js';
-
-const structuredClone =
-  globalThis.structuredClone || ((obj) => JSON.parse(JSON.stringify(obj)));
+import { deepClone } from '../utils/clone.ts';
 
 const STORAGE_KEY = 'apocalypse-idle-save';
 
@@ -211,7 +209,7 @@ export function save(state) {
 }
 
 export function load(raw) {
-  const save = typeof raw === 'string' ? JSON.parse(raw) : structuredClone(raw);
+  const save = typeof raw === 'string' ? JSON.parse(raw) : deepClone(raw);
   save.version = save.version ?? save.schemaVersion ?? 1;
   validateSave(save);
   const start = save.version;

--- a/src/engine/production.js
+++ b/src/engine/production.js
@@ -9,9 +9,7 @@ import { getSeason, getSeasonMultiplier } from './time.js';
 import { getCapacity, getResearchOutputBonus } from '../state/selectors.js';
 import { BALANCE } from '../data/balance.js';
 import { updateRadio } from './radio.js';
-
-const structuredClone =
-  globalThis.structuredClone || ((obj) => JSON.parse(JSON.stringify(obj)));
+import { deepClone } from '../utils/clone.ts';
 
 export function clampResource(value, capacity) {
   let v = Number.isFinite(value) ? value : 0;
@@ -145,7 +143,7 @@ export function processTick(state, seconds = 1, roleBonuses = {}) {
 
 export function applyOfflineProgress(state, elapsedSeconds, roleBonuses = {}) {
   if (elapsedSeconds <= 0) return { state, gains: {} };
-  const before = structuredClone(state.resources);
+  const before = deepClone(state.resources);
   let current = applyProduction({ ...state }, elapsedSeconds, roleBonuses);
   const settlers =
     state.population?.settlers?.filter((s) => !s.isDead)?.length || 0;

--- a/src/state/__tests__/prepareLoadedState.test.js
+++ b/src/state/__tests__/prepareLoadedState.test.js
@@ -1,12 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { prepareLoadedState } from '../prepareLoadedState.ts';
 import { defaultState } from '../defaultState.js';
+import { deepClone } from '../../utils/clone.ts';
 
 // Test that offline gains produce log entries
 
 describe('prepareLoadedState', () => {
   it('adds offline progress entries to log', () => {
-    const loaded = JSON.parse(JSON.stringify(defaultState));
+    const loaded = deepClone(defaultState);
     loaded.lastSaved = Date.now() - 10000; // 10 seconds offline
     const state = prepareLoadedState(loaded);
     expect(state.log.length).toBeGreaterThan(0);

--- a/src/state/prepareLoadedState.ts
+++ b/src/state/prepareLoadedState.ts
@@ -6,15 +6,16 @@ import { createLogEntry } from '../utils/log.js';
 import { RESOURCES } from '../data/resources.js';
 import { formatAmount } from '../utils/format.js';
 import { buildInitialPowerTypeOrder } from '../engine/power.js';
+import { deepClone } from '../utils/clone.ts';
 
 /* eslint-disable-next-line react-refresh/only-export-components */
 export function prepareLoadedState(loaded: any) {
-  const cloned = structuredClone(loaded || {});
+  const cloned = deepClone(loaded || {});
   const gameTime =
     typeof cloned.gameTime === 'number'
       ? { seconds: cloned.gameTime }
       : cloned.gameTime || { seconds: 0 };
-  const base = structuredClone(defaultState);
+  const base = deepClone(defaultState);
   base.version = cloned.version ?? base.version;
   base.gameTime = { ...base.gameTime, ...gameTime };
   base.meta = { ...base.meta, ...cloned.meta, seasons: initSeasons() };

--- a/src/utils/clone.ts
+++ b/src/utils/clone.ts
@@ -1,0 +1,8 @@
+export function deepClone<T>(value: T): T {
+  if (typeof globalThis.structuredClone === 'function') {
+    return globalThis.structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
+export default deepClone;


### PR DESCRIPTION
## Summary
- add `deepClone` utility with structuredClone and JSON fallback
- replace ad-hoc cloning in persistence, production, and state load preparation
- update tests to use shared deepClone

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bd407a3a48331a80a381bd50f789f