### PR TITLE
Remove season tooltip from top bar

### DIFF
--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,33 +1,19 @@
 import type { JSX } from 'react';
-import { getSeasonModifiers, getTimeBreakdown } from '../engine/time.js';
+import { getTimeBreakdown } from '../engine/time.js';
 import { useGame } from '../state/useGame.tsx';
 import { Button } from './Button';
-import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip';
 
 export default function TopBar(): JSX.Element {
   const { state, toggleDrawer } = useGame();
   const time = getTimeBreakdown(state);
-  const modifiers: Record<string, number> = getSeasonModifiers(state);
-  const labels: Record<string, string> = { FOOD: 'Food', RAW: 'Raw' };
 
   return (
     <header className="sticky top-0 z-10 flex items-center justify-between px-4 py-2 border-b border-border bg-card">
       <span className="tabular-nums text-xl">Year {time.year}</span>
       <div className="flex items-center gap-2">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button variant="ghost" className="text-xl tabular-nums px-0">
-              {time.season.icon} {time.season.label}, Day {time.day}
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            {Object.entries(modifiers).map(([key, val]) => (
-              <div key={key} className="whitespace-nowrap">
-                {labels[key] || key} x{val.toFixed(2)}
-              </div>
-            ))}
-          </TooltipContent>
-        </Tooltip>
+        <span className="text-xl tabular-nums">
+          {time.season.icon} {time.season.label}, Day {time.day}
+        </span>
         <Button
           variant="outline"
           size="sm"


### PR DESCRIPTION
## Summary
- remove tooltip and hover from season/day indicator in top bar

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 31 files)*

------
https://chatgpt.com/codex/tasks/task_e_689c94c355708331947f96068ecf8bc7