### PR TITLE
refactor: add types to game hooks

### DIFF
--- a/src/state/hooks/useAutosave.ts
+++ b/src/state/hooks/useAutosave.ts
@@ -1,8 +1,12 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, type Dispatch, type SetStateAction } from 'react';
 import { saveGame } from '../../engine/persistence.js';
+import type { GameState } from '../useGame.ts';
 
-export default function useAutosave(state: any, setState: any) {
-  const stateRef = useRef(state);
+export default function useAutosave(
+  state: GameState,
+  setState: Dispatch<SetStateAction<GameState>>,
+): void {
+  const stateRef = useRef<GameState>(state);
   useEffect(() => {
     stateRef.current = state;
   }, [state]);


### PR DESCRIPTION
## Summary
- replace `any` usage in `useAutosave` and `useGameActions` with `GameState` and typed interfaces
- define explicit parameter and return types for game hooks

## Testing
- `npm test`
- `npm run typecheck` *(fails: Property 'scrap' is incompatible with index signature ...)*

------
https://chatgpt.com/codex/tasks/task_e_689bd55d842c833181a1a9c6ff6eb287