### PR TITLE
Display storage capacity increases like costs

### DIFF
--- a/src/components/BuildingRow.jsx
+++ b/src/components/BuildingRow.jsx
@@ -135,19 +135,24 @@ export default function BuildingRow({ building, completedResearch }) {
       </div>
       <div className="space-y-2 text-sm">
         <div>{building.description}</div>
-        <div className="grid grid-cols-2 gap-4 text-xs">
+        <div
+          className={`grid gap-4 text-xs ${
+            perOutputs.length > 0 || building.capacityAdd
+              ? 'grid-cols-2'
+              : 'grid-cols-1'
+          }`}
+        >
           <div>
             <div className="font-medium">Cost:</div>
             <div className="mt-1 flex flex-wrap gap-2">
               {costEntries.map(([res, amt]) => (
                 <span key={res} className="flex items-center gap-1">
-                  {RESOURCES[res].icon} {formatAmount(amt)}{' '}
-                  {RESOURCES[res].name}
+                  {RESOURCES[res].icon} {formatAmount(amt)} {RESOURCES[res].name}
                 </span>
               ))}
             </div>
           </div>
-          {perOutputs.length > 0 && (
+          {perOutputs.length > 0 ? (
             <div>
               <div className="font-medium">Produces:</div>
               <div className="mt-1 flex flex-wrap gap-2">
@@ -158,6 +163,19 @@ export default function BuildingRow({ building, completedResearch }) {
                 ))}
               </div>
             </div>
+          ) : (
+            building.capacityAdd && (
+              <div>
+                <div className="font-medium">Increase:</div>
+                <div className="mt-1 flex flex-wrap gap-2">
+                  {Object.entries(building.capacityAdd).map(([res, cap]) => (
+                    <span key={res} className="flex items-center gap-1">
+                      {RESOURCES[res].icon} +{formatAmount(cap)} {RESOURCES[res].name} capacity
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )
           )}
         </div>
         {perInputs.map((i) => (
@@ -165,16 +183,6 @@ export default function BuildingRow({ building, completedResearch }) {
             Consumes: {formatPerSec(-i.perSec, i.res)}
           </div>
         ))}
-        {building.capacityAdd && (
-          <div className="text-xs">
-            {Object.entries(building.capacityAdd)
-              .map(
-                ([res, cap]) =>
-                  `+${formatAmount(cap)} ${RESOURCES[res].name} capacity`,
-              )
-              .join(', ')}
-          </div>
-        )}
         {!unlocked && building.requiresResearch && (
           <div className="text-xs text-red-400">
             Requires:{' '}

--- a/src/components/BuildingRow.test.jsx
+++ b/src/components/BuildingRow.test.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import BuildingRow from './BuildingRow.jsx';
+import { BUILDING_MAP } from '../data/buildings.js';
+import { GameContext } from '../state/useGame.ts';
+import { defaultState } from '../state/defaultState.js';
+
+describe('BuildingRow', () => {
+  it('shows capacity increase for storage buildings', () => {
+    const ctx = {
+      state: defaultState,
+      setState: vi.fn(),
+      setActiveTab: vi.fn(),
+      toggleDrawer: vi.fn(),
+      setSettlerRole: vi.fn(),
+      beginResearch: vi.fn(),
+      abortResearch: vi.fn(),
+      dismissOfflineModal: vi.fn(),
+      resetGame: vi.fn(),
+      loadError: false,
+      retryLoad: vi.fn(),
+    };
+
+    render(
+      <GameContext.Provider value={ctx}>
+        <BuildingRow
+          building={BUILDING_MAP.foodStorage}
+          completedResearch={[]}
+        />
+      </GameContext.Provider>,
+    );
+
+    expect(screen.getByText('Increase:')).toBeTruthy();
+    expect(screen.getByText(/🍖 \+150 Meat capacity/)).toBeTruthy();
+    expect(screen.getByText(/🥔 \+300 Potatoes capacity/)).toBeTruthy();
+  });
+});
+


### PR DESCRIPTION
## Summary
- Show storage capacity increases alongside build cost using resource icons
- Add test covering storage building capacity display

## Testing
- `npx vitest run src/components/BuildingRow.test.jsx`
- `npx vitest run src/components/BottomDock.test.jsx src/components/EventLog.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_689bd52279588331b809e5994d81bf60