### PR TITLE
Rebalance early game resources and roles

### DIFF
--- a/src/components/BuildingRow.test.jsx
+++ b/src/components/BuildingRow.test.jsx
@@ -32,7 +32,7 @@ describe('BuildingRow', () => {
     );
 
     expect(screen.getByText('Increase:')).toBeTruthy();
-    expect(screen.getByText(/🍖 \+150 Meat capacity/)).toBeTruthy();
-    expect(screen.getByText(/🥔 \+300 Potatoes capacity/)).toBeTruthy();
+    expect(screen.getByText(/🍖 \+75 Meat capacity/)).toBeTruthy(); // changed: 150 -> 75
+    expect(screen.getByText(/🥔 \+150 Potatoes capacity/)).toBeTruthy(); // changed: 300 -> 150
   });
 });

--- a/src/components/useResourceSections.test.js
+++ b/src/components/useResourceSections.test.js
@@ -18,6 +18,6 @@ describe('useResourceSections', () => {
     });
     const foodSection = result.current.sections.find((s) => s.title === 'Food');
     const totalRow = foodSection.items.find((i) => i.id === 'food-total');
-    expect(totalRow.capacity).toBe(450 + 150);
+    expect(totalRow.capacity).toBe(200 + 100); // changed: 450+150 -> 200+100
   });
 });

--- a/src/data/balance.js
+++ b/src/data/balance.js
@@ -8,13 +8,14 @@ export const BALANCE = {
   HAPPINESS_OVERCR_PENALTY_PER: 5,
 };
 
+export const ROLE_LINE_BONUS_CAP = 0.3; // added cap per line
+
 export function XP_TIME_TO_NEXT_LEVEL_SECONDS(level) {
-  return Math.round(15 * Math.pow(1.8, level - 1));
+  return Math.round(22.5 * Math.pow(1.8, level - 1)); // changed: 15 -> 22.5
 }
 
 export function ROLE_BONUS_PER_SETTLER(level) {
-  if (level <= 10) return 0.02 * level; // changed: 0.1*level→0.02*level
-  return 0.2 + 0.01 * (level - 10); // changed: 1+0.05*(level-10)→0.2+0.01*(level-10)
+  return Math.min(0.005 * level, 0.025); // changed: 0.02*level→min(0.005*level,0.025)
 }
 
 export function FOOD_VARIETY_BONUS(count) {

--- a/src/data/buildings.js
+++ b/src/data/buildings.js
@@ -8,7 +8,7 @@ export const BUILDINGS = [
     category: 'Food',
     outputsPerSecBase: { potatoes: 0.375 },
     costBase: { wood: 17 }, // changed: 15→17
-    costGrowth: 1.13, // changed: 1.15→1.13
+    costGrowth: 1.12, // changed: 1.13 -> 1.12
     refund: 0.5,
     description: 'Reliable staple crop. Strongly affected by seasons.',
   },
@@ -18,7 +18,7 @@ export const BUILDINGS = [
     type: 'production',
     category: 'Food',
     requiresResearch: 'hunting1',
-    outputsPerSecBase: { meat: 0.19 }, // changed: 0.15→0.19
+    outputsPerSecBase: { meat: 0.22 }, // changed: 0.19 -> 0.22
     costBase: { wood: 25, scrap: 10, stone: 5 },
     costGrowth: 1.15,
     refund: 0.5,
@@ -33,7 +33,7 @@ export const BUILDINGS = [
     category: 'Raw Materials',
     outputsPerSecBase: { wood: 0.3 }, // changed: 0.25→0.3
     costBase: { scrap: 15 },
-    costGrowth: 1.13, // changed: 1.15→1.13
+    costGrowth: 1.12, // changed: 1.13 -> 1.12
     refund: 0.5,
     description: 'Steady wood income. Slight weather impact.',
   },
@@ -44,7 +44,7 @@ export const BUILDINGS = [
     category: 'Raw Materials',
     outputsPerSecBase: { scrap: 0.08 },
     costBase: { wood: 12 },
-    costGrowth: 1.13, // changed: 1.15→1.13
+    costGrowth: 1.12, // changed: 1.13 -> 1.12
     refund: 0.5,
     description: 'Collects scrap from nearby ruins.',
   },
@@ -53,9 +53,9 @@ export const BUILDINGS = [
     name: 'Quarry',
     type: 'production',
     category: 'Raw Materials',
-    outputsPerSecBase: { stone: 0.104 }, // changed: 0.08→0.104
+    outputsPerSecBase: { stone: 0.12 }, // changed: 0.104 -> 0.12
     costBase: { wood: 20, scrap: 5 },
-    costGrowth: 1.13, // changed: 1.15→1.13
+    costGrowth: 1.12, // changed: 1.13 -> 1.12
     refund: 0.5,
     description: 'Extracts stone slowly but steadily.',
   },
@@ -67,7 +67,7 @@ export const BUILDINGS = [
     requiresResearch: 'industry1',
     inputsPerSecBase: { wood: 0.8 },
     outputsPerSecBase: { planks: 0.5 },
-    costBase: { wood: 48, scrap: 18, stone: 12 }, // changed: wood 40→48, scrap 15→18, stone 10→12
+    costBase: { wood: 53, scrap: 20, stone: 13 }, // changed: wood 48 -> 53, scrap 18 -> 20, stone 12 -> 13
     costGrowth: 1.13, // changed: 1.15→1.13
     refund: 0.5,
     seasonProfile: 'constant',
@@ -142,9 +142,9 @@ export const BUILDINGS = [
     name: 'Granary',
     type: 'storage',
     costBase: { wood: 20, scrap: 5, stone: 5 },
-    costGrowth: 1.2, // changed: 1.15→1.2
+    costGrowth: 1.22, // changed: 1.2 -> 1.22
     refund: 0.5,
-    capacityAdd: { potatoes: 300, meat: 150 },
+    capacityAdd: { potatoes: 150, meat: 75 }, // changed: potatoes 300->150, meat 150->75
     description: 'Increases storage for harvested crops.',
   },
   {
@@ -152,9 +152,9 @@ export const BUILDINGS = [
     name: 'Warehouse',
     type: 'storage',
     costBase: { wood: 25, scrap: 10, stone: 10 },
-    costGrowth: 1.2, // changed: 1.15→1.2
+    costGrowth: 1.22, // changed: 1.2 -> 1.22
     refund: 0.5,
-    capacityAdd: { wood: 200, stone: 80, scrap: 90 }, // changed: scrap 120→90
+    capacityAdd: { wood: 120, scrap: 80, stone: 60 }, // changed: wood 200->120, scrap 90->80, stone 80->60
     description: 'Increases storage for wood, stone and scrap.',
   },
   {
@@ -163,9 +163,9 @@ export const BUILDINGS = [
     type: 'storage',
     requiresResearch: 'industry1',
     costBase: { wood: 25, scrap: 10, stone: 5 },
-    costGrowth: 1.2, // changed: 1.15→1.2
+    costGrowth: 1.22, // changed: 1.2 -> 1.22
     refund: 0.5,
-    capacityAdd: { planks: 300, metalParts: 240 }, // changed: planks 150→300, metalParts 60→240
+    capacityAdd: { planks: 100, metalParts: 40 }, // changed: planks 300->100, metalParts 240->40
     description: 'Stores processed construction materials.',
   },
   {
@@ -173,9 +173,9 @@ export const BUILDINGS = [
     name: 'Battery',
     type: 'storage',
     costBase: { wood: 40, stone: 20 },
-    costGrowth: 1.2, // changed: 1.15→1.2
+    costGrowth: 1.22, // changed: 1.2 -> 1.22
     refund: 0.5,
-    capacityAdd: { power: 600 }, // changed: 40→600
+    capacityAdd: { power: 40 }, // changed: 600->40
     requiresResearch: 'basicEnergy',
     description: 'Allows storing more generated Power.',
   },

--- a/src/data/resources.js
+++ b/src/data/resources.js
@@ -5,7 +5,7 @@ export const RESOURCES = {
     icon: '🥔',
     category: 'FOOD',
     startingAmount: 0,
-    startingCapacity: 450, // changed: 300→450
+    startingCapacity: 200, // changed: 450 -> 200
   },
   meat: {
     id: 'meat',
@@ -13,7 +13,7 @@ export const RESOURCES = {
     icon: '🍖',
     category: 'FOOD',
     startingAmount: 0,
-    startingCapacity: 150, // changed: 300→150
+    startingCapacity: 100, // changed: 150 -> 100
     unit: '',
   },
   wood: {
@@ -22,7 +22,7 @@ export const RESOURCES = {
     icon: '🪵',
     category: 'RAW',
     startingAmount: 0,
-    startingCapacity: 150, // changed: 100→150
+    startingCapacity: 80, // changed: 150 -> 80
   },
   stone: {
     id: 'stone',
@@ -30,7 +30,7 @@ export const RESOURCES = {
     icon: '🪨',
     category: 'RAW',
     startingAmount: 0,
-    startingCapacity: 80, // changed: 100→80
+    startingCapacity: 50, // changed: 80 -> 50
   },
   scrap: {
     id: 'scrap',
@@ -38,7 +38,7 @@ export const RESOURCES = {
     icon: '♻️',
     category: 'RAW',
     startingAmount: 0,
-    startingCapacity: 80, // changed: 100→80
+    startingCapacity: 60, // changed: 80 -> 60
   },
   planks: {
     id: 'planks',
@@ -46,7 +46,7 @@ export const RESOURCES = {
     icon: '\u{1F332}',
     category: 'CONSTRUCTION_MATERIALS',
     startingAmount: 0,
-    startingCapacity: 50,
+    startingCapacity: 40, // changed: 50 -> 40
   },
   metalParts: {
     id: 'metalParts',
@@ -54,7 +54,7 @@ export const RESOURCES = {
     icon: '\u2699\uFE0F',
     category: 'CONSTRUCTION_MATERIALS',
     startingAmount: 0,
-    startingCapacity: 20,
+    startingCapacity: 24, // changed: 20 -> 24
   },
   science: {
     id: 'science',
@@ -70,7 +70,7 @@ export const RESOURCES = {
     icon: '⚡',
     category: 'ENERGY',
     startingAmount: 0,
-    startingCapacity: 2,
+    startingCapacity: 20, // changed: 2 -> 20
   },
 };
 

--- a/src/engine/__tests__/economy.test.js
+++ b/src/engine/__tests__/economy.test.js
@@ -72,6 +72,6 @@ describe('economy basics', () => {
     state.gameTime.seconds = SEASON_DURATION * 3;
     state.buildings.huntersHut = { count: 1 };
     const next = processTick(state, 1);
-    expect(next.resources.meat.amount).toBeCloseTo(0.19 * 0.6, 5); // changed: 0.15*0.8→0.19*0.6
+    expect(next.resources.meat.amount).toBeCloseTo(0.22 * 0.6, 5); // changed: 0.19*0.6 -> 0.22*0.6
   });
 });

--- a/src/engine/__tests__/research.test.js
+++ b/src/engine/__tests__/research.test.js
@@ -51,9 +51,9 @@ describe('research engine', () => {
     }));
     let s = startResearch(state, 'industry1');
     const bonuses = computeRoleBonuses(state.population.settlers);
-    s = processResearchTick(s, 40, bonuses); // changed: 12→40
+    s = processResearchTick(s, 80, bonuses); // changed: 40 -> 80
     expect(s.research.current).not.toBe(null);
-    s = processResearchTick(s, 1, bonuses);
+    s = processResearchTick(s, 2, bonuses); // changed: 1 -> 2
     expect(s.research.current).toBe(null);
   });
 

--- a/src/engine/settlers.js
+++ b/src/engine/settlers.js
@@ -15,7 +15,7 @@ export function computeRoleBonuses(settlers) {
   settlers.forEach((s) => {
     if (s.isDead || !s.role) return;
     const skill = s.skills?.[s.role] || { level: 0 };
-    const bonus = ROLE_BONUS_PER_SETTLER(skill.level) * 100;
+    const bonus = ROLE_BONUS_PER_SETTLER(skill.level) * 100; // TODO: bonus already fractional; remove ×100 in application
     bonuses[s.role] = (bonuses[s.role] || 0) + bonus;
   });
   return bonuses;


### PR DESCRIPTION
## Summary
- tighten starting resource capacities and storage building gains
- soften T1 building cost curves and boost hunter/quarry output
- cap role bonuses and slow leveling progression

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 25 files)*
- `npm run report:economy` *(fails: Unknown file extension ".ts" for src/utils/clone.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689c5fd68b5083319fb0123824bcbc40