### PR TITLE
Handle near-capacity resource output and highlight storage limits

### DIFF
--- a/src/components/ResourceRow.jsx
+++ b/src/components/ResourceRow.jsx
@@ -7,6 +7,7 @@ export default function ResourceRow({
   name,
   amount,
   capacity,
+  capped,
   rate,
   tooltip,
 }) {
@@ -17,7 +18,7 @@ export default function ResourceRow({
         <span>{name}</span>
       </span>
       <span className="flex flex-col items-end">
-        <span>
+        <span className={capped ? 'text-orange-500' : undefined}>
           {formatAmount(amount)}
           {capacity != null && ` / ${formatAmount(capacity)}`}
         </span>

--- a/src/components/useResourceSections.test.js
+++ b/src/components/useResourceSections.test.js
@@ -20,4 +20,23 @@ describe('useResourceSections', () => {
     const totalRow = foodSection.items.find((i) => i.id === 'food-total');
     expect(totalRow.capacity).toBe(200 + 100); // changed: 450+150 -> 200+100
   });
+
+  test('marks resources at capacity', () => {
+    const state = {
+      resources: {
+        wood: { amount: 80, discovered: true },
+      },
+      buildings: {},
+      research: { completed: [] },
+      population: { settlers: [] },
+    };
+    const { result } = renderHook((props) => useResourceSections(props), {
+      initialProps: state,
+    });
+    const rawSection = result.current.sections.find(
+      (s) => s.title === 'Raw Materials',
+    );
+    const woodRow = rawSection.items.find((i) => i.id === 'wood');
+    expect(woodRow.capped).toBe(true);
+  });
 });

--- a/src/engine/__tests__/economy.test.js
+++ b/src/engine/__tests__/economy.test.js
@@ -46,6 +46,18 @@ describe('economy basics', () => {
     expect(next.resources.planks.amount).toBeCloseTo(0, 5);
   });
 
+  test('sawmill respects plank capacity and partial runs', () => {
+    const state = deepClone(defaultState);
+    state.resources.wood.amount = 10;
+    state.resources.planks.amount = 139.75;
+    state.buildings.loggingCamp.count = 0;
+    state.buildings.sawmill = { count: 1 };
+    state.buildings.materialsDepot = { count: 1 };
+    const next = processTick(state, 1);
+    expect(next.resources.planks.amount).toBeCloseTo(140, 5);
+    expect(next.resources.wood.amount).toBeCloseTo(9.6, 5);
+  });
+
   test('removing last required building unassigns settlers', () => {
     const state = deepClone(defaultState);
     state.buildings.potatoField.count = 1;

--- a/src/engine/production.js
+++ b/src/engine/production.js
@@ -22,6 +22,25 @@ export function clampResource(value, capacity) {
   return Math.round(result * 1e6) / 1e6;
 }
 
+function getOutputCapacityFactor(state, resources, outputs = {}, count, seconds) {
+  let f = 1;
+  Object.entries(outputs).forEach(([res, base]) => {
+    const capacity = getCapacity(state, res);
+    if (!Number.isFinite(capacity)) return;
+    const current = resources[res]?.amount || 0;
+    const room = capacity - current;
+    if (room <= 0) {
+      f = 0;
+      return;
+    }
+    const maxGain = base * count * seconds;
+    if (maxGain > 0) {
+      f = Math.min(f, room / maxGain);
+    }
+  });
+  return Math.max(0, Math.min(1, f));
+}
+
 export function applyProduction(state, seconds = 1, roleBonuses = {}) {
   const season = getSeason(state);
   const resources = { ...state.resources };
@@ -33,10 +52,18 @@ export function applyProduction(state, seconds = 1, roleBonuses = {}) {
     let powerShortage = false;
     if (b.inputsPerSecBase) {
       if (b.type === 'processing') {
+        const capFactor = getOutputCapacityFactor(
+          state,
+          resources,
+          b.outputsPerSecBase,
+          count,
+          seconds,
+        );
+        if (capFactor <= 0) return;
         let missingPower = false;
         const canRun = Object.entries(b.inputsPerSecBase).every(
           ([res, base]) => {
-            const need = base * count * seconds;
+            const need = base * count * seconds * capFactor;
             const have = resources[res]?.amount || 0;
             const enough = have >= need;
             if (res === 'power' && !enough) missingPower = true;
@@ -60,7 +87,7 @@ export function applyProduction(state, seconds = 1, roleBonuses = {}) {
           buildings[b.id] = copy;
         }
         Object.entries(b.inputsPerSecBase).forEach(([res, base]) => {
-          const amt = base * count * seconds;
+          const amt = base * count * seconds * capFactor;
           const capacity = getCapacity(state, res);
           const entryRes = resources[res] || { amount: 0, discovered: false };
           const next = clampResource(entryRes.amount - amt, capacity);
@@ -70,7 +97,7 @@ export function applyProduction(state, seconds = 1, roleBonuses = {}) {
             discovered: entryRes.discovered || next > 0,
           };
         });
-        factor = 1;
+        factor = capFactor;
       } else {
         Object.entries(b.inputsPerSecBase).forEach(([res, base]) => {
           const need = base * count * seconds;
@@ -84,6 +111,14 @@ export function applyProduction(state, seconds = 1, roleBonuses = {}) {
         } else {
           factor = Math.min(1, factor);
         }
+        const capFactor = getOutputCapacityFactor(
+          state,
+          resources,
+          b.outputsPerSecBase,
+          count,
+          seconds,
+        );
+        factor = Math.min(factor, capFactor);
         Object.entries(b.inputsPerSecBase).forEach(([res, base]) => {
           const amt = base * count * seconds * factor;
           const capacity = getCapacity(state, res);
@@ -104,6 +139,15 @@ export function applyProduction(state, seconds = 1, roleBonuses = {}) {
           buildings[b.id] = copy;
         }
       }
+    } else {
+      factor = getOutputCapacityFactor(
+        state,
+        resources,
+        b.outputsPerSecBase,
+        count,
+        seconds,
+      );
+      if (factor <= 0) return;
     }
     if (b.outputsPerSecBase) {
       Object.entries(b.outputsPerSecBase).forEach(([res, base]) => {

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -265,12 +265,14 @@ function buildResourceGroups(state, netRates, prodRates) {
     const discovered = state.resources[r.id]?.discovered;
     if (rateInfo.perSec !== 0 || amount > 0 || discovered) {
       if (!groups[r.category]) groups[r.category] = [];
+      const capped = capacity != null && amount >= capacity;
       groups[r.category].push({
         id: r.id,
         name: r.name,
         icon: r.icon,
         amount,
         capacity,
+        capped,
         rate: rateInfo.label,
         tooltip:
           r.id === 'power'


### PR DESCRIPTION
## Summary
- Prevent overproduction by scaling inputs/outputs when storage is almost full
- Mark resources that reach capacity in orange in the sidebar
- Cover partial capacity fills with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c89676b548331bb6716ba1410bafe