### PR TITLE
feat: add building toggle and shortage badges

### DIFF
--- a/src/components/BuildingRow.jsx
+++ b/src/components/BuildingRow.jsx
@@ -5,6 +5,7 @@ import { RESEARCH_MAP } from '../data/research.js';
 import { Button } from './Button';
 import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip';
 import { Container } from './ui/container';
+import { Switch } from './ui/switch';
 
 export default function BuildingRow({
   building,
@@ -16,10 +17,13 @@ export default function BuildingRow({
   canAfford = false,
   unlocked = false,
   offlineReason,
+  isDesiredOn = true,
+  resourceShortage = false,
   buildTooltip,
   showPowerWarning = false,
   onBuild,
   onDemolish,
+  onToggle,
 }) {
   const formatPerSec = (perSec, res) => {
     const sign = perSec >= 0 ? '+' : '-';
@@ -47,13 +51,24 @@ export default function BuildingRow({
               ? `${count}/${building.maxCount}`
               : `(${count})`}
           </span>
-          {offlineReason && (
+          {!isDesiredOn && (
+            <span className="px-1 text-xs text-white bg-gray-600 rounded">
+              Off
+            </span>
+          )}
+          {isDesiredOn && offlineReason === 'power' && (
             <span className="px-1 text-xs text-white bg-red-600 rounded">
-              {offlineReason === 'power' ? 'No Power' : 'Offline'}
+              No Power
+            </span>
+          )}
+          {isDesiredOn && (resourceShortage || offlineReason === 'resources') && (
+            <span className="px-1 text-xs text-white bg-red-600 rounded">
+              No Resources
             </span>
           )}
         </div>
-        <div className="space-x-2">
+        <div className="space-x-2 flex items-center">
+          <Switch checked={isDesiredOn} onCheckedChange={onToggle} />
           <Button
             variant="outline"
             size="sm"

--- a/src/components/BuildingRowContainer.jsx
+++ b/src/components/BuildingRowContainer.jsx
@@ -3,6 +3,17 @@ import useBuilding from '../state/hooks/useBuilding.tsx';
 import BuildingRow from './BuildingRow.jsx';
 
 export default function BuildingRowContainer({ building, completedResearch }) {
-  const props = useBuilding(building, completedResearch);
-  return <BuildingRow building={building} {...props} />;
+  const { isDesiredOn, resourceShortage, onToggle, ...rest } = useBuilding(
+    building,
+    completedResearch,
+  );
+  return (
+    <BuildingRow
+      building={building}
+      isDesiredOn={isDesiredOn}
+      resourceShortage={resourceShortage}
+      onToggle={onToggle}
+      {...rest}
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- allow useBuilding hook to toggle and track desired power state
- show building on/off switch with status badges for shortages
- pass desired state props through BuildingRowContainer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb6e1d4688331bd8f7ff0f36af7c9