### PR TITLE
feat: notify when research finishes

### DIFF
--- a/src/state/GameContext.jsx
+++ b/src/state/GameContext.jsx
@@ -6,6 +6,7 @@ import { prepareLoadedState } from './prepareLoadedState.ts';
 import useGameTick from './hooks/useGameTick.tsx';
 import useAutosave from './hooks/useAutosave.tsx';
 import useGameActions from './hooks/useGameActions.tsx';
+import useNotifications from './hooks/useNotifications.tsx';
 
 export function GameProvider({ children }) {
   const { state: loaded, error: loadErr } = loadGame();
@@ -21,6 +22,7 @@ export function GameProvider({ children }) {
 
   useGameTick(setState);
   useAutosave(state, setState);
+  useNotifications(state);
 
   const actions = useGameActions(setState, setLoadError);
 

--- a/src/state/__tests__/GameContext.test.jsx
+++ b/src/state/__tests__/GameContext.test.jsx
@@ -5,6 +5,8 @@ import { GameProvider } from '../GameContext.jsx';
 import { useGame } from '../useGame.tsx';
 import { loadGame } from '../../engine/persistence.js';
 
+vi.mock('../hooks/useNotifications.tsx', () => ({ default: vi.fn() }));
+
 vi.mock('../../engine/persistence.js', () => ({
   saveGame: vi.fn((s) => s),
   loadGame: vi.fn(),

--- a/src/state/hooks/__tests__/useNotifications.test.tsx
+++ b/src/state/hooks/__tests__/useNotifications.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+
+const toast = vi.fn();
+vi.mock('../../../components/ui/toast.tsx', () => ({
+  useToast: () => ({ toast, dismiss: vi.fn() }),
+}));
+
+import useNotifications from '../useNotifications';
+import { RESEARCH_MAP } from '../../../data/research.js';
+
+function Wrapper({ state }: { state: any }) {
+  useNotifications(state);
+  return null;
+}
+
+describe('useNotifications', () => {
+  beforeEach(() => {
+    toast.mockClear();
+  });
+
+  it('toasts when research completes', () => {
+    const initial = { research: { current: { id: 'industry1' }, completed: [] } };
+    const done = {
+      research: { current: null, completed: ['industry1'] },
+    };
+    const { rerender } = render(<Wrapper state={initial} />);
+    rerender(<Wrapper state={done} />);
+    expect(toast).toHaveBeenCalledWith({
+      description: `${RESEARCH_MAP.industry1.name} research complete`,
+    });
+  });
+
+  it('does not toast when research is cancelled', () => {
+    const initial = { research: { current: { id: 'industry1' }, completed: [] } };
+    const cancelled = { research: { current: null, completed: [] } };
+    const { rerender } = render(<Wrapper state={initial} />);
+    rerender(<Wrapper state={cancelled} />);
+    expect(toast).not.toHaveBeenCalled();
+  });
+});

--- a/src/state/hooks/useNotifications.tsx
+++ b/src/state/hooks/useNotifications.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from 'react';
+import { RESEARCH_MAP } from '../../data/research.js';
+import { useToast } from '../../components/ui/toast.tsx';
+import type { GameState } from '../useGame.tsx';
+
+export default function useNotifications(state: GameState): void {
+  const prevRef = useRef<GameState>(state);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const prev = prevRef.current;
+    if (
+      prev.research.current &&
+      !state.research.current &&
+      state.research.completed.includes(prev.research.current.id)
+    ) {
+      const id = prev.research.current.id;
+      const name = RESEARCH_MAP[id]?.name || id;
+      toast({ description: `${name} research complete` });
+    }
+    prevRef.current = state;
+  }, [state, toast]);
+}


### PR DESCRIPTION
## Summary
- add useNotifications hook to watch for research completion
- trigger dismissable toasts when research finishes
- test notifications and mock in GameContext tests

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689c73cb192883319f1bb66570b2f599