### PR TITLE
Skip production & power alerts for disabled buildings

### DIFF
--- a/src/state/__tests__/selectors.test.js
+++ b/src/state/__tests__/selectors.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { getResourceRates } from '../selectors.js';
+
+describe('getResourceRates', () => {
+  it('ignores buildings that are turned off', () => {
+    const state = {
+      resources: { wood: { amount: 0 } },
+      buildings: { loggingCamp: { count: 1, isDesiredOn: false } },
+      population: { settlers: [] },
+      research: { completed: [] },
+    };
+    const rates = getResourceRates(state);
+    expect(rates.wood.perSec).toBe(0);
+  });
+});

--- a/src/state/hooks/__tests__/useNotifications.test.tsx
+++ b/src/state/hooks/__tests__/useNotifications.test.tsx
@@ -145,4 +145,22 @@ describe('useNotifications', () => {
     rerender(<Wrapper state={offline} />);
     expect(toast).toHaveBeenCalledTimes(1);
   });
+
+  it('does not toast power loss when building is off', () => {
+    const initial = {
+      research: { current: null, completed: [] },
+      resources: {},
+      population: { candidate: null, settlers: [] },
+      buildings: { radio: { isDesiredOn: false } },
+    };
+    const offline = {
+      research: { current: null, completed: [] },
+      resources: {},
+      population: { candidate: null, settlers: [] },
+      buildings: { radio: { isDesiredOn: false, offlineReason: 'power' } },
+    };
+    const { rerender } = render(<Wrapper state={initial} />);
+    rerender(<Wrapper state={offline} />);
+    expect(toast).not.toHaveBeenCalled();
+  });
 });

--- a/src/state/hooks/useNotifications.tsx
+++ b/src/state/hooks/useNotifications.tsx
@@ -46,6 +46,7 @@ export default function useNotifications(state: GameState): void {
       if (
         currReason === 'power' &&
         prevReason !== 'power' &&
+        b?.isDesiredOn !== false &&
         !powerNotified.current.has(id)
       ) {
         const name = BUILDING_MAP[id]?.name || id;

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -95,8 +95,10 @@ function aggregateBuildingRates(state, roleBonuses) {
   const season = getSeason(state);
   const rates = {};
   PRODUCTION_BUILDINGS.forEach((b) => {
-    const count = state.buildings?.[b.id]?.count || 0;
-    if (count <= 0) return;
+    const entry = state.buildings?.[b.id];
+    const count = entry?.count || 0;
+    const on = entry?.isDesiredOn !== false;
+    if (count <= 0 || !on) return;
     let factor = 1;
     if (b.inputsPerSecBase) {
       if (b.type === 'processing') {


### PR DESCRIPTION
## Summary
- ignore buildings switched off when aggregating resource rates
- suppress power loss notifications for buildings that are intentionally off
- cover new behavior with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cbd2c69b083319ee8bcf7624f5c76