### PR TITLE
Announce candidate arrivals, deaths, and power shortages

### DIFF
--- a/src/state/hooks/__tests__/useNotifications.test.tsx
+++ b/src/state/hooks/__tests__/useNotifications.test.tsx
@@ -10,6 +10,7 @@ vi.mock('../../../components/ui/toast.tsx', () => ({
 import useNotifications from '../useNotifications';
 import { RESEARCH_MAP } from '../../../data/research.js';
 import { RESOURCES } from '../../../data/resources.js';
+import { BUILDING_MAP } from '../../../data/buildings.js';
 
 function Wrapper({ state }: { state: any }) {
   useNotifications(state);
@@ -25,10 +26,14 @@ describe('useNotifications', () => {
     const initial = {
       research: { current: { id: 'industry1' }, completed: [] },
       resources: {},
+      population: { candidate: null, settlers: [] },
+      buildings: {},
     };
     const done = {
       research: { current: null, completed: ['industry1'] },
       resources: {},
+      population: { candidate: null, settlers: [] },
+      buildings: {},
     };
     const { rerender } = render(<Wrapper state={initial} />);
     rerender(<Wrapper state={done} />);
@@ -41,10 +46,14 @@ describe('useNotifications', () => {
     const initial = {
       research: { current: { id: 'industry1' }, completed: [] },
       resources: {},
+      population: { candidate: null, settlers: [] },
+      buildings: {},
     };
     const cancelled = {
       research: { current: null, completed: [] },
       resources: {},
+      population: { candidate: null, settlers: [] },
+      buildings: {},
     };
     const { rerender } = render(<Wrapper state={initial} />);
     rerender(<Wrapper state={cancelled} />);
@@ -55,15 +64,85 @@ describe('useNotifications', () => {
     const initial = {
       research: { current: null, completed: [] },
       resources: { wood: { amount: 79 } },
+      population: { candidate: null, settlers: [] },
+      buildings: {},
     };
     const next = {
       research: { current: null, completed: [] },
       resources: { wood: { amount: 80 } },
+      population: { candidate: null, settlers: [] },
+      buildings: {},
     };
     const { rerender } = render(<Wrapper state={initial} />);
     rerender(<Wrapper state={next} />);
     expect(toast).toHaveBeenCalledWith({
       description: `${RESOURCES.wood.name} storage full`,
     });
+  });
+
+  it('toasts when a candidate appears', () => {
+    const initial = {
+      research: { current: null, completed: [] },
+      resources: {},
+      population: { candidate: null, settlers: [] },
+      buildings: {},
+    };
+    const next = {
+      research: { current: null, completed: [] },
+      resources: {},
+      population: { candidate: { id: 'cand1' }, settlers: [] },
+      buildings: {},
+    };
+    const { rerender } = render(<Wrapper state={initial} />);
+    rerender(<Wrapper state={next} />);
+    expect(toast).toHaveBeenCalledWith({
+      description: 'New settler candidate available',
+    });
+    rerender(<Wrapper state={next} />);
+    expect(toast).toHaveBeenCalledTimes(1);
+  });
+
+  it('announces settler deaths', () => {
+    const alive = { id: 's1', name: 'Bob', isDead: false };
+    const dead = { id: 's1', name: 'Bob', isDead: true };
+    const initial = {
+      research: { current: null, completed: [] },
+      resources: {},
+      population: { candidate: null, settlers: [alive] },
+      buildings: {},
+    };
+    const next = {
+      research: { current: null, completed: [] },
+      resources: {},
+      population: { candidate: null, settlers: [dead] },
+      buildings: {},
+    };
+    const { rerender } = render(<Wrapper state={initial} />);
+    rerender(<Wrapper state={next} />);
+    expect(toast).toHaveBeenCalledWith({ description: 'Bob has died' });
+    rerender(<Wrapper state={next} />);
+    expect(toast).toHaveBeenCalledTimes(1);
+  });
+
+  it('toasts when building loses power and dedupes', () => {
+    const initial = {
+      research: { current: null, completed: [] },
+      resources: {},
+      population: { candidate: null, settlers: [] },
+      buildings: { radio: {} },
+    };
+    const offline = {
+      research: { current: null, completed: [] },
+      resources: {},
+      population: { candidate: null, settlers: [] },
+      buildings: { radio: { offlineReason: 'power' } },
+    };
+    const { rerender } = render(<Wrapper state={initial} />);
+    rerender(<Wrapper state={offline} />);
+    expect(toast).toHaveBeenCalledWith({
+      description: `Power shortage: ${BUILDING_MAP.radio.name} offline`,
+    });
+    rerender(<Wrapper state={offline} />);
+    expect(toast).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/state/hooks/useNotifications.tsx
+++ b/src/state/hooks/useNotifications.tsx
@@ -1,16 +1,20 @@
 import { useEffect, useRef } from 'react';
 import { RESEARCH_MAP } from '../../data/research.js';
 import { RESOURCES } from '../../data/resources.js';
+import { BUILDING_MAP } from '../../data/buildings.js';
 import { useToast } from '../../components/ui/toast.tsx';
 import { getCapacity } from '../selectors.js';
 import type { GameState } from '../useGame.tsx';
 
 export default function useNotifications(state: GameState): void {
   const prevRef = useRef<GameState>(state);
+  const resourceNotified = useRef<Set<string>>(new Set());
+  const powerNotified = useRef<Set<string>>(new Set());
   const { toast } = useToast();
 
   useEffect(() => {
     const prev = prevRef.current;
+
     if (
       prev.research.current &&
       !state.research.current &&
@@ -21,15 +25,52 @@ export default function useNotifications(state: GameState): void {
       toast({ description: `${name} research complete` });
     }
 
+    if (!prev.population.candidate && state.population.candidate) {
+      toast({ description: 'New settler candidate available' });
+    }
+
+    const prevSettlers = prev.population.settlers;
+    const alivePrev = new Set(
+      prevSettlers.filter((s) => !s.isDead).map((s) => s.id),
+    );
+    state.population.settlers.forEach((s) => {
+      if (s.isDead && alivePrev.has(s.id)) {
+        const name = s.name ? `${s.name} has died` : 'A settler has died';
+        toast({ description: name });
+      }
+    });
+
+    Object.entries(state.buildings).forEach(([id, b]) => {
+      const currReason = b?.offlineReason;
+      const prevReason = prev.buildings?.[id]?.offlineReason;
+      if (
+        currReason === 'power' &&
+        prevReason !== 'power' &&
+        !powerNotified.current.has(id)
+      ) {
+        const name = BUILDING_MAP[id]?.name || id;
+        toast({ description: `Power shortage: ${name} offline` });
+        powerNotified.current.add(id);
+      }
+      if (currReason !== 'power') powerNotified.current.delete(id);
+    });
+
     Object.entries(state.resources).forEach(([id, res]) => {
       const prevAmt = prev.resources?.[id]?.amount || 0;
       const currAmt = res.amount;
       const cap = getCapacity(state, id);
-      if (prevAmt < cap && currAmt >= cap) {
+      if (
+        prevAmt < cap &&
+        currAmt >= cap &&
+        !resourceNotified.current.has(id)
+      ) {
         const name = RESOURCES[id]?.name || id;
         toast({ description: `${name} storage full` });
+        resourceNotified.current.add(id);
       }
+      if (currAmt < cap) resourceNotified.current.delete(id);
     });
+
     prevRef.current = state;
   }, [state, toast]);
 }


### PR DESCRIPTION
## Summary
- notify when a new settler candidate appears
- announce settler deaths and power-related building shutdowns with deduping
- test coverage for new notification cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c76425be4833191672b2bdd4f8979