### PR TITLE
Show happiness breakdown values in sidebar

### DIFF
--- a/src/components/ResourceSidebar.jsx
+++ b/src/components/ResourceSidebar.jsx
@@ -16,13 +16,25 @@ export default function ResourceSidebar() {
     <div className="border border-border rounded-xl overflow-hidden bg-card">
       {sections.map((g, i) =>
         g.settlers ? (
-          <SettlerSection key={g.title} title={g.title} info={settlersInfo} noBottomBorder={i === sections.length - 1} />
+          <SettlerSection
+            key={g.title}
+            title={g.title}
+            info={settlersInfo}
+            noBottomBorder={i === sections.length - 1}
+          />
         ) : g.happiness ? (
-          <Accordion key={g.title} title={g.title} contentClassName="p-0" noBottomBorder={i === sections.length - 1}>
+          <Accordion
+            key={g.title}
+            title={g.title}
+            contentClassName="p-0"
+            noBottomBorder={i === sections.length - 1}
+          >
             <ul className="mt-2 px-0 space-y-3">
               <li className="flex justify-between px-0">
                 <span>👥 Settlers</span>
-                <span>{happinessInfo.total} / {happinessInfo.capacity}</span>
+                <span>
+                  {happinessInfo.total} / {happinessInfo.capacity}
+                </span>
               </li>
               <div className="border-t" />
               <li className="flex justify-between px-0">
@@ -31,11 +43,17 @@ export default function ResourceSidebar() {
               </li>
               <li className="flex justify-between px-0">
                 <span>👬 Overcrowding</span>
-                <span>{happinessInfo.overcrowding}</span>
+                <span>
+                  {happinessInfo.overcrowding >= 0 ? '+' : ''}
+                  {happinessInfo.overcrowding}
+                </span>
               </li>
               <li className="flex justify-between px-0">
                 <span>🥗 Food variety</span>
-                <span>{happinessInfo.foodVariety}</span>
+                <span>
+                  {happinessInfo.foodVariety >= 0 ? '+' : ''}
+                  {happinessInfo.foodVariety}
+                </span>
               </li>
             </ul>
           </Accordion>

--- a/src/components/useResourceSections.js
+++ b/src/components/useResourceSections.js
@@ -168,11 +168,16 @@ export function useResourceSections(state) {
     powered,
   };
 
+  const happinessBreakdown = state.colony?.happiness?.breakdown || [];
   const happinessInfo = {
     avg: Math.round(state.colony?.happiness?.value || 0),
     total: totalSettlers,
     capacity,
-    breakdown: state.colony?.happiness?.breakdown || [],
+    breakdown: happinessBreakdown,
+    overcrowding:
+      happinessBreakdown.find((b) => b.label === 'Overcrowding')?.value || 0,
+    foodVariety:
+      happinessBreakdown.find((b) => b.label === 'Food variety')?.value || 0,
   };
 
   return { sections, settlersInfo, happinessInfo };


### PR DESCRIPTION
## Summary
- compute overcrowding and food variety from happiness breakdown
- display signed values for overcrowding and food variety in Happiness section

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 24 files. Run Prettier with --write to fix.)*


------
https://chatgpt.com/codex/tasks/task_e_689c601540b88331a868d069b86b5a89