### PR TITLE
Extract engine helpers into modules with tests

### DIFF
--- a/src/engine/__tests__/offline.test.js
+++ b/src/engine/__tests__/offline.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest';
+
+const fakeCandidate = { id: 'cand1' };
+vi.mock('../candidates.js', () => ({
+  generateCandidate: vi.fn(() => fakeCandidate),
+}));
+
+import { applyOfflineProgress } from '../offline.js';
+import { generateCandidate } from '../candidates.js';
+
+describe('applyOfflineProgress', () => {
+  it('uses post-production state to update radio', () => {
+    generateCandidate.mockClear();
+    const state = {
+      buildings: { radio: { count: 1 }, woodGenerator: { count: 1 } },
+      resources: { power: { amount: 0 }, wood: { amount: 100 } },
+      population: { candidate: null },
+      colony: { radioTimer: 3 },
+    };
+    const { state: next } = applyOfflineProgress(state, 5);
+    expect(generateCandidate).toHaveBeenCalledOnce();
+    expect(next.population.candidate).toEqual(fakeCandidate);
+    expect(next.colony.radioTimer).toBe(0);
+  });
+
+  it('returns resource gains for production while offline', () => {
+    const state = {
+      buildings: { woodGenerator: { count: 1 } },
+      resources: { power: { amount: 0 }, wood: { amount: 100 } },
+      population: { candidate: null },
+      colony: { radioTimer: 0 },
+    };
+    const { gains } = applyOfflineProgress(state, 5);
+    expect(gains.power).toBeGreaterThan(0);
+  });
+});

--- a/src/engine/__tests__/powerHandling.test.js
+++ b/src/engine/__tests__/powerHandling.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { setPowerStatus } from '../powerHandling.js';
+
+describe('setPowerStatus', () => {
+  it('marks building offline on power shortage', () => {
+    const buildings = {};
+    setPowerStatus(buildings, 'radio', 1, true);
+    expect(buildings.radio.offlineReason).toBe('power');
+  });
+
+  it('clears offline flag when power is restored', () => {
+    const buildings = { radio: { count: 1, offlineReason: 'power' } };
+    setPowerStatus(buildings, 'radio', 1, false);
+    expect(buildings.radio.offlineReason).toBeUndefined();
+  });
+});

--- a/src/engine/__tests__/radio.test.js
+++ b/src/engine/__tests__/radio.test.js
@@ -7,7 +7,7 @@ vi.mock('../candidates.js', () => ({
 }));
 
 import { updateRadio } from '../radio.js';
-import { applyProduction, applyOfflineProgress } from '../production.js';
+import { applyProduction } from '../production.js';
 import { getResourceRates } from '../../state/selectors.js';
 import { generateCandidate } from '../candidates.js';
 
@@ -52,22 +52,6 @@ describe('radio building production', () => {
     };
     const rates = getResourceRates(state);
     expect(rates.power.perSec).toBeCloseTo(-0.1, 5);
-  });
-});
-
-describe('applyOfflineProgress', () => {
-  it('uses post-production state to update radio', () => {
-    generateCandidate.mockClear();
-    const state = {
-      buildings: { radio: { count: 1 }, woodGenerator: { count: 1 } },
-      resources: { power: { amount: 0 }, wood: { amount: 100 } },
-      population: { candidate: null },
-      colony: { radioTimer: 3 },
-    };
-    const { state: next } = applyOfflineProgress(state, 5);
-    expect(generateCandidate).toHaveBeenCalledOnce();
-    expect(next.population.candidate).toEqual(fakeCandidate);
-    expect(next.colony.radioTimer).toBe(0);
   });
 });
 

--- a/src/engine/__tests__/resources.test.js
+++ b/src/engine/__tests__/resources.test.js
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { clampResource } from '../resources.js';
+
+describe('clampResource', () => {
+  it('clamps values to [0, capacity]', () => {
+    expect(clampResource(5, 3)).toBe(3);
+    expect(clampResource(-2, 5)).toBe(0);
+  });
+
+  it('handles non-finite numbers', () => {
+    expect(clampResource(NaN, 2)).toBe(0);
+  });
+});

--- a/src/engine/offline.js
+++ b/src/engine/offline.js
@@ -1,0 +1,52 @@
+import { RESOURCES } from '../data/resources.js';
+import { getResourceRates } from '../state/selectors.js';
+import { updateRadio } from './radio.js';
+import { deepClone } from '../utils/clone.ts';
+import { processSettlersTick } from './settlers.js';
+import { applyProduction } from './production.js';
+
+export function applyOfflineProgress(state, elapsedSeconds, roleBonuses = {}) {
+  if (elapsedSeconds <= 0) return { state, gains: {}, events: [] };
+  const before = deepClone(state.resources);
+  const productionBonuses = { ...roleBonuses };
+  delete productionBonuses.farmer;
+  let current = applyProduction({ ...state }, elapsedSeconds, productionBonuses);
+  const rates = getResourceRates(current);
+  let totalFoodProdBase = 0;
+  Object.keys(RESOURCES).forEach((id) => {
+    if (RESOURCES[id].category === 'FOOD') {
+      totalFoodProdBase += rates[id]?.perSec || 0;
+    }
+  });
+  const bonusFoodPerSec =
+    totalFoodProdBase * ((roleBonuses['farmer'] || 0) / 100);
+  const { state: afterSettlers, events } = processSettlersTick(
+    current,
+    elapsedSeconds,
+    bonusFoodPerSec,
+    Math.random,
+    roleBonuses,
+  );
+  current = afterSettlers;
+  Object.keys(current.resources).forEach((res) => {
+    if (current.resources[res].amount > 0)
+      current.resources[res].discovered = true;
+  });
+  const { candidate, radioTimer } = updateRadio(current, elapsedSeconds);
+  current = {
+    ...current,
+    population: { ...current.population, candidate },
+    colony: { ...current.colony, radioTimer },
+  };
+  const gains = {};
+  Object.keys(before).forEach((res) => {
+    const gain =
+      (current.resources[res]?.amount || 0) - (before[res]?.amount || 0);
+    if (gain > 0) gains[res] = gain;
+  });
+  return {
+    state: current,
+    gains,
+    events,
+  };
+}

--- a/src/engine/powerHandling.js
+++ b/src/engine/powerHandling.js
@@ -1,0 +1,10 @@
+export function setPowerStatus(buildings, id, count, shortage) {
+  const entry = buildings[id] || { count };
+  if (shortage) {
+    buildings[id] = { ...entry, offlineReason: 'power' };
+  } else if (entry.offlineReason) {
+    const copy = { ...entry };
+    delete copy.offlineReason;
+    buildings[id] = copy;
+  }
+}

--- a/src/engine/research.js
+++ b/src/engine/research.js
@@ -1,5 +1,5 @@
 import { RESEARCH_MAP } from '../data/research.js';
-import { clampResource } from './production.js';
+import { clampResource } from './resources.js';
 import { getCapacity } from '../state/selectors.js';
 
 export function startResearch(state, id) {

--- a/src/engine/resources.js
+++ b/src/engine/resources.js
@@ -1,0 +1,6 @@
+export function clampResource(value, capacity) {
+  let v = Number.isFinite(value) ? value : 0;
+  const c = Number.isFinite(capacity) ? Math.max(0, capacity) : 0;
+  const result = Math.max(0, Math.min(c, v));
+  return Math.round(result * 1e6) / 1e6;
+}

--- a/src/engine/settlers.js
+++ b/src/engine/settlers.js
@@ -6,7 +6,7 @@ import {
   XP_MULTIPLIER_FROM_HAPPINESS,
 } from '../data/balance.js';
 import { getCapacity, getSettlerCapacity } from '../state/selectors.js';
-import { clampResource } from './production.js';
+import { clampResource } from './resources.js';
 import { SECONDS_PER_DAY } from './time.js';
 import { RESOURCES } from '../data/resources.js';
 import { createLogEntry } from '../utils/log.js';

--- a/src/state/hooks/useBuilding.tsx
+++ b/src/state/hooks/useBuilding.tsx
@@ -7,7 +7,8 @@ import {
   canAffordBuilding,
   getCapacity,
 } from '../selectors.js';
-import { clampResource, demolishBuilding } from '../../engine/production.js';
+import { clampResource } from '../../engine/resources.js';
+import { demolishBuilding } from '../../engine/production.js';
 import { RESEARCH_MAP } from '../../data/research.js';
 
 export default function useBuilding(building: any, completedResearch: string[] = []) {

--- a/src/state/prepareLoadedState.ts
+++ b/src/state/prepareLoadedState.ts
@@ -1,7 +1,7 @@
 import { defaultState } from './defaultState.js';
 import { getYear, initSeasons, SECONDS_PER_DAY } from '../engine/time.js';
 import { computeRoleBonuses } from '../engine/settlers.js';
-import { applyOfflineProgress } from '../engine/production.js';
+import { applyOfflineProgress } from '../engine/offline.js';
 import { createLogEntry } from '../utils/log.js';
 import { RESOURCES } from '../data/resources.js';
 import { formatAmount } from '../utils/format.js';


### PR DESCRIPTION
## Summary
- Move resource clamping to `resources` module
- Extract power status handling into `powerHandling` module
- Separate offline progress logic into `offline` module with dedicated tests
- Add unit tests for new utilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c888868288331b760841bb29b2331