### PR TITLE
refactor: extract building calc hooks

### DIFF
--- a/src/components/BuildingRow.jsx
+++ b/src/components/BuildingRow.jsx
@@ -1,88 +1,29 @@
 import React from 'react';
-import { useGame } from '../state/useGame.tsx';
-import { getBuildingCost } from '../data/buildings.js';
 import { RESOURCES } from '../data/resources.js';
-import { getSeason, getSeasonMultiplier } from '../engine/time.js';
-import { getCapacity } from '../state/selectors.js';
 import { formatAmount } from '../utils/format.js';
-import { clampResource, demolishBuilding } from '../engine/production.js';
 import { RESEARCH_MAP } from '../data/research.js';
 import { Button } from './Button';
 import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip';
 
-export default function BuildingRow({ building, completedResearch }) {
-  const { state, setState } = useGame();
-  const count = state.buildings[building.id]?.count || 0;
-  const atMax = building.maxCount != null && count >= building.maxCount;
-  const season = getSeason(state);
-  const scaledCost = getBuildingCost(building, count);
-  const costEntries = Object.entries(scaledCost);
-  const offlineReason = state.buildings[building.id]?.offlineReason;
-  const unlocked =
-    !building.requiresResearch ||
-    completedResearch.includes(building.requiresResearch);
-  const canAfford = costEntries.every(
-    ([res, amt]) => (state.resources[res]?.amount || 0) >= amt,
-  );
-  const perOutputs = Object.entries(building.outputsPerSecBase || {}).map(
-    ([res, base]) => {
-      let mult;
-      if (building.seasonProfile === 'constant') mult = 1;
-      else if (typeof building.seasonProfile === 'object')
-        mult = building.seasonProfile[season.id] ?? 1;
-      else mult = getSeasonMultiplier(season, RESOURCES[res].category);
-      return { res, perSec: base * mult };
-    },
-  );
-  const perInputs = Object.entries(building.inputsPerSecBase || {}).map(
-    ([res, base]) => ({ res, perSec: base }),
-  );
-
+export default function BuildingRow({
+  building,
+  count = 0,
+  atMax = false,
+  costEntries = [],
+  perOutputs = [],
+  perInputs = [],
+  canAfford = false,
+  unlocked = false,
+  offlineReason,
+  buildTooltip,
+  showPowerWarning = false,
+  onBuild,
+  onDemolish,
+}) {
   const formatPerSec = (perSec, res) => {
     const sign = perSec >= 0 ? '+' : '-';
     return `${sign}${Math.abs(perSec).toFixed(2)} ${RESOURCES[res].name}/s`;
   };
-
-  const build = () => {
-    if (!canAfford || !unlocked || atMax) return;
-    setState((prev) => {
-      const resources = { ...prev.resources };
-      costEntries.forEach(([res, amt]) => {
-        const currentEntry = resources[res] || { amount: 0, discovered: false };
-        const next = currentEntry.amount - amt;
-        resources[res] = {
-          amount: next,
-          discovered: currentEntry.discovered || next > 0,
-        };
-      });
-      const newCount = count + 1;
-      const buildings = {
-        ...prev.buildings,
-        [building.id]: { count: newCount },
-      };
-      Object.keys(resources).forEach((res) => {
-        const cap = getCapacity({ ...prev, buildings }, res);
-        const entry = resources[res];
-        entry.amount = clampResource(entry.amount, cap);
-        if (entry.amount > 0) entry.discovered = true;
-      });
-      return { ...prev, resources, buildings };
-    });
-  };
-
-  const demolish = () => {
-    if (count <= 0) return;
-    setState((prev) => demolishBuilding(prev, building.id));
-  };
-
-  const buildTooltip = !unlocked
-    ? `Requires: ${
-        RESEARCH_MAP[building.requiresResearch]?.name ||
-        building.requiresResearch
-      }`
-    : atMax
-      ? `Max ${building.maxCount}`
-      : null;
 
   return (
     <div className="p-4 rounded-lg border border-border bg-card space-y-3">
@@ -104,7 +45,7 @@ export default function BuildingRow({ building, completedResearch }) {
           <Button
             variant="outline"
             size="sm"
-            onClick={demolish}
+            onClick={onDemolish}
             disabled={count <= 0}
           >
             Demolish
@@ -114,7 +55,7 @@ export default function BuildingRow({ building, completedResearch }) {
               <TooltipTrigger asChild>
                 <Button
                   size="sm"
-                  onClick={build}
+                  onClick={onBuild}
                   disabled={!canAfford || !unlocked || atMax}
                 >
                   Build
@@ -125,7 +66,7 @@ export default function BuildingRow({ building, completedResearch }) {
           ) : (
             <Button
               size="sm"
-              onClick={build}
+              onClick={onBuild}
               disabled={!canAfford || !unlocked || atMax}
             >
               Build
@@ -147,8 +88,7 @@ export default function BuildingRow({ building, completedResearch }) {
             <div className="mt-2 flex flex-wrap gap-3">
               {costEntries.map(([res, amt]) => (
                 <span key={res} className="flex items-center gap-1">
-                  {RESOURCES[res].icon} {formatAmount(amt)}{' '}
-                  {RESOURCES[res].name}
+                  {RESOURCES[res].icon} {formatAmount(amt)} {RESOURCES[res].name}
                 </span>
               ))}
             </div>
@@ -195,10 +135,9 @@ export default function BuildingRow({ building, completedResearch }) {
         {building.maxCount != null && (
           <div className="text-xs">Max: {building.maxCount}</div>
         )}
-        {building.outputsPerSecBase?.power &&
-          getCapacity(state, 'power') <= 0 && (
-            <div className="text-xs">No Power storage. Excess is lost.</div>
-          )}
+        {showPowerWarning && (
+          <div className="text-xs">No Power storage. Excess is lost.</div>
+        )}
       </div>
     </div>
   );

--- a/src/components/BuildingRow.test.jsx
+++ b/src/components/BuildingRow.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import BuildingRow from './BuildingRow.jsx';
+import BuildingRow from './BuildingRowContainer.jsx';
 import { BUILDING_MAP } from '../data/buildings.js';
 import { GameContext } from '../state/useGame.tsx';
 import { defaultState } from '../state/defaultState.js';

--- a/src/components/BuildingRowContainer.jsx
+++ b/src/components/BuildingRowContainer.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import useBuilding from '../state/hooks/useBuilding.tsx';
+import BuildingRow from './BuildingRow.jsx';
+
+export default function BuildingRowContainer({ building, completedResearch }) {
+  const props = useBuilding(building, completedResearch);
+  return <BuildingRow building={building} {...props} />;
+}

--- a/src/components/ProductionSection.jsx
+++ b/src/components/ProductionSection.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Accordion from './Accordion.jsx';
-import BuildingRow from './BuildingRow.jsx';
+import BuildingRow from './BuildingRowContainer.jsx';
 import { Card, CardContent } from './ui/card';
 
 export default function ProductionSection({

--- a/src/state/hooks/useBuilding.tsx
+++ b/src/state/hooks/useBuilding.tsx
@@ -1,0 +1,79 @@
+import { useCallback } from 'react';
+import { useGame } from '../useGame.tsx';
+import {
+  getBuildingCostEntries,
+  getBuildingOutputs,
+  getBuildingInputs,
+  canAffordBuilding,
+  getCapacity,
+} from '../selectors.js';
+import { clampResource, demolishBuilding } from '../../engine/production.js';
+import { RESEARCH_MAP } from '../../data/research.js';
+
+export default function useBuilding(building: any, completedResearch: string[] = []) {
+  const { state, setState } = useGame();
+  const count = state.buildings[building.id]?.count || 0;
+  const atMax = building.maxCount != null && count >= building.maxCount;
+  const costEntries = getBuildingCostEntries(state, building);
+  const perOutputs = getBuildingOutputs(state, building);
+  const perInputs = getBuildingInputs(state, building);
+  const canAfford = canAffordBuilding(state, building);
+  const offlineReason = state.buildings[building.id]?.offlineReason;
+  const unlocked =
+    !building.requiresResearch || completedResearch.includes(building.requiresResearch);
+  const buildTooltip = !unlocked
+    ? `Requires: ${RESEARCH_MAP[building.requiresResearch]?.name || building.requiresResearch}`
+    : atMax
+      ? `Max ${building.maxCount}`
+      : null;
+  const showPowerWarning = Boolean(
+    building.outputsPerSecBase?.power && getCapacity(state, 'power') <= 0,
+  );
+
+  const onBuild = useCallback(() => {
+    if (!canAfford || !unlocked || atMax) return;
+    setState((prev) => {
+      const resources = { ...prev.resources } as any;
+      costEntries.forEach(([res, amt]) => {
+        const currentEntry = resources[res] || { amount: 0, discovered: false };
+        const next = currentEntry.amount - amt;
+        resources[res] = {
+          amount: next,
+          discovered: currentEntry.discovered || next > 0,
+        };
+      });
+      const newCount = count + 1;
+      const buildings = {
+        ...prev.buildings,
+        [building.id]: { count: newCount },
+      } as any;
+      Object.keys(resources).forEach((res) => {
+        const cap = getCapacity({ ...prev, buildings } as any, res);
+        const entry = resources[res];
+        entry.amount = clampResource(entry.amount, cap);
+        if (entry.amount > 0) entry.discovered = true;
+      });
+      return { ...prev, resources, buildings } as any;
+    });
+  }, [canAfford, unlocked, atMax, costEntries, setState, count, building.id]);
+
+  const onDemolish = useCallback(() => {
+    if (count <= 0) return;
+    setState((prev) => demolishBuilding(prev, building.id));
+  }, [count, setState, building.id]);
+
+  return {
+    count,
+    atMax,
+    costEntries,
+    perOutputs,
+    perInputs,
+    canAfford,
+    unlocked,
+    offlineReason,
+    buildTooltip,
+    showPowerWarning,
+    onBuild,
+    onDemolish,
+  };
+}


### PR DESCRIPTION
## Summary
- move building cost/output computations into selectors
- add reusable `useBuilding` hook for build/demolish logic
- make `BuildingRow` purely presentational

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 30 files)*

------
https://chatgpt.com/codex/tasks/task_e_689c77a4b90483318b6773fdbaca40c3