### PR TITLE
feat: overhaul settler roles

### DIFF
--- a/src/components/SettlerList.jsx
+++ b/src/components/SettlerList.jsx
@@ -30,7 +30,7 @@ export default function SettlerList({
     settlers.map((s) => {
       const { years, days } = formatAge(s.ageDays);
       const skillEntries = Object.entries(s.skills || {})
-        .filter(([, sk]) => sk.level > 0)
+        .filter(([, sk]) => sk.level > 0 || (sk.xp || 0) > 0)
         .sort((a, b) => b[1].level - a[1].level);
       return (
         <Card key={s.id}>

--- a/src/data/roles.js
+++ b/src/data/roles.js
@@ -3,57 +3,80 @@ export const ROLES = {
     id: 'farmer',
     name: 'Farmer',
     skill: 'Farming',
-    resource: 'potatoes',
-    building: 'potatoField',
+    resources: ['potatoes'],
+    buildings: ['potatoField'],
   },
   hunter: {
     id: 'hunter',
     name: 'Hunter',
     skill: 'Hunting',
-    resource: 'meat',
-    building: 'huntersHut',
+    resources: ['meat'],
+    buildings: ['huntersHut'],
   },
-  woodcutter: {
-    id: 'woodcutter',
-    name: 'Woodcutter',
-    skill: 'Woodcutting',
-    resource: 'wood',
-    building: 'loggingCamp',
+  gatherer: {
+    id: 'gatherer',
+    name: 'Gatherer',
+    skill: 'Gathering',
+    resources: ['wood', 'scrap', 'stone'],
+    buildings: ['loggingCamp', 'scrapyard', 'quarry'],
   },
-  scavenger: {
-    id: 'scavenger',
-    name: 'Scavenger',
-    skill: 'Scavenging',
-    resource: 'scrap',
-    building: 'scrapyard',
+  carpenter: {
+    id: 'carpenter',
+    name: 'Carpenter',
+    skill: 'Carpentry',
+    resources: ['planks'],
+    buildings: ['sawmill'],
   },
-  quarryWorker: {
-    id: 'quarryWorker',
-    name: 'Quarry Worker',
-    skill: 'Quarrying',
-    resource: 'stone',
-    building: 'quarry',
+  metalworker: {
+    id: 'metalworker',
+    name: 'Metalworker',
+    skill: 'Metalworking',
+    resources: ['metalParts'],
+    buildings: ['metalWorkshop'],
+  },
+  toolsmith: {
+    id: 'toolsmith',
+    name: 'Toolsmith',
+    skill: 'Toolsmithing',
+    resources: ['tools'],
+    buildings: ['toolsmithy'],
+  },
+  engineer: {
+    id: 'engineer',
+    name: 'Engineer',
+    skill: 'Engineering',
+    resources: ['power'],
+    buildings: ['woodGenerator'],
   },
   scientist: {
     id: 'scientist',
     name: 'Scientist',
     skill: 'Scientist',
-    resource: 'science',
-    building: 'school',
+    resources: ['science'],
+    buildings: ['school'],
   },
 };
 
 export const ROLE_LIST = Object.values(ROLES);
-export const ROLE_BY_RESOURCE = Object.fromEntries(
-  ROLE_LIST.map((r) => [r.resource, r.id]),
-);
+
+export const ROLE_BY_RESOURCE = ROLE_LIST.reduce((acc, r) => {
+  r.resources.forEach((res) => {
+    acc[res] = r.id;
+  });
+  return acc;
+}, {});
+
 export const SKILL_LABELS = Object.fromEntries(
   ROLE_LIST.map((r) => [r.id, r.skill]),
 );
 
 export const ROLE_BUILDINGS = Object.fromEntries(
-  ROLE_LIST.map((r) => [r.id, r.building]),
+  ROLE_LIST.map((r) => [r.id, r.buildings]),
 );
-export const BUILDING_ROLES = Object.fromEntries(
-  ROLE_LIST.map((r) => [r.building, r.id]),
-);
+
+export const BUILDING_ROLES = ROLE_LIST.reduce((acc, r) => {
+  r.buildings.forEach((b) => {
+    acc[b] = r.id;
+  });
+  return acc;
+}, {});

--- a/src/engine/production.js
+++ b/src/engine/production.js
@@ -4,14 +4,24 @@ import {
   getBuildingCost,
 } from '../data/buildings.js';
 import { RESOURCES } from '../data/resources.js';
-import { ROLE_BY_RESOURCE, BUILDING_ROLES } from '../data/roles.js';
+import {
+  ROLE_BY_RESOURCE,
+  BUILDING_ROLES,
+  ROLE_BUILDINGS,
+} from '../data/roles.js';
 import { getSeason, getSeasonMultiplier } from './time.js';
 import { getCapacity, getResearchOutputBonus } from '../state/selectors.js';
 import { clampResource } from './resources.js';
 import { setOfflineReason } from './powerHandling.js';
 import { getTypeOrderIndex } from './power.js';
 
-function getOutputCapacityFactor(state, resources, outputs = {}, count, seconds) {
+function getOutputCapacityFactor(
+  state,
+  resources,
+  outputs = {},
+  count,
+  seconds,
+) {
   let f = 1;
   Object.entries(outputs).forEach(([res, base]) => {
     const capacity = getCapacity(state, res);
@@ -165,9 +175,11 @@ export function demolishBuilding(state, buildingId) {
     if (entry.amount > 0) entry.discovered = true;
   });
   let settlers = state.population?.settlers || [];
-  if ((buildings[buildingId]?.count || 0) <= 0) {
-    const role = BUILDING_ROLES[buildingId];
-    if (role) {
+  const role = BUILDING_ROLES[buildingId];
+  if (role) {
+    const relevant = ROLE_BUILDINGS[role].filter((b) => b !== buildingId);
+    const hasOther = relevant.some((b) => (buildings[b]?.count || 0) > 0);
+    if ((buildings[buildingId]?.count || 0) <= 0 && !hasOther) {
       settlers = settlers.map((s) =>
         s.role === role ? { ...s, role: null } : s,
       );

--- a/src/state/hooks/__tests__/useNotifications.test.tsx
+++ b/src/state/hooks/__tests__/useNotifications.test.tsx
@@ -202,7 +202,7 @@ describe('useNotifications', () => {
             firstName: 'Ann',
             lastName: 'Lee',
             isDead: false,
-            skills: { scavenger: { level: 3 } },
+            skills: { gatherer: { level: 3 } },
           },
         ],
       },
@@ -219,7 +219,7 @@ describe('useNotifications', () => {
             firstName: 'Ann',
             lastName: 'Lee',
             isDead: false,
-            skills: { scavenger: { level: 4 } },
+            skills: { gatherer: { level: 4 } },
           },
         ],
       },
@@ -228,7 +228,7 @@ describe('useNotifications', () => {
     const { rerender } = render(<Wrapper state={before} />);
     rerender(<Wrapper state={after} />);
     expect(toast).toHaveBeenCalledWith({
-      description: `Ann Lee reached ${SKILL_LABELS.scavenger} level 4`,
+      description: `Ann Lee reached ${SKILL_LABELS.gatherer} level 4`,
     });
   });
 

--- a/src/state/hooks/usePopulationActions.tsx
+++ b/src/state/hooks/usePopulationActions.tsx
@@ -18,11 +18,13 @@ export default function usePopulationActions(
         if (!settler) return prev;
         const normalized = role === 'idle' ? null : role;
         if (normalized) {
-          const building = ROLE_BUILDINGS[
+          const buildings = ROLE_BUILDINGS[
             normalized as keyof typeof ROLE_BUILDINGS
-          ] as keyof GameState['buildings'];
-          const count = prev.buildings[building]?.count || 0;
-          if (count <= 0) return prev;
+          ] as Array<keyof GameState['buildings']>;
+          const hasBuilding = buildings.some(
+            (b) => (prev.buildings[b]?.count || 0) > 0,
+          );
+          if (!hasBuilding) return prev;
         }
         const settlers = prev.population.settlers.map((s) =>
           s.id === id ? { ...s, role: normalized } : s,

--- a/src/views/PopulationView.jsx
+++ b/src/views/PopulationView.jsx
@@ -2,17 +2,11 @@ import React, { useState } from 'react';
 import { useGame } from '../state/useGame.tsx';
 import { computeRoleBonuses } from '../engine/settlers.js';
 import { ROLE_LIST } from '../data/roles.js';
-import { RESOURCES } from '../data/resources.js';
 import { getSettlerCapacity } from '../state/selectors.js';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import SettlerFilters from '../components/SettlerFilters.jsx';
 import SettlerList from '../components/SettlerList.jsx';
 import BanishSettlerModal from '../components/BanishSettlerModal.jsx';
-
-const BONUS_LABELS = ROLE_LIST.reduce((acc, r) => {
-  acc[r.id] = RESOURCES[r.resource].name;
-  return acc;
-}, {});
 
 export default function PopulationView() {
   const { state, setSettlerRole, banishSettler } = useGame();
@@ -20,8 +14,8 @@ export default function PopulationView() {
   const [unassignedOnly, setUnassignedOnly] = useState(false);
   const [banishing, setBanishing] = useState(null);
   const settlers = state.population?.settlers ?? [];
-  const availableRoles = ROLE_LIST.filter(
-    (r) => (state.buildings?.[r.building]?.count || 0) > 0,
+  const availableRoles = ROLE_LIST.filter((r) =>
+    r.buildings.some((b) => (state.buildings?.[b]?.count || 0) > 0),
   );
   const filtered = settlers
     .filter((s) => !onlyLiving || !s.isDead)
@@ -43,15 +37,15 @@ export default function PopulationView() {
             {living}/{capacity}
           </CardContent>
         </Card>
-        {Object.entries(BONUS_LABELS).map(([role, label]) => (
-          <Card key={role} className="text-center">
+        {availableRoles.map((r) => (
+          <Card key={r.id} className="text-center">
             <CardHeader className="p-0">
               <CardTitle className="text-sm font-normal text-muted-foreground">
-                {label} bonus
+                {r.name} bonus
               </CardTitle>
             </CardHeader>
             <CardContent className="p-0 text-lg font-semibold">
-              +{Math.round(bonuses[role] || 0)}%
+              +{Math.round(bonuses[r.id] || 0)}%
             </CardContent>
           </Card>
         ))}


### PR DESCRIPTION
## Summary
- merge woodcutter, scavenger and quarry worker into a single Gatherer role
- add Toolsmith, Metalworker, Carpenter and Engineer roles and hook them into buildings/resources
- show skills from level 0 XP and hide role assignments until supporting buildings are built

## Testing
- `npm test`
- `npm run report:economy` *(fails: Unknown file extension ".ts" for /workspace/apocalypse-idle/src/utils/clone.ts)*
- `npm run lint` *(fails: Prettier found code style issues)*
- `npm run typecheck` *(fails: numerous TypeScript errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689d108fcac883318aa28ca5c7481449