### PR TITLE
feat: log and toast key events

### DIFF
--- a/src/state/GameContext.jsx
+++ b/src/state/GameContext.jsx
@@ -25,7 +25,7 @@ export function GameProvider({ children }) {
 
   useGameTick(setState);
   useAutosave(state, setState);
-  useNotifications(state);
+  useNotifications(state, setState);
 
   const ui = useUiActions(setState);
   const population = usePopulationActions(setState);


### PR DESCRIPTION
## Summary
- announce major game events via toasts and changelog entries
- cover skill level ups, resource/power shortages, research completion and more
- test notifications for new cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d0b789dc08331b13c5379d73aaea3