### PR TITLE
Show power supply details in energy sidebar

### DIFF
--- a/src/components/ResourceRow.jsx
+++ b/src/components/ResourceRow.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { formatAmount } from '../utils/format.js';
+import { formatAmount, formatRate } from '../utils/format.js';
 import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip';
 
 export default function ResourceRow({
@@ -10,6 +10,9 @@ export default function ResourceRow({
   capped,
   rate,
   tooltip,
+  supply,
+  demand,
+  stored,
 }) {
   const content = (
     <li className="flex items-center justify-between text-sm tabular-nums">
@@ -18,13 +21,24 @@ export default function ResourceRow({
         <span>{name}</span>
       </span>
       <span className="flex flex-col items-end">
-        <span className={capped ? 'text-orange-500' : undefined}>
-          {formatAmount(amount)}
-          {capacity != null && ` / ${formatAmount(capacity)}`}
-        </span>
-        {rate != null && (
-          <span className="text-xs text-muted-foreground">{rate}</span>
+        {supply != null && demand != null ? (
+          <span>
+            {formatRate(supply)} / {formatRate(demand)}
+          </span>
+        ) : (
+          <span className={capped ? 'text-orange-500' : undefined}>
+            {formatAmount(amount)}
+            {capacity != null && ` / ${formatAmount(capacity)}`}
+          </span>
         )}
+        {supply != null && demand != null ? (
+          <span className="text-xs text-muted-foreground">
+            {formatAmount(stored ?? amount)}
+            {capacity != null && ` / ${formatAmount(capacity)}`}
+          </span>
+        ) : rate != null ? (
+          <span className="text-xs text-muted-foreground">{rate}</span>
+        ) : null}
       </span>
     </li>
   );

--- a/src/components/ResourceSidebar.jsx
+++ b/src/components/ResourceSidebar.jsx
@@ -68,8 +68,13 @@ export default function ResourceSidebar() {
           >
             <ul className="mt-2 space-y-3">
               {g.items.map((r) => (
-                <li key={r.id}>
+                <li key={r.id} className="flex flex-col">
                   <ResourceRow {...r} />
+                  {r.status && (
+                    <span className="text-xs text-right text-muted-foreground">
+                      {r.status}
+                    </span>
+                  )}
                 </li>
               ))}
             </ul>

--- a/src/components/useResourceSections.test.js
+++ b/src/components/useResourceSections.test.js
@@ -39,4 +39,26 @@ describe('useResourceSections', () => {
     const woodRow = rawSection.items.find((i) => i.id === 'wood');
     expect(woodRow.capped).toBe(true);
   });
+
+  test('includes power status info', () => {
+    const state = {
+      resources: { power: { amount: 5, discovered: true } },
+      powerStatus: { supply: 2, demand: 1, stored: 5, capacity: 10 },
+      buildings: {},
+      research: { completed: ['basicEnergy'] },
+      population: { settlers: [] },
+    };
+    const { result } = renderHook((props) => useResourceSections(props), {
+      initialProps: state,
+    });
+    const energySection = result.current.sections.find(
+      (s) => s.title === 'Energy',
+    );
+    const powerRow = energySection.items.find((i) => i.id === 'power');
+    expect(powerRow.supply).toBe(2);
+    expect(powerRow.demand).toBe(1);
+    expect(powerRow.stored).toBe(5);
+    expect(powerRow.capacity).toBe(10);
+    expect(powerRow.status).toBe('charging');
+  });
 });


### PR DESCRIPTION
## Summary
- show power supply, demand, stored, and capacity in energy section
- display charging state for energy

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 35 files. Run Prettier with --write to fix.)*
- `npx eslint .` *(fails: 92 problems (89 errors, 3 warnings))*
- `npm run typecheck` *(fails: TS errors in multiple files)*


------
https://chatgpt.com/codex/tasks/task_e_689d1db06d3083318094bdcf79833ab7