### PR TITLE
refactor: update research tree and add tools

### DIFF
--- a/src/data/buildings.js
+++ b/src/data/buildings.js
@@ -17,7 +17,7 @@ export const BUILDINGS = [
     name: "Hunter's Hut",
     type: 'production',
     category: 'Food',
-    requiresResearch: 'hunting1',
+    requiresResearch: 'huntingHut',
     outputsPerSecBase: { meat: 0.22 }, // changed: 0.19 -> 0.22
     costBase: { wood: 25, scrap: 10, stone: 5 },
     costGrowth: 1.15,
@@ -88,6 +88,21 @@ export const BUILDINGS = [
     description: 'Processes scrap into metal parts.',
   },
   {
+    id: 'toolsmithy',
+    name: 'Toolsmithy',
+    type: 'processing',
+    category: 'Construction Materials',
+    requiresResearch: 'industry2',
+    requiresPower: true,
+    inputsPerSecBase: { planks: 0.25, metalParts: 0.15, power: 0.4 },
+    outputsPerSecBase: { tools: 0.18 },
+    costBase: { wood: 50, scrap: 30, stone: 20, planks: 25, metalParts: 15 },
+    costGrowth: 1.13,
+    refund: 0.5,
+    seasonProfile: 'constant',
+    description: 'Produces tools for advanced construction.',
+  },
+  {
     id: 'school',
     name: 'School',
     type: 'production',
@@ -105,7 +120,7 @@ export const BUILDINGS = [
     category: 'Energy',
     outputsPerSecBase: { power: 1 },
     inputsPerSecBase: { wood: 0.25 },
-    costBase: { wood: 50, stone: 10 },
+    costBase: { wood: 50, stone: 10, planks: 20, metalParts: 10 },
     costGrowth: 1.13, // changed: 1.15→1.13
     refund: 0.5,
     requiresResearch: 'basicEnergy',
@@ -131,7 +146,7 @@ export const BUILDINGS = [
     requiresResearch: 'radio',
     requiresPower: true,
     inputsPerSecBase: { power: 0.1 },
-    costBase: { wood: 80, scrap: 40, stone: 20, planks: 20 }, // changed: +planks 20
+    costBase: { wood: 80, scrap: 40, stone: 20, planks: 20, metalParts: 10 }, // changed: +planks 20
     costGrowth: 1,
     refund: 0.5,
     maxCount: 1,
@@ -172,7 +187,7 @@ export const BUILDINGS = [
     id: 'battery',
     name: 'Battery',
     type: 'storage',
-    costBase: { wood: 40, stone: 20 },
+    costBase: { wood: 40, stone: 20, planks: 20, metalParts: 10 },
     costGrowth: 1.22, // changed: 1.2 -> 1.22
     refund: 0.5,
     capacityAdd: { power: 40 }, // changed: 600->40

--- a/src/data/research.js
+++ b/src/data/research.js
@@ -1,21 +1,5 @@
 export const RESEARCH = [
-  {
-    id: 'basicEnergy',
-    name: 'Basic Energy',
-    type: 'unlock',
-    shortDesc:
-      'Learn the fundamentals of generating and storing electrical power.',
-    cost: { science: 80 },
-    timeSec: 120,
-    prereqs: ['industry1'],
-    unlocks: {
-      resources: ['power'],
-      buildings: ['woodGenerator', 'battery'],
-      categories: ['Energy'],
-    },
-    row: 1,
-    effects: [],
-  },
+  // Industry track
   {
     id: 'industry1',
     name: 'Industry I',
@@ -23,7 +7,7 @@ export const RESEARCH = [
     shortDesc:
       'Unlocks basic processing and storage for construction materials.',
     cost: { science: 60 },
-    timeSec: 90,
+    timeSec: 120,
     prereqs: [],
     unlocks: {
       buildings: ['sawmill', 'metalWorkshop', 'materialsDepot'],
@@ -34,36 +18,12 @@ export const RESEARCH = [
     effects: [],
   },
   {
-    id: 'hunting1',
-    name: 'Hunting I',
-    type: 'unlock',
-    shortDesc: 'Unlocks hunting for supplemental food.',
-    cost: { science: 50 }, // changed: 35→50
-    timeSec: 90, // changed: 45→90
-    prereqs: [],
-    unlocks: { buildings: ['huntersHut'], resources: ['meat'] },
-    row: 1,
-    effects: [],
-  },
-  {
-    id: 'radio',
-    name: 'Radio',
-    type: 'unlock',
-    shortDesc: 'Unlocks radio broadcasts to attract settlers.',
-    cost: { science: 150 }, // changed: 120→150
-    timeSec: 240, // changed: 180→240
-    prereqs: ['industry1', 'basicEnergy'],
-    unlocks: { buildings: ['radio'] },
-    row: 1,
-    effects: [],
-  },
-  {
     id: 'woodworking1',
     name: 'Woodworking I',
     type: 'efficiency',
     shortDesc: '+5% to wood and derived planks.',
-    cost: { science: 60 }, // changed: 50→60
-    timeSec: 90, // changed: 70→90
+    cost: { science: 60 },
+    timeSec: 90,
     prereqs: ['industry1'],
     effects: [{ category: 'WOOD', percent: 0.05, type: 'output' }],
     row: 1,
@@ -73,8 +33,8 @@ export const RESEARCH = [
     name: 'Salvaging I',
     type: 'efficiency',
     shortDesc: '+5% to scrap and derived metal parts.',
-    cost: { science: 60 }, // changed: 50→60
-    timeSec: 90, // changed: 70→90
+    cost: { science: 60 },
+    timeSec: 90,
     prereqs: ['industry1'],
     effects: [{ category: 'SCRAP', percent: 0.05, type: 'output' }],
     row: 1,
@@ -101,20 +61,39 @@ export const RESEARCH = [
     shortDesc: 'Unlocks advanced tools and further processing.',
     cost: { science: 200 },
     timeSec: 240,
-    prereqs: ['industry1'],
+    prereqs: ['woodworking1', 'salvaging1', 'logistics1'],
     milestones: { produced: { planks: 50, metalParts: 30 } },
     unlocks: { buildings: ['toolsmithy'] },
     row: 2,
     effects: [],
   },
   {
+    id: 'industryProduction',
+    name: 'Industry Production',
+    type: 'efficiency',
+    shortDesc: '+5% output for construction materials.',
+    cost: { science: 170 },
+    timeSec: 270,
+    prereqs: ['woodworking1', 'salvaging1', 'logistics1'],
+    effects: [
+      { category: 'CONSTRUCTION_MATERIALS', percent: 0.05, type: 'output' },
+    ],
+    row: 2,
+  },
+  {
     id: 'woodworking2',
     name: 'Woodworking II',
     type: 'efficiency',
     shortDesc: 'Additional +5% to wood and planks.',
-    cost: { science: 140 }, // changed: 110→140
-    timeSec: 240, // changed: 180→240
-    prereqs: ['woodworking1', 'industry2'],
+    cost: { science: 220 },
+    timeSec: 360,
+    prereqs: [
+      'industry2',
+      'industryProduction',
+      'woodworking1',
+      'salvaging1',
+      'logistics1',
+    ],
     effects: [{ category: 'WOOD', percent: 0.05, type: 'output' }],
     row: 3,
   },
@@ -123,9 +102,15 @@ export const RESEARCH = [
     name: 'Salvaging II',
     type: 'efficiency',
     shortDesc: 'Additional +5% to scrap and metal parts.',
-    cost: { science: 140 }, // changed: 110→140
-    timeSec: 240, // changed: 180→240
-    prereqs: ['salvaging1', 'industry2'],
+    cost: { science: 220 },
+    timeSec: 360,
+    prereqs: [
+      'industry2',
+      'industryProduction',
+      'woodworking1',
+      'salvaging1',
+      'logistics1',
+    ],
     effects: [{ category: 'SCRAP', percent: 0.05, type: 'output' }],
     row: 3,
   },
@@ -135,35 +120,85 @@ export const RESEARCH = [
     type: 'efficiency',
     shortDesc:
       'Additional +5% storage capacity for raw materials and construction materials.',
-    cost: { science: 150 }, // changed: 120→150
-    timeSec: 270, // changed: 210→270
-    prereqs: ['logistics1', 'industry2'],
+    cost: { science: 230 },
+    timeSec: 360,
+    prereqs: [
+      'industry2',
+      'industryProduction',
+      'woodworking1',
+      'salvaging1',
+      'logistics1',
+    ],
     effects: [
       { category: 'RAW', percent: 0.05, type: 'storage' },
       { category: 'CONSTRUCTION_MATERIALS', percent: 0.05, type: 'storage' },
     ],
     row: 3,
   },
+  // Power track
   {
-    id: 'hunting2',
-    name: 'Hunting II',
-    type: 'efficiency',
-    shortDesc: '+10% to all food outputs.',
-    cost: { science: 130 },
-    timeSec: 240,
-    prereqs: ['hunting1'],
-    effects: [{ category: 'FOOD', percent: 0.1, type: 'output' }],
-    row: 2,
+    id: 'basicEnergy',
+    name: 'Basic Energy',
+    type: 'unlock',
+    shortDesc:
+      'Learn the fundamentals of generating and storing electrical power.',
+    cost: { science: 150 },
+    timeSec: 210,
+    prereqs: ['industry2'],
+    unlocks: {
+      resources: ['power'],
+      buildings: ['woodGenerator', 'battery'],
+      categories: ['Energy'],
+    },
+    row: 3,
+    effects: [],
   },
   {
-    id: 'industryProduction',
-    name: 'Industry Production',
-    type: 'efficiency',
-    shortDesc: '+10% output for construction materials.',
-    cost: { science: 130 },
+    id: 'radio',
+    name: 'Radio',
+    type: 'unlock',
+    shortDesc: 'Unlocks radio broadcasts to attract settlers.',
+    cost: { science: 150 },
     timeSec: 240,
-    prereqs: ['industry1'],
-    effects: [{ category: 'CONSTRUCTION_MATERIALS', percent: 0.1, type: 'output' }],
+    prereqs: ['basicEnergy'],
+    unlocks: { buildings: ['radio'] },
+    row: 4,
+    effects: [],
+  },
+  // Food track
+  {
+    id: 'food1',
+    name: 'Food I',
+    type: 'unlock',
+    shortDesc: 'Lays the groundwork for improved food gathering.',
+    cost: { science: 50 },
+    timeSec: 90,
+    prereqs: [],
+    unlocks: {},
+    row: 0,
+    effects: [],
+  },
+  {
+    id: 'huntingHut',
+    name: 'Hunting Hut',
+    type: 'unlock',
+    shortDesc: 'Unlocks the hunting hut for supplemental meat.',
+    cost: { science: 60 },
+    timeSec: 90,
+    prereqs: ['food1'],
+    unlocks: { buildings: ['huntersHut'], resources: ['meat'] },
+    row: 1,
+    effects: [],
+  },
+  {
+    id: 'food2',
+    name: 'Food II',
+    type: 'efficiency',
+    shortDesc: '+4% to meat output.',
+    cost: { science: 150 },
+    timeSec: 240,
+    prereqs: ['huntingHut'],
+    effects: [{ resource: 'meat', percent: 0.04, type: 'output' }],
     row: 2,
   },
 ];

--- a/src/data/resources.js
+++ b/src/data/resources.js
@@ -56,6 +56,14 @@ export const RESOURCES = {
     startingAmount: 0,
     startingCapacity: 24, // changed: 20 -> 24
   },
+  tools: {
+    id: 'tools',
+    name: 'Tools',
+    icon: '\u{1F6E0}\uFE0F',
+    category: 'CONSTRUCTION_MATERIALS',
+    startingAmount: 0,
+    startingCapacity: 24,
+  },
   science: {
     id: 'science',
     name: 'Science',

--- a/src/engine/__tests__/research.test.js
+++ b/src/engine/__tests__/research.test.js
@@ -51,17 +51,25 @@ describe('research engine', () => {
     }));
     let s = startResearch(state, 'industry1');
     const bonuses = computeRoleBonuses(state.population.settlers);
-    s = processResearchTick(s, 80, bonuses); // changed: 40 -> 80
+    s = processResearchTick(s, 100, bonuses);
     expect(s.research.current).not.toBe(null);
-    s = processResearchTick(s, 2, bonuses); // changed: 1 -> 2
+    s = processResearchTick(s, 10, bonuses);
     expect(s.research.current).toBe(null);
   });
 
   it('unlocks radio after industry research', () => {
     const state = deepClone(defaultState);
-    state.resources.science.amount = 300;
+    state.resources.science.amount = 1000;
     let s = startResearch(state, 'industry1');
     s = processResearchTick(s, RESEARCH_MAP['industry1'].timeSec);
+    s = startResearch(s, 'woodworking1');
+    s = processResearchTick(s, RESEARCH_MAP['woodworking1'].timeSec);
+    s = startResearch(s, 'salvaging1');
+    s = processResearchTick(s, RESEARCH_MAP['salvaging1'].timeSec);
+    s = startResearch(s, 'logistics1');
+    s = processResearchTick(s, RESEARCH_MAP['logistics1'].timeSec);
+    s = startResearch(s, 'industry2');
+    s = processResearchTick(s, RESEARCH_MAP['industry2'].timeSec);
     s = startResearch(s, 'basicEnergy');
     s = processResearchTick(s, RESEARCH_MAP['basicEnergy'].timeSec);
     s = startResearch(s, 'radio');


### PR DESCRIPTION
## Summary
- elongate Industry research into an AND-gated spine with new Toolsmithy unlock
- shift Radio into the Power track and add construction-material costs to energy structures
- rename Hunting track to Food with Hunting Hut gate and modest meat bonus

## Testing
- `npm test`
- `npm run report:economy` *(fails: Unknown file extension ".ts" for clone.ts)*
- `npm run lint` *(fails: code style issues in repo)*

------
https://chatgpt.com/codex/tasks/task_e_689c64c77e7483318ad48ede6457293a