### PR TITLE
Add default isDesiredOn flag to buildings and migrate saves

### DIFF
--- a/src/engine/persistence.js
+++ b/src/engine/persistence.js
@@ -4,7 +4,7 @@ import { deepClone } from '../utils/clone.ts';
 
 const STORAGE_KEY = 'apocalypse-idle-save';
 
-export const CURRENT_SAVE_VERSION = 6;
+export const CURRENT_SAVE_VERSION = 7;
 
 export const migrations = [
   {
@@ -119,6 +119,20 @@ export const migrations = [
       return save;
     },
   },
+  {
+    from: 6,
+    to: 7,
+    up(save) {
+      if (save.buildings && typeof save.buildings === 'object') {
+        Object.values(save.buildings).forEach((b) => {
+          if (b && typeof b === 'object' && !('isDesiredOn' in b)) {
+            b.isDesiredOn = true;
+          }
+        });
+      }
+      return save;
+    },
+  },
 ];
 
 export function applyMigrations(save) {
@@ -200,6 +214,15 @@ export function validateSave(obj) {
       if (!('colony' in obj) || typeof obj.colony !== 'object')
         throw new Error('Invalid save: missing colony');
     }
+    if (
+      obj.version >= 7 &&
+      !Object.values(obj.buildings).every(
+        (b) => b && typeof b === 'object' && typeof b.isDesiredOn === 'boolean',
+      )
+    )
+      throw new Error(
+        'Invalid save: building entries must include isDesiredOn flag',
+      );
   }
   return true;
 }

--- a/src/state/__tests__/GameContext.test.jsx
+++ b/src/state/__tests__/GameContext.test.jsx
@@ -11,7 +11,7 @@ vi.mock('../../engine/persistence.js', () => ({
   saveGame: vi.fn((s) => s),
   loadGame: vi.fn(),
   deleteSave: vi.fn(),
-  CURRENT_SAVE_VERSION: 6,
+  CURRENT_SAVE_VERSION: 7,
 }));
 
 vi.mock('../../engine/useGameLoop.tsx', () => ({

--- a/src/state/__tests__/prepareLoadedState.test.js
+++ b/src/state/__tests__/prepareLoadedState.test.js
@@ -13,4 +13,10 @@ describe('prepareLoadedState', () => {
     expect(state.log.length).toBeGreaterThan(0);
     expect(state.log[0].text).toMatch(/while offline/);
   });
+
+  it('defaults missing building flags to true', () => {
+    const loaded = { buildings: { loggingCamp: { count: 3 } } };
+    const state = prepareLoadedState(loaded);
+    expect(state.buildings.loggingCamp.isDesiredOn).toBe(true);
+  });
 });

--- a/src/state/defaultState.js
+++ b/src/state/defaultState.js
@@ -16,9 +16,9 @@ const initResources = () => {
 };
 
 const initBuildings = () => ({
-  potatoField: { count: 2 },
-  loggingCamp: { count: 1 },
-  shelter: { count: 1 },
+  potatoField: { count: 2, isDesiredOn: true },
+  loggingCamp: { count: 1, isDesiredOn: true },
+  shelter: { count: 1, isDesiredOn: true },
 });
 
 const initPowerTypeOrder = () => buildInitialPowerTypeOrder([]);

--- a/src/state/hooks/__tests__/usePersistenceActions.test.ts
+++ b/src/state/hooks/__tests__/usePersistenceActions.test.ts
@@ -5,7 +5,7 @@ vi.mock('../../../engine/persistence.js', () => ({
   loadGame: vi.fn(),
   deleteSave: vi.fn(),
   saveGame: vi.fn(),
-  CURRENT_SAVE_VERSION: 1,
+  CURRENT_SAVE_VERSION: 7,
 }));
 vi.mock('../../prepareLoadedState.ts', () => ({
   prepareLoadedState: vi.fn((s: any) => ({ ...s, prepared: true })),

--- a/src/state/prepareLoadedState.ts
+++ b/src/state/prepareLoadedState.ts
@@ -22,6 +22,9 @@ export function prepareLoadedState(loaded: any) {
   base.ui = { ...base.ui, ...cloned.ui };
   base.resources = { ...base.resources, ...cloned.resources };
   base.buildings = { ...base.buildings, ...cloned.buildings };
+  Object.values(base.buildings).forEach((b: any) => {
+    if (typeof b.isDesiredOn !== 'boolean') b.isDesiredOn = true;
+  });
   base.powerTypeOrder = buildInitialPowerTypeOrder(cloned.powerTypeOrder || []);
   base.research = { ...base.research, ...cloned.research };
   base.population = { ...base.population, ...cloned.population };


### PR DESCRIPTION
## Summary
- Default new and starting buildings to `isDesiredOn: true`
- Ensure loaded saves add `isDesiredOn` flag to each building and bump save version
- Validate presence of `isDesiredOn` for v7 saves

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cb4ab26bc83318e83778f0344bdf8