### PR TITLE
Clamp resource rates to available capacity

### DIFF
--- a/src/state/__tests__/resourceRates.test.js
+++ b/src/state/__tests__/resourceRates.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'vitest';
+import { getResourceRates } from '../selectors.js';
+import { defaultState } from '../defaultState.js';
+import { deepClone } from '../../utils/clone.ts';
+
+describe('getResourceRates', () => {
+  test('respects capacity when nearly full', () => {
+    const state = deepClone(defaultState);
+    state.resources.wood.amount = 79.8;
+    state.resources.wood.discovered = true;
+    state.buildings = { loggingCamp: { count: 1 } };
+    state.population = { settlers: [] };
+    const rates = getResourceRates(state);
+    expect(rates.wood.perSec).toBeCloseTo(0.2, 5);
+  });
+});


### PR DESCRIPTION
## Summary
- prevent resource generation from stalling below max storage by capping building output to remaining room
- track provisional resource amounts when aggregating rates
- test that resource rate respects capacity limits

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 30 files)*

------
https://chatgpt.com/codex/tasks/task_e_689d0c4ea88c83319b286327ee6400d1