### PR TITLE
Persist power allocation offline reason

### DIFF
--- a/src/engine/__tests__/powerHandling.test.js
+++ b/src/engine/__tests__/powerHandling.test.js
@@ -19,4 +19,10 @@ describe('setOfflineReason', () => {
     setOfflineReason(buildings, 'radio', 1, null);
     expect(buildings.radio.offlineReason).toBeUndefined();
   });
+
+  it('ignores unrecognised reasons', () => {
+    const buildings = { radio: { count: 1 } };
+    setOfflineReason(buildings, 'radio', 1, 'foo');
+    expect(buildings.radio.offlineReason).toBeUndefined();
+  });
 });

--- a/src/engine/powerHandling.js
+++ b/src/engine/powerHandling.js
@@ -1,6 +1,10 @@
 export function setOfflineReason(buildings, id, count, reason) {
   const entry = buildings[id] || { count };
-  if (reason) {
+
+  // Only persist recognised reasons. This currently includes "power" when a
+  // building can't get enough energy and "resources" when input materials are
+  // missing. Unknown values should clear any previous offline reason.
+  if (reason === 'power' || reason === 'resources') {
     buildings[id] = { ...entry, offlineReason: reason };
   } else if (entry.offlineReason) {
     const copy = { ...entry };


### PR DESCRIPTION
## Summary
- Ensure `setOfflineReason` persists recognized reasons, including `power`
- Ignore unrecognized offline reasons
- Test power handling reason persistence

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d184c6d6c8331be07063f2e56c084