### PR TITLE
feat: add toast notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-switch": "^1.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
+        "@radix-ui/react-toast": "^1.2.14",
         "@radix-ui/react-tooltip": "^1.2.7",
         "@tailwindcss/vite": "^4.1.11",
         "class-variance-authority": "^0.7.1",
@@ -1964,6 +1965,40 @@
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-roving-focus": "1.1.10",
         "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.14.tgz",
+      "integrity": "sha512-nAP5FBxBJGQ/YfUB+r+O6USFVkWq3gAInkxyEnmvEV5jtSbfDhfa4hwX8CraCnbjMLsE7XSf/K75l9xXY7joWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.5",
     "@radix-ui/react-tabs": "^1.1.12",
+    "@radix-ui/react-toast": "^1.2.14",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@tailwindcss/vite": "^4.1.11",
     "class-variance-authority": "^0.7.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import PopulationView from './views/PopulationView.jsx';
 import ResearchView from './views/ResearchView.jsx';
 import ExpeditionsView from './views/ExpeditionsView.jsx';
 import { useGame } from './state/useGame.tsx';
+import { ToastProvider, Toaster } from './components/ui/toast.tsx';
 
 function ActiveView() {
   const { state } = useGame();
@@ -26,17 +27,20 @@ function ActiveView() {
 
 export default function App() {
   return (
-    <GameProvider>
-      <div className="min-h-screen flex flex-col bg-background text-foreground">
-        <TopBar />
-        <div className="flex-1">
-          <ActiveView />
+    <ToastProvider>
+      <GameProvider>
+        <div className="min-h-screen flex flex-col bg-background text-foreground">
+          <TopBar />
+          <div className="flex-1">
+            <ActiveView />
+          </div>
+          <BottomDock />
+          <Drawer />
+          <OfflineProgressModal />
+          <CorruptSaveModal />
+          <Toaster />
         </div>
-        <BottomDock />
-        <Drawer />
-        <OfflineProgressModal />
-        <CorruptSaveModal />
-      </div>
-    </GameProvider>
+      </GameProvider>
+    </ToastProvider>
   );
 }

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,0 +1,154 @@
+import * as React from 'react';
+import * as ToastPrimitive from '@radix-ui/react-toast';
+import { XIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const ToastContext = React.createContext<
+  | {
+      toasts: ToastItem[];
+      toast: (toast: Omit<ToastItem, 'id'>) => void;
+      dismiss: (id: string) => void;
+    }
+  | undefined
+>(undefined);
+
+interface ToastItem {
+  id: string;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  action?: React.ReactNode;
+  duration?: number;
+}
+
+function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = React.useState<ToastItem[]>([]);
+
+  const dismiss = React.useCallback((id: string) => {
+    setToasts((toasts) => toasts.filter((t) => t.id !== id));
+  }, []);
+
+  const toast = React.useCallback((toast: Omit<ToastItem, 'id'>) => {
+    const id = Math.random().toString(36).slice(2);
+    setToasts((toasts) => [...toasts, { id, ...toast }]);
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ toasts, toast, dismiss }}>
+      <ToastPrimitive.Provider swipeDirection="right">
+        {children}
+      </ToastPrimitive.Provider>
+    </ToastContext.Provider>
+  );
+}
+
+function useToast() {
+  const context = React.useContext(ToastContext);
+  if (!context) throw new Error('useToast must be used within a ToastProvider');
+  return context;
+}
+
+const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitive.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitive.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitive.Viewport
+    ref={ref}
+    className={cn(
+      'fixed bottom-4 right-4 flex flex-col gap-2 z-50 outline-none',
+      className,
+    )}
+    {...props}
+  />
+));
+ToastViewport.displayName = ToastPrimitive.Viewport.displayName;
+
+const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitive.Root
+    ref={ref}
+    className={cn(
+      'bg-card text-card-foreground border shadow-lg rounded-md p-4 grid gap-1',
+      className,
+    )}
+    {...props}
+  />
+));
+Toast.displayName = ToastPrimitive.Root.displayName;
+
+const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitive.Title
+    ref={ref}
+    className={cn('font-semibold', className)}
+    {...props}
+  />
+));
+ToastTitle.displayName = ToastPrimitive.Title.displayName;
+
+const ToastDescription = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitive.Description
+    ref={ref}
+    className={cn('text-sm opacity-90', className)}
+    {...props}
+  />
+));
+ToastDescription.displayName = ToastPrimitive.Description.displayName;
+
+const ToastClose = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitive.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitive.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitive.Close
+    ref={ref}
+    className={cn(
+      'absolute top-2 right-2 rounded-xs opacity-0 transition-opacity hover:opacity-100 focus:opacity-100',
+      className,
+    )}
+    {...props}
+  >
+    <XIcon className="h-4 w-4" />
+  </ToastPrimitive.Close>
+));
+ToastClose.displayName = ToastPrimitive.Close.displayName;
+
+function Toaster() {
+  const { toasts, dismiss } = useToast();
+  return (
+    <>
+      {toasts.map((toast) => (
+        <Toast
+          key={toast.id}
+          open
+          duration={toast.duration}
+          onOpenChange={(open) => !open && dismiss(toast.id)}
+        >
+          {toast.title && <ToastTitle>{toast.title}</ToastTitle>}
+          {toast.description && (
+            <ToastDescription>{toast.description}</ToastDescription>
+          )}
+          {toast.action}
+          <ToastClose />
+        </Toast>
+      ))}
+      <ToastViewport />
+    </>
+  );
+}
+
+export {
+  Toast,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+  Toaster,
+  useToast,
+};


### PR DESCRIPTION
## Summary
- add Radix toast dependency
- implement ToastProvider, hook, and Toaster container
- wire provider and toaster into app layout

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 30 files)*

------
https://chatgpt.com/codex/tasks/task_e_689c71dda514833191b6265487a88269