### PR TITLE
chore: update economy snapshot

### DIFF
--- a/docs/ECONOMY_REPORT.md
+++ b/docs/ECONOMY_REPORT.md
@@ -1,75 +1,80 @@
 # Economy Report
 
 ## 1) Overview
-Economy generated from commit **5e5a6b7d1786bbde7e8dafea4711f644f2d09a5b** on 2025-08-13 01:43:36 +0200. Save version: **6**.
+Economy generated from commit **35f35aa12e885b89cd28e6978415732365573f45** on 2025-08-14 01:19:44 +0200. Save version: **7**.
 Each tick represents 1 second. For each building: base production is modified by season multipliers, summed, then clamped to capacity. Offline progress processes in 60-second chunks.
 
 ## 2) Resources
 | key | displayName | category | startingAmount | startingCapacity | unit | source |
 | - | - | - | - | - | - | - |
-| potatoes | Potatoes | FOOD | 0 | 450 |  | resources.js:RESOURCES.potatoes |
-| meat | Meat | FOOD | 0 | 150 |  | resources.js:RESOURCES.meat |
-| wood | Wood | RAW | 0 | 150 |  | resources.js:RESOURCES.wood |
-| stone | Stone | RAW | 0 | 80 |  | resources.js:RESOURCES.stone |
-| scrap | Scrap | RAW | 0 | 80 |  | resources.js:RESOURCES.scrap |
-| planks | Planks | CONSTRUCTION_MATERIALS | 0 | 50 |  | resources.js:RESOURCES.planks |
-| metalParts | Metal Parts | CONSTRUCTION_MATERIALS | 0 | 20 |  | resources.js:RESOURCES.metalParts |
+| potatoes | Potatoes | FOOD | 0 | 200 |  | resources.js:RESOURCES.potatoes |
+| meat | Meat | FOOD | 0 | 100 |  | resources.js:RESOURCES.meat |
+| wood | Wood | RAW | 0 | 80 |  | resources.js:RESOURCES.wood |
+| stone | Stone | RAW | 0 | 50 |  | resources.js:RESOURCES.stone |
+| scrap | Scrap | RAW | 0 | 60 |  | resources.js:RESOURCES.scrap |
+| planks | Planks | CONSTRUCTION_MATERIALS | 0 | 40 |  | resources.js:RESOURCES.planks |
+| metalParts | Metal Parts | CONSTRUCTION_MATERIALS | 0 | 24 |  | resources.js:RESOURCES.metalParts |
+| tools | Tools | CONSTRUCTION_MATERIALS | 0 | 24 |  | resources.js:RESOURCES.tools |
 | science | Science | SOCIETY | 0 | 400 |  | resources.js:RESOURCES.science |
-| power | Power | ENERGY | 0 | 2 |  | resources.js:RESOURCES.power |
+| power | Power | ENERGY | 0 | 20 |  | resources.js:RESOURCES.power |
 
 ## 3) Seasons
-| season | duration (sec) | potatoes | meat | wood | stone | scrap | planks | metalParts | science | power | source |
-| - | - | - | - | - | - | - | - | - | - | - | - |
-| spring | 270 | 1.250 | 1.250 | 1.100 | 1.100 | 1.100 | 1.000 | 1.000 | 1.000 | 1.000 | time.js:SEASONS[0] |
-| summer | 270 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | time.js:SEASONS[1] |
-| autumn | 270 | 0.850 | 0.850 | 0.900 | 0.900 | 0.900 | 1.000 | 1.000 | 1.000 | 1.000 | time.js:SEASONS[2] |
-| winter | 270 | 0.000 | 0.000 | 0.800 | 0.800 | 0.800 | 1.000 | 1.000 | 1.000 | 1.000 | time.js:SEASONS[3] |
+| season | duration (sec) | potatoes | meat | wood | stone | scrap | planks | metalParts | tools | science | power | source |
+| - | - | - | - | - | - | - | - | - | - | - | - | - |
+| spring | 270 | 1.250 | 1.250 | 1.100 | 1.100 | 1.100 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | time.js:SEASONS[0] |
+| summer | 270 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | time.js:SEASONS[1] |
+| autumn | 270 | 0.850 | 0.850 | 0.900 | 0.900 | 0.900 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | time.js:SEASONS[2] |
+| winter | 270 | 0.000 | 0.000 | 0.800 | 0.800 | 0.800 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | time.js:SEASONS[3] |
 
 ## 4) Buildings
 | id | name | type | cost | costGrowth | refund | storage | base prod/s | inputs per sec | requiresResearch | season mults | source |
 | - | - | - | - | - | - | - | - | - | - | - | - |
-| potatoField | Potato Field | production | {"wood":17} | 1.13 | 0.5 | - | {"potatoes":0.375} | - | - | {"spring":1.25,"summer":1,"autumn":0.85,"winter":0} | buildings.js:BUILDINGS[0] |
-| huntersHut | Hunter's Hut | production | {"wood":25,"scrap":10,"stone":5} | 1.15 | 0.5 | - | {"meat":0.19} | - | hunting1 | {"spring":1.1,"summer":1,"autumn":0.9,"winter":0.6} | buildings.js:BUILDINGS[1] |
-| loggingCamp | Logging Camp | production | {"scrap":15} | 1.13 | 0.5 | - | {"wood":0.3} | - | - | {"spring":1.1,"summer":1,"autumn":0.9,"winter":0.8} | buildings.js:BUILDINGS[2] |
-| scrapyard | Scrap Yard | production | {"wood":12} | 1.13 | 0.5 | - | {"scrap":0.08} | - | - | {"spring":1.1,"summer":1,"autumn":0.9,"winter":0.8} | buildings.js:BUILDINGS[3] |
-| quarry | Quarry | production | {"wood":20,"scrap":5} | 1.13 | 0.5 | - | {"stone":0.104} | - | - | {"spring":1.1,"summer":1,"autumn":0.9,"winter":0.8} | buildings.js:BUILDINGS[4] |
-| sawmill | Sawmill | processing | {"wood":48,"scrap":18,"stone":12} | 1.13 | 0.5 | - | {"planks":0.5} | {"wood":0.8} | industry1 | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[5] |
+| potatoField | Potato Field | production | {"wood":17} | 1.12 | 0.5 | - | {"potatoes":0.375} | - | - | {"spring":1.25,"summer":1,"autumn":0.85,"winter":0} | buildings.js:BUILDINGS[0] |
+| huntersHut | Hunter's Hut | production | {"wood":25,"scrap":10,"stone":5} | 1.15 | 0.5 | - | {"meat":0.22} | - | huntingHut | {"spring":1.1,"summer":1,"autumn":0.9,"winter":0.6} | buildings.js:BUILDINGS[1] |
+| loggingCamp | Logging Camp | production | {"scrap":15} | 1.12 | 0.5 | - | {"wood":0.3} | - | - | {"spring":1.1,"summer":1,"autumn":0.9,"winter":0.8} | buildings.js:BUILDINGS[2] |
+| scrapyard | Scrap Yard | production | {"wood":12} | 1.12 | 0.5 | - | {"scrap":0.08} | - | - | {"spring":1.1,"summer":1,"autumn":0.9,"winter":0.8} | buildings.js:BUILDINGS[3] |
+| quarry | Quarry | production | {"wood":20,"scrap":5} | 1.12 | 0.5 | - | {"stone":0.12} | - | - | {"spring":1.1,"summer":1,"autumn":0.9,"winter":0.8} | buildings.js:BUILDINGS[4] |
+| sawmill | Sawmill | processing | {"wood":53,"scrap":20,"stone":13} | 1.13 | 0.5 | - | {"planks":0.5} | {"wood":0.8} | industry1 | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[5] |
 | metalWorkshop | Metal Workshop | processing | {"wood":30,"scrap":30,"stone":10,"planks":10} | 1.13 | 0.5 | - | {"metalParts":0.4} | {"scrap":0.4} | industry1 | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[6] |
-| school | School | production | {"wood":30,"scrap":12,"stone":12} | 1.13 | 0.5 | - | {"science":0.45} | - | - | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[7] |
-| woodGenerator | Wood Generator | production | {"wood":50,"stone":10} | 1.13 | 0.5 | - | {"power":1} | {"wood":0.25} | basicEnergy | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[8] |
-| shelter | Shelter | production | {"wood":30,"scrap":10} | 1.8 | 0.5 | - | - | - | - | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[9] |
-| radio | Radio | production | {"wood":80,"scrap":40,"stone":20,"planks":20} | 1 | 0.5 | - | - | {"power":0.1} | radio | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[10] |
-| foodStorage | Granary | storage | {"wood":20,"scrap":5,"stone":5} | 1.2 | 0.5 | {"potatoes":300,"meat":150} | - | - | - | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[11] |
-| rawStorage | Warehouse | storage | {"wood":25,"scrap":10,"stone":10} | 1.2 | 0.5 | {"wood":200,"stone":80,"scrap":90} | - | - | - | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[12] |
-| materialsDepot | Materials Depot | storage | {"wood":25,"scrap":10,"stone":5} | 1.2 | 0.5 | {"planks":300,"metalParts":240} | - | - | industry1 | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[13] |
-| battery | Battery | storage | {"wood":40,"stone":20} | 1.2 | 0.5 | {"power":600} | - | - | basicEnergy | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[14] |
+| toolsmithy | Toolsmithy | processing | {"wood":50,"scrap":30,"stone":20,"planks":25,"metalParts":15} | 1.13 | 0.5 | - | {"tools":0.18} | {"planks":0.25,"metalParts":0.15,"power":0.4} | industry2 | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[7] |
+| school | School | production | {"wood":30,"scrap":12,"stone":12} | 1.13 | 0.5 | - | {"science":0.45} | - | - | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[8] |
+| woodGenerator | Wood Generator | production | {"wood":50,"stone":10,"planks":20,"metalParts":10} | 1.13 | 0.5 | - | {"power":1} | {"wood":0.25} | basicEnergy | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[9] |
+| shelter | Shelter | production | {"wood":30,"scrap":10} | 1.8 | 0.5 | - | - | - | - | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[10] |
+| radio | Radio | production | {"wood":80,"scrap":40,"stone":20,"planks":20,"metalParts":10} | 1 | 0.5 | - | - | {"power":0.1} | radio | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[11] |
+| foodStorage | Granary | storage | {"wood":20,"scrap":5,"stone":5} | 1.22 | 0.5 | {"potatoes":150,"meat":75} | - | - | - | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[12] |
+| rawStorage | Warehouse | storage | {"wood":25,"scrap":10,"stone":10} | 1.22 | 0.5 | {"wood":120,"scrap":80,"stone":60} | - | - | - | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[13] |
+| materialsDepot | Materials Depot | storage | {"wood":25,"scrap":10,"stone":5} | 1.22 | 0.5 | {"planks":100,"metalParts":40} | - | - | industry1 | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[14] |
+| battery | Battery | storage | {"wood":40,"stone":20,"planks":20,"metalParts":10} | 1.22 | 0.5 | {"power":40} | - | - | basicEnergy | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[15] |
 
 ## 5) Research
 | id | name | science cost | time (sec) | prereqs | milestones | unlocks | effects | source |
 | - | - | - | - | - | - | - | - | - |
-| basicEnergy | Basic Energy | 80 | 120 | industry1 | - | {"resources":["power"],"buildings":["woodGenerator","battery"],"categories":["Energy"]} | - | research.js:RESEARCH[0] |
-| industry1 | Industry I | 60 | 90 | - | - | {"resources":["planks","metalParts"],"buildings":["sawmill","metalWorkshop","materialsDepot"],"categories":["CONSTRUCTION_MATERIALS"]} | - | research.js:RESEARCH[1] |
-| hunting1 | Hunting I | 50 | 90 | - | - | {"resources":["meat"],"buildings":["huntersHut"],"categories":[]} | - | research.js:RESEARCH[2] |
-| radio | Radio | 150 | 240 | industry1, basicEnergy | - | {"resources":[],"buildings":["radio"],"categories":[]} | - | research.js:RESEARCH[3] |
-| woodworking1 | Woodworking I | 60 | 90 | industry1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"WOOD","percent":0.05,"type":"output"}] | research.js:RESEARCH[4] |
-| salvaging1 | Salvaging I | 60 | 90 | industry1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"SCRAP","percent":0.05,"type":"output"}] | research.js:RESEARCH[5] |
-| logistics1 | Logistics I | 60 | 90 | industry1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"RAW","percent":0.05,"type":"storage"},{"category":"CONSTRUCTION_MATERIALS","percent":0.05,"type":"storage"}] | research.js:RESEARCH[6] |
-| industry2 | Industry II | 200 | 240 | industry1 | {"produced":{"planks":50,"metalParts":30}} | {"resources":[],"buildings":["toolsmithy"],"categories":[]} | - | research.js:RESEARCH[7] |
-| woodworking2 | Woodworking II | 140 | 240 | woodworking1, industry2 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"WOOD","percent":0.05,"type":"output"}] | research.js:RESEARCH[8] |
-| salvaging2 | Salvaging II | 140 | 240 | salvaging1, industry2 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"SCRAP","percent":0.05,"type":"output"}] | research.js:RESEARCH[9] |
-| logistics2 | Logistics II | 150 | 270 | logistics1, industry2 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"RAW","percent":0.05,"type":"storage"},{"category":"CONSTRUCTION_MATERIALS","percent":0.05,"type":"storage"}] | research.js:RESEARCH[10] |
-| hunting2 | Hunting II | 130 | 240 | hunting1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"FOOD","percent":0.1,"type":"output"}] | research.js:RESEARCH[11] |
-| industryProduction | Industry Production | 130 | 240 | industry1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"CONSTRUCTION_MATERIALS","percent":0.1,"type":"output"}] | research.js:RESEARCH[12] |
+| industry1 | Industry I | 60 | 120 | - | - | {"resources":["planks","metalParts"],"buildings":["sawmill","metalWorkshop","materialsDepot"],"categories":["CONSTRUCTION_MATERIALS"]} | - | research.js:RESEARCH[0] |
+| woodworking1 | Woodworking I | 60 | 90 | industry1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"WOOD","percent":0.05,"type":"output"}] | research.js:RESEARCH[1] |
+| salvaging1 | Salvaging I | 60 | 90 | industry1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"SCRAP","percent":0.05,"type":"output"}] | research.js:RESEARCH[2] |
+| logistics1 | Logistics I | 60 | 90 | industry1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"RAW","percent":0.05,"type":"storage"},{"category":"CONSTRUCTION_MATERIALS","percent":0.05,"type":"storage"}] | research.js:RESEARCH[3] |
+| industry2 | Industry II | 200 | 240 | woodworking1, salvaging1, logistics1 | {"produced":{"planks":50,"metalParts":30}} | {"resources":[],"buildings":["toolsmithy"],"categories":[]} | - | research.js:RESEARCH[4] |
+| industryProduction | Industry Production | 170 | 270 | woodworking1, salvaging1, logistics1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"CONSTRUCTION_MATERIALS","percent":0.05,"type":"output"}] | research.js:RESEARCH[5] |
+| woodworking2 | Woodworking II | 220 | 360 | industry2, industryProduction, woodworking1, salvaging1, logistics1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"WOOD","percent":0.05,"type":"output"}] | research.js:RESEARCH[6] |
+| salvaging2 | Salvaging II | 220 | 360 | industry2, industryProduction, woodworking1, salvaging1, logistics1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"SCRAP","percent":0.05,"type":"output"}] | research.js:RESEARCH[7] |
+| logistics2 | Logistics II | 230 | 360 | industry2, industryProduction, woodworking1, salvaging1, logistics1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"RAW","percent":0.05,"type":"storage"},{"category":"CONSTRUCTION_MATERIALS","percent":0.05,"type":"storage"}] | research.js:RESEARCH[8] |
+| basicEnergy | Basic Energy | 150 | 210 | industry2 | - | {"resources":["power"],"buildings":["woodGenerator","battery"],"categories":["Energy"]} | - | research.js:RESEARCH[9] |
+| radio | Radio | 150 | 240 | basicEnergy | - | {"resources":[],"buildings":["radio"],"categories":[]} | - | research.js:RESEARCH[10] |
+| food1 | Food I | 50 | 90 | - | - | {"resources":[],"buildings":[],"categories":[]} | - | research.js:RESEARCH[11] |
+| huntingHut | Hunting Hut | 60 | 90 | food1 | - | {"resources":["meat"],"buildings":["huntersHut"],"categories":[]} | - | research.js:RESEARCH[12] |
+| food2 | Food II | 150 | 240 | huntingHut | - | {"resources":[],"buildings":[],"categories":[]} | [{"resource":"meat","percent":0.04,"type":"output"}] | research.js:RESEARCH[13] |
 
 ## 6) Roles
 | id | name | skill | resource | building | source |
 | - | - | - | - | - | - |
-| farmer | Farmer | Farming | potatoes | potatoField | roles.js:ROLES.farmer |
-| hunter | Hunter | Hunting | meat | huntersHut | roles.js:ROLES.hunter |
-| woodcutter | Woodcutter | Woodcutting | wood | loggingCamp | roles.js:ROLES.woodcutter |
-| scavenger | Scavenger | Scavenging | scrap | scrapyard | roles.js:ROLES.scavenger |
-| quarryWorker | Quarry Worker | Quarrying | stone | quarry | roles.js:ROLES.quarryWorker |
-| scientist | Scientist | Scientist | science | school | roles.js:ROLES.scientist |
+| farmer | Farmer | Farming | undefined | undefined | roles.js:ROLES.farmer |
+| hunter | Hunter | Hunting | undefined | undefined | roles.js:ROLES.hunter |
+| gatherer | Gatherer | Gathering | undefined | undefined | roles.js:ROLES.gatherer |
+| carpenter | Carpenter | Carpentry | undefined | undefined | roles.js:ROLES.carpenter |
+| metalworker | Metalworker | Metalworking | undefined | undefined | roles.js:ROLES.metalworker |
+| toolsmith | Toolsmith | Toolsmithing | undefined | undefined | roles.js:ROLES.toolsmith |
+| engineer | Engineer | Engineering | undefined | undefined | roles.js:ROLES.engineer |
+| scientist | Scientist | Scientist | undefined | undefined | roles.js:ROLES.scientist |
 
 ## 7) Starting State
 Starting season: spring, Year: 1.
@@ -77,15 +82,16 @@ Starting season: spring, Year: 1.
 ### Resources
 | resource | amount | capacity | source |
 | - | - | - | - |
-| potatoes | 0 | 450 | resources.js:RESOURCES.potatoes.startingAmount/startingCapacity |
-| meat | 0 | 150 | resources.js:RESOURCES.meat.startingAmount/startingCapacity |
-| wood | 0 | 150 | resources.js:RESOURCES.wood.startingAmount/startingCapacity |
-| stone | 0 | 80 | resources.js:RESOURCES.stone.startingAmount/startingCapacity |
-| scrap | 0 | 80 | resources.js:RESOURCES.scrap.startingAmount/startingCapacity |
-| planks | 0 | 50 | resources.js:RESOURCES.planks.startingAmount/startingCapacity |
-| metalParts | 0 | 20 | resources.js:RESOURCES.metalParts.startingAmount/startingCapacity |
+| potatoes | 0 | 200 | resources.js:RESOURCES.potatoes.startingAmount/startingCapacity |
+| meat | 0 | 100 | resources.js:RESOURCES.meat.startingAmount/startingCapacity |
+| wood | 0 | 80 | resources.js:RESOURCES.wood.startingAmount/startingCapacity |
+| stone | 0 | 50 | resources.js:RESOURCES.stone.startingAmount/startingCapacity |
+| scrap | 0 | 60 | resources.js:RESOURCES.scrap.startingAmount/startingCapacity |
+| planks | 0 | 40 | resources.js:RESOURCES.planks.startingAmount/startingCapacity |
+| metalParts | 0 | 24 | resources.js:RESOURCES.metalParts.startingAmount/startingCapacity |
+| tools | 0 | 24 | resources.js:RESOURCES.tools.startingAmount/startingCapacity |
 | science | 0 | 400 | resources.js:RESOURCES.science.startingAmount/startingCapacity |
-| power | 0 | 2 | resources.js:RESOURCES.power.startingAmount/startingCapacity |
+| power | 0 | 20 | resources.js:RESOURCES.power.startingAmount/startingCapacity |
 
 ### Buildings
 | building | count | source |
@@ -107,58 +113,60 @@ Starting season: spring, Year: 1.
 - RADIO_BASE_SECONDS = 120 (source: settlement.js:RADIO_BASE_SECONDS)
 
 ## Summary
-Analyzed **15** buildings. Season mode: **average**.
+Analyzed **16** buildings. Season mode: **average**.
 Weights: {"wood":1,"stone":1.3,"scrap":2.2,"planks":4,"metalParts":6,"power":1,"potatoes":0.9,"meat":1.4,"science":2.5}. Targets: 1, 10, 50.
-Outliers – too fast: 1, too slow: 13.
+Outliers – too fast: 0, too slow: 15.
 
 ## Buildings
 | id | category | type | growth | PBT@1 | PBT@10 | PBT@50 | out/s (base) | in/s (base) |
 | - | - | - | - | - | - | - | - | - |
-| potatoField | Food | production | 1.13 | 64.99 | 198.81 | 25,924.97 | potatoes:0.375 | - |
-| huntersHut | Food | production | 1.15 | 223.48 | 796.16 | 210,594.82 | meat:0.19 | - |
-| loggingCamp | Raw Materials | production | 1.13 | 115.79 | 355.09 | 46,192.28 | wood:0.3 | - |
-| scrapyard | Raw Materials | production | 1.13 | 71.77 | 221.29 | 28,630.38 | scrap:0.08 | - |
-| quarry | Raw Materials | production | 1.13 | 241.36 | 748.99 | 96,286.2 | stone:0.104 | - |
-| sawmill | Construction Materials | processing | 1.13 | 86 | 261.75 | 34,305.08 | planks:0.5 | wood:0.8 |
+| potatoField | Food | production | 1.12 | 64.99 | 183.51 | 16,772.28 | potatoes:0.375 | - |
+| huntersHut | Food | production | 1.15 | 193 | 687.59 | 181,877.34 | meat:0.22 | - |
+| loggingCamp | Raw Materials | production | 1.12 | 115.79 | 324.21 | 29,881.4 | wood:0.3 | - |
+| scrapyard | Raw Materials | production | 1.12 | 71.77 | 203.35 | 18,522.73 | scrap:0.08 | - |
+| quarry | Raw Materials | production | 1.12 | 209.18 | 585.7 | 53,989.2 | stone:0.12 | - |
+| sawmill | Construction Materials | processing | 1.13 | 94.92 | 288.5 | 37,862 | planks:0.5 | wood:0.8 |
 | metalWorkshop | Construction Materials | processing | 1.13 | 98.03 | 299.67 | 39,102.7 | metalParts:0.4 | scrap:0.4 |
+| toolsmithy | Construction Materials | processing | 1.13 | — | — | — | tools:0.18 | planks:0.25,metalParts:0.15,power:0.4 |
 | school | Science | production | 1.13 | 64 | 196 | 25,530.22 | science:0.45 | - |
-| woodGenerator | Energy | production | 1.13 | 84 | 255.07 | 33,507.6 | power:1 | wood:0.25 |
+| woodGenerator | Energy | production | 1.13 | 270.67 | 828.4 | 107,968.93 | power:1 | wood:0.25 |
 | shelter | Settlement | production | 1.8 | — | — | — | - | - |
 | radio | Utilities | production | 1 | — | — | — | - | power:0.1 |
-| foodStorage |  | storage | 1.2 | — | — | — | - | - |
-| rawStorage |  | storage | 1.2 | — | — | — | - | - |
-| materialsDepot |  | storage | 1.2 | — | — | — | - | - |
-| battery |  | storage | 1.2 | — | — | — | - | - |
+| foodStorage |  | storage | 1.22 | — | — | — | - | - |
+| rawStorage |  | storage | 1.22 | — | — | — | - | - |
+| materialsDepot |  | storage | 1.22 | — | — | — | - | - |
+| battery |  | storage | 1.22 | — | — | — | - | - |
 
 ## Converters
 | id | growth | in/s | out/s | ratio(out/in) | PBT@1 | PBT@10 | PBT@50 | mode |
 | - | - | - | - | - | - | - | - | - |
-| sawmill | 1.13 | wood:0.8 | planks:0.5 | 2.5 | 86 | 261.75 | 34,305.08 | all-or-nothing |
+| sawmill | 1.13 | wood:0.8 | planks:0.5 | 2.5 | 94.92 | 288.5 | 37,862 | all-or-nothing |
 | metalWorkshop | 1.13 | scrap:0.4 | metalParts:0.4 | 2.73 | 98.03 | 299.67 | 39,102.7 | all-or-nothing |
+| toolsmithy | 1.13 | planks:0.25,metalParts:0.15,power:0.4 | tools:0.18 | 0 | — | — | — | all-or-nothing |
 
 ## Storage
 | id | growth | +capacity |
 | - | - | - |
-| foodStorage | 1.2 | potatoes:300,meat:150 |
-| rawStorage | 1.2 | wood:200,stone:80,scrap:90 |
-| materialsDepot | 1.2 | planks:300,metalParts:240 |
-| battery | 1.2 | power:600 |
+| foodStorage | 1.22 | potatoes:150,meat:75 |
+| rawStorage | 1.22 | wood:120,scrap:80,stone:60 |
+| materialsDepot | 1.22 | planks:100,metalParts:40 |
+| battery | 1.22 | power:40 |
 
 ## Outliers
-### Too Fast
-- sawmill @1: 86 sec
 ### Too Slow
-- potatoField @50: 25,924.97 sec
-- huntersHut @1: 223.48 sec
-- huntersHut @10: 796.16 sec
-- huntersHut @50: 210,594.82 sec
-- loggingCamp @50: 46,192.28 sec
-- scrapyard @50: 28,630.38 sec
-- quarry @1: 241.36 sec
-- quarry @10: 748.99 sec
-- quarry @50: 96,286.2 sec
-- sawmill @50: 34,305.08 sec
+- potatoField @50: 16,772.28 sec
+- huntersHut @1: 193 sec
+- huntersHut @10: 687.59 sec
+- huntersHut @50: 181,877.34 sec
+- loggingCamp @50: 29,881.4 sec
+- scrapyard @50: 18,522.73 sec
+- quarry @1: 209.18 sec
+- quarry @10: 585.7 sec
+- quarry @50: 53,989.2 sec
+- sawmill @50: 37,862 sec
 - metalWorkshop @50: 39,102.7 sec
 - school @50: 25,530.22 sec
-- woodGenerator @50: 33,507.6 sec
+- woodGenerator @1: 270.67 sec
+- woodGenerator @10: 828.4 sec
+- woodGenerator @50: 107,968.93 sec
 

--- a/docs/economy-snapshot.json
+++ b/docs/economy-snapshot.json
@@ -1,6 +1,6 @@
 {
-  "version": "5e5a6b7d1786bbde7e8dafea4711f644f2d09a5b",
-  "saveVersion": 6,
+  "version": "35f35aa12e885b89cd28e6978415732365573f45",
+  "saveVersion": 7,
   "tickSeconds": 1,
   "seasons": {
     "spring": {
@@ -13,6 +13,7 @@
         "scrap": 1.1,
         "planks": 1,
         "metalParts": 1,
+        "tools": 1,
         "science": 1,
         "power": 1
       },
@@ -31,6 +32,7 @@
         "scrap": 1,
         "planks": 1,
         "metalParts": 1,
+        "tools": 1,
         "science": 1,
         "power": 1
       },
@@ -49,6 +51,7 @@
         "scrap": 0.9,
         "planks": 1,
         "metalParts": 1,
+        "tools": 1,
         "science": 1,
         "power": 1
       },
@@ -67,6 +70,7 @@
         "scrap": 0.8,
         "planks": 1,
         "metalParts": 1,
+        "tools": 1,
         "science": 1,
         "power": 1
       },
@@ -82,7 +86,7 @@
       "displayName": "Potatoes",
       "category": "FOOD",
       "startingAmount": 0,
-      "startingCapacity": 450,
+      "startingCapacity": 200,
       "unit": null,
       "origin": {
         "file": "resources.js",
@@ -94,7 +98,7 @@
       "displayName": "Meat",
       "category": "FOOD",
       "startingAmount": 0,
-      "startingCapacity": 150,
+      "startingCapacity": 100,
       "unit": "",
       "origin": {
         "file": "resources.js",
@@ -106,7 +110,7 @@
       "displayName": "Wood",
       "category": "RAW",
       "startingAmount": 0,
-      "startingCapacity": 150,
+      "startingCapacity": 80,
       "unit": null,
       "origin": {
         "file": "resources.js",
@@ -118,7 +122,7 @@
       "displayName": "Stone",
       "category": "RAW",
       "startingAmount": 0,
-      "startingCapacity": 80,
+      "startingCapacity": 50,
       "unit": null,
       "origin": {
         "file": "resources.js",
@@ -130,7 +134,7 @@
       "displayName": "Scrap",
       "category": "RAW",
       "startingAmount": 0,
-      "startingCapacity": 80,
+      "startingCapacity": 60,
       "unit": null,
       "origin": {
         "file": "resources.js",
@@ -142,7 +146,7 @@
       "displayName": "Planks",
       "category": "CONSTRUCTION_MATERIALS",
       "startingAmount": 0,
-      "startingCapacity": 50,
+      "startingCapacity": 40,
       "unit": null,
       "origin": {
         "file": "resources.js",
@@ -154,11 +158,23 @@
       "displayName": "Metal Parts",
       "category": "CONSTRUCTION_MATERIALS",
       "startingAmount": 0,
-      "startingCapacity": 20,
+      "startingCapacity": 24,
       "unit": null,
       "origin": {
         "file": "resources.js",
         "path": "RESOURCES.metalParts"
+      }
+    },
+    {
+      "key": "tools",
+      "displayName": "Tools",
+      "category": "CONSTRUCTION_MATERIALS",
+      "startingAmount": 0,
+      "startingCapacity": 24,
+      "unit": null,
+      "origin": {
+        "file": "resources.js",
+        "path": "RESOURCES.tools"
       }
     },
     {
@@ -178,7 +194,7 @@
       "displayName": "Power",
       "category": "ENERGY",
       "startingAmount": 0,
-      "startingCapacity": 2,
+      "startingCapacity": 20,
       "unit": null,
       "origin": {
         "file": "resources.js",
@@ -194,7 +210,7 @@
       "cost": {
         "wood": 17
       },
-      "costGrowth": 1.13,
+      "costGrowth": 1.12,
       "refund": 0.5,
       "storage": {},
       "outputsPerSec": {
@@ -226,10 +242,10 @@
       "refund": 0.5,
       "storage": {},
       "outputsPerSec": {
-        "meat": 0.19
+        "meat": 0.22
       },
       "inputsPerSec": {},
-      "requiresResearch": "hunting1",
+      "requiresResearch": "huntingHut",
       "seasonMults": {
         "spring": 1.1,
         "summer": 1,
@@ -248,7 +264,7 @@
       "cost": {
         "scrap": 15
       },
-      "costGrowth": 1.13,
+      "costGrowth": 1.12,
       "refund": 0.5,
       "storage": {},
       "outputsPerSec": {
@@ -274,7 +290,7 @@
       "cost": {
         "wood": 12
       },
-      "costGrowth": 1.13,
+      "costGrowth": 1.12,
       "refund": 0.5,
       "storage": {},
       "outputsPerSec": {
@@ -301,11 +317,11 @@
         "wood": 20,
         "scrap": 5
       },
-      "costGrowth": 1.13,
+      "costGrowth": 1.12,
       "refund": 0.5,
       "storage": {},
       "outputsPerSec": {
-        "stone": 0.104
+        "stone": 0.12
       },
       "inputsPerSec": {},
       "requiresResearch": "",
@@ -325,9 +341,9 @@
       "name": "Sawmill",
       "type": "processing",
       "cost": {
-        "wood": 48,
-        "scrap": 18,
-        "stone": 12
+        "wood": 53,
+        "scrap": 20,
+        "stone": 13
       },
       "costGrowth": 1.13,
       "refund": 0.5,
@@ -382,6 +398,40 @@
       }
     },
     {
+      "id": "toolsmithy",
+      "name": "Toolsmithy",
+      "type": "processing",
+      "cost": {
+        "wood": 50,
+        "scrap": 30,
+        "stone": 20,
+        "planks": 25,
+        "metalParts": 15
+      },
+      "costGrowth": 1.13,
+      "refund": 0.5,
+      "storage": {},
+      "outputsPerSec": {
+        "tools": 0.18
+      },
+      "inputsPerSec": {
+        "planks": 0.25,
+        "metalParts": 0.15,
+        "power": 0.4
+      },
+      "requiresResearch": "industry2",
+      "seasonMults": {
+        "spring": 1,
+        "summer": 1,
+        "autumn": 1,
+        "winter": 1
+      },
+      "origin": {
+        "file": "buildings.js",
+        "path": "BUILDINGS[7]"
+      }
+    },
+    {
       "id": "school",
       "name": "School",
       "type": "production",
@@ -406,7 +456,7 @@
       },
       "origin": {
         "file": "buildings.js",
-        "path": "BUILDINGS[7]"
+        "path": "BUILDINGS[8]"
       }
     },
     {
@@ -415,7 +465,9 @@
       "type": "production",
       "cost": {
         "wood": 50,
-        "stone": 10
+        "stone": 10,
+        "planks": 20,
+        "metalParts": 10
       },
       "costGrowth": 1.13,
       "refund": 0.5,
@@ -435,7 +487,7 @@
       },
       "origin": {
         "file": "buildings.js",
-        "path": "BUILDINGS[8]"
+        "path": "BUILDINGS[9]"
       }
     },
     {
@@ -460,7 +512,7 @@
       },
       "origin": {
         "file": "buildings.js",
-        "path": "BUILDINGS[9]"
+        "path": "BUILDINGS[10]"
       }
     },
     {
@@ -471,7 +523,8 @@
         "wood": 80,
         "scrap": 40,
         "stone": 20,
-        "planks": 20
+        "planks": 20,
+        "metalParts": 10
       },
       "costGrowth": 1,
       "refund": 0.5,
@@ -489,7 +542,7 @@
       },
       "origin": {
         "file": "buildings.js",
-        "path": "BUILDINGS[10]"
+        "path": "BUILDINGS[11]"
       }
     },
     {
@@ -501,41 +554,11 @@
         "scrap": 5,
         "stone": 5
       },
-      "costGrowth": 1.2,
+      "costGrowth": 1.22,
       "refund": 0.5,
       "storage": {
-        "potatoes": 300,
-        "meat": 150
-      },
-      "outputsPerSec": {},
-      "inputsPerSec": {},
-      "requiresResearch": "",
-      "seasonMults": {
-        "spring": 1,
-        "summer": 1,
-        "autumn": 1,
-        "winter": 1
-      },
-      "origin": {
-        "file": "buildings.js",
-        "path": "BUILDINGS[11]"
-      }
-    },
-    {
-      "id": "rawStorage",
-      "name": "Warehouse",
-      "type": "storage",
-      "cost": {
-        "wood": 25,
-        "scrap": 10,
-        "stone": 10
-      },
-      "costGrowth": 1.2,
-      "refund": 0.5,
-      "storage": {
-        "wood": 200,
-        "stone": 80,
-        "scrap": 90
+        "potatoes": 150,
+        "meat": 75
       },
       "outputsPerSec": {},
       "inputsPerSec": {},
@@ -552,23 +575,24 @@
       }
     },
     {
-      "id": "materialsDepot",
-      "name": "Materials Depot",
+      "id": "rawStorage",
+      "name": "Warehouse",
       "type": "storage",
       "cost": {
         "wood": 25,
         "scrap": 10,
-        "stone": 5
+        "stone": 10
       },
-      "costGrowth": 1.2,
+      "costGrowth": 1.22,
       "refund": 0.5,
       "storage": {
-        "planks": 300,
-        "metalParts": 240
+        "wood": 120,
+        "scrap": 80,
+        "stone": 60
       },
       "outputsPerSec": {},
       "inputsPerSec": {},
-      "requiresResearch": "industry1",
+      "requiresResearch": "",
       "seasonMults": {
         "spring": 1,
         "summer": 1,
@@ -581,17 +605,48 @@
       }
     },
     {
+      "id": "materialsDepot",
+      "name": "Materials Depot",
+      "type": "storage",
+      "cost": {
+        "wood": 25,
+        "scrap": 10,
+        "stone": 5
+      },
+      "costGrowth": 1.22,
+      "refund": 0.5,
+      "storage": {
+        "planks": 100,
+        "metalParts": 40
+      },
+      "outputsPerSec": {},
+      "inputsPerSec": {},
+      "requiresResearch": "industry1",
+      "seasonMults": {
+        "spring": 1,
+        "summer": 1,
+        "autumn": 1,
+        "winter": 1
+      },
+      "origin": {
+        "file": "buildings.js",
+        "path": "BUILDINGS[14]"
+      }
+    },
+    {
       "id": "battery",
       "name": "Battery",
       "type": "storage",
       "cost": {
         "wood": 40,
-        "stone": 20
+        "stone": 20,
+        "planks": 20,
+        "metalParts": 10
       },
-      "costGrowth": 1.2,
+      "costGrowth": 1.22,
       "refund": 0.5,
       "storage": {
-        "power": 600
+        "power": 40
       },
       "outputsPerSec": {},
       "inputsPerSec": {},
@@ -604,43 +659,16 @@
       },
       "origin": {
         "file": "buildings.js",
-        "path": "BUILDINGS[14]"
+        "path": "BUILDINGS[15]"
       }
     }
   ],
   "research": [
     {
-      "id": "basicEnergy",
-      "name": "Basic Energy",
-      "scienceCost": 80,
-      "timeSec": 120,
-      "prereqs": [
-        "industry1"
-      ],
-      "milestones": null,
-      "unlocks": {
-        "resources": [
-          "power"
-        ],
-        "buildings": [
-          "woodGenerator",
-          "battery"
-        ],
-        "categories": [
-          "Energy"
-        ]
-      },
-      "effects": [],
-      "origin": {
-        "file": "research.js",
-        "path": "RESEARCH[0]"
-      }
-    },
-    {
       "id": "industry1",
       "name": "Industry I",
       "scienceCost": 60,
-      "timeSec": 90,
+      "timeSec": 120,
       "prereqs": [],
       "milestones": null,
       "unlocks": {
@@ -660,52 +688,7 @@
       "effects": [],
       "origin": {
         "file": "research.js",
-        "path": "RESEARCH[1]"
-      }
-    },
-    {
-      "id": "hunting1",
-      "name": "Hunting I",
-      "scienceCost": 50,
-      "timeSec": 90,
-      "prereqs": [],
-      "milestones": null,
-      "unlocks": {
-        "resources": [
-          "meat"
-        ],
-        "buildings": [
-          "huntersHut"
-        ],
-        "categories": []
-      },
-      "effects": [],
-      "origin": {
-        "file": "research.js",
-        "path": "RESEARCH[2]"
-      }
-    },
-    {
-      "id": "radio",
-      "name": "Radio",
-      "scienceCost": 150,
-      "timeSec": 240,
-      "prereqs": [
-        "industry1",
-        "basicEnergy"
-      ],
-      "milestones": null,
-      "unlocks": {
-        "resources": [],
-        "buildings": [
-          "radio"
-        ],
-        "categories": []
-      },
-      "effects": [],
-      "origin": {
-        "file": "research.js",
-        "path": "RESEARCH[3]"
+        "path": "RESEARCH[0]"
       }
     },
     {
@@ -731,7 +714,7 @@
       ],
       "origin": {
         "file": "research.js",
-        "path": "RESEARCH[4]"
+        "path": "RESEARCH[1]"
       }
     },
     {
@@ -757,7 +740,7 @@
       ],
       "origin": {
         "file": "research.js",
-        "path": "RESEARCH[5]"
+        "path": "RESEARCH[2]"
       }
     },
     {
@@ -788,7 +771,7 @@
       ],
       "origin": {
         "file": "research.js",
-        "path": "RESEARCH[6]"
+        "path": "RESEARCH[3]"
       }
     },
     {
@@ -797,7 +780,9 @@
       "scienceCost": 200,
       "timeSec": 240,
       "prereqs": [
-        "industry1"
+        "woodworking1",
+        "salvaging1",
+        "logistics1"
       ],
       "milestones": {
         "produced": {
@@ -815,17 +800,48 @@
       "effects": [],
       "origin": {
         "file": "research.js",
-        "path": "RESEARCH[7]"
+        "path": "RESEARCH[4]"
+      }
+    },
+    {
+      "id": "industryProduction",
+      "name": "Industry Production",
+      "scienceCost": 170,
+      "timeSec": 270,
+      "prereqs": [
+        "woodworking1",
+        "salvaging1",
+        "logistics1"
+      ],
+      "milestones": null,
+      "unlocks": {
+        "resources": [],
+        "buildings": [],
+        "categories": []
+      },
+      "effects": [
+        {
+          "category": "CONSTRUCTION_MATERIALS",
+          "percent": 0.05,
+          "type": "output"
+        }
+      ],
+      "origin": {
+        "file": "research.js",
+        "path": "RESEARCH[5]"
       }
     },
     {
       "id": "woodworking2",
       "name": "Woodworking II",
-      "scienceCost": 140,
-      "timeSec": 240,
+      "scienceCost": 220,
+      "timeSec": 360,
       "prereqs": [
+        "industry2",
+        "industryProduction",
         "woodworking1",
-        "industry2"
+        "salvaging1",
+        "logistics1"
       ],
       "milestones": null,
       "unlocks": {
@@ -842,17 +858,20 @@
       ],
       "origin": {
         "file": "research.js",
-        "path": "RESEARCH[8]"
+        "path": "RESEARCH[6]"
       }
     },
     {
       "id": "salvaging2",
       "name": "Salvaging II",
-      "scienceCost": 140,
-      "timeSec": 240,
+      "scienceCost": 220,
+      "timeSec": 360,
       "prereqs": [
+        "industry2",
+        "industryProduction",
+        "woodworking1",
         "salvaging1",
-        "industry2"
+        "logistics1"
       ],
       "milestones": null,
       "unlocks": {
@@ -869,17 +888,20 @@
       ],
       "origin": {
         "file": "research.js",
-        "path": "RESEARCH[9]"
+        "path": "RESEARCH[7]"
       }
     },
     {
       "id": "logistics2",
       "name": "Logistics II",
-      "scienceCost": 150,
-      "timeSec": 270,
+      "scienceCost": 230,
+      "timeSec": 360,
       "prereqs": [
-        "logistics1",
-        "industry2"
+        "industry2",
+        "industryProduction",
+        "woodworking1",
+        "salvaging1",
+        "logistics1"
       ],
       "milestones": null,
       "unlocks": {
@@ -901,42 +923,107 @@
       ],
       "origin": {
         "file": "research.js",
+        "path": "RESEARCH[8]"
+      }
+    },
+    {
+      "id": "basicEnergy",
+      "name": "Basic Energy",
+      "scienceCost": 150,
+      "timeSec": 210,
+      "prereqs": [
+        "industry2"
+      ],
+      "milestones": null,
+      "unlocks": {
+        "resources": [
+          "power"
+        ],
+        "buildings": [
+          "woodGenerator",
+          "battery"
+        ],
+        "categories": [
+          "Energy"
+        ]
+      },
+      "effects": [],
+      "origin": {
+        "file": "research.js",
+        "path": "RESEARCH[9]"
+      }
+    },
+    {
+      "id": "radio",
+      "name": "Radio",
+      "scienceCost": 150,
+      "timeSec": 240,
+      "prereqs": [
+        "basicEnergy"
+      ],
+      "milestones": null,
+      "unlocks": {
+        "resources": [],
+        "buildings": [
+          "radio"
+        ],
+        "categories": []
+      },
+      "effects": [],
+      "origin": {
+        "file": "research.js",
         "path": "RESEARCH[10]"
       }
     },
     {
-      "id": "hunting2",
-      "name": "Hunting II",
-      "scienceCost": 130,
-      "timeSec": 240,
-      "prereqs": [
-        "hunting1"
-      ],
+      "id": "food1",
+      "name": "Food I",
+      "scienceCost": 50,
+      "timeSec": 90,
+      "prereqs": [],
       "milestones": null,
       "unlocks": {
         "resources": [],
         "buildings": [],
         "categories": []
       },
-      "effects": [
-        {
-          "category": "FOOD",
-          "percent": 0.1,
-          "type": "output"
-        }
-      ],
+      "effects": [],
       "origin": {
         "file": "research.js",
         "path": "RESEARCH[11]"
       }
     },
     {
-      "id": "industryProduction",
-      "name": "Industry Production",
-      "scienceCost": 130,
+      "id": "huntingHut",
+      "name": "Hunting Hut",
+      "scienceCost": 60,
+      "timeSec": 90,
+      "prereqs": [
+        "food1"
+      ],
+      "milestones": null,
+      "unlocks": {
+        "resources": [
+          "meat"
+        ],
+        "buildings": [
+          "huntersHut"
+        ],
+        "categories": []
+      },
+      "effects": [],
+      "origin": {
+        "file": "research.js",
+        "path": "RESEARCH[12]"
+      }
+    },
+    {
+      "id": "food2",
+      "name": "Food II",
+      "scienceCost": 150,
       "timeSec": 240,
       "prereqs": [
-        "industry1"
+        "huntingHut"
       ],
       "milestones": null,
       "unlocks": {
@@ -946,14 +1033,14 @@
       },
       "effects": [
         {
-          "category": "CONSTRUCTION_MATERIALS",
-          "percent": 0.1,
+          "resource": "meat",
+          "percent": 0.04,
           "type": "output"
         }
       ],
       "origin": {
         "file": "research.js",
-        "path": "RESEARCH[12]"
+        "path": "RESEARCH[13]"
       }
     }
   ],
@@ -962,8 +1049,6 @@
       "id": "farmer",
       "name": "Farmer",
       "skill": "Farming",
-      "resource": "potatoes",
-      "building": "potatoField",
       "origin": {
         "file": "roles.js",
         "path": "ROLES.farmer"
@@ -973,52 +1058,60 @@
       "id": "hunter",
       "name": "Hunter",
       "skill": "Hunting",
-      "resource": "meat",
-      "building": "huntersHut",
       "origin": {
         "file": "roles.js",
         "path": "ROLES.hunter"
       }
     },
     {
-      "id": "woodcutter",
-      "name": "Woodcutter",
-      "skill": "Woodcutting",
-      "resource": "wood",
-      "building": "loggingCamp",
+      "id": "gatherer",
+      "name": "Gatherer",
+      "skill": "Gathering",
       "origin": {
         "file": "roles.js",
-        "path": "ROLES.woodcutter"
+        "path": "ROLES.gatherer"
       }
     },
     {
-      "id": "scavenger",
-      "name": "Scavenger",
-      "skill": "Scavenging",
-      "resource": "scrap",
-      "building": "scrapyard",
+      "id": "carpenter",
+      "name": "Carpenter",
+      "skill": "Carpentry",
       "origin": {
         "file": "roles.js",
-        "path": "ROLES.scavenger"
+        "path": "ROLES.carpenter"
       }
     },
     {
-      "id": "quarryWorker",
-      "name": "Quarry Worker",
-      "skill": "Quarrying",
-      "resource": "stone",
-      "building": "quarry",
+      "id": "metalworker",
+      "name": "Metalworker",
+      "skill": "Metalworking",
       "origin": {
         "file": "roles.js",
-        "path": "ROLES.quarryWorker"
+        "path": "ROLES.metalworker"
+      }
+    },
+    {
+      "id": "toolsmith",
+      "name": "Toolsmith",
+      "skill": "Toolsmithing",
+      "origin": {
+        "file": "roles.js",
+        "path": "ROLES.toolsmith"
+      }
+    },
+    {
+      "id": "engineer",
+      "name": "Engineer",
+      "skill": "Engineering",
+      "origin": {
+        "file": "roles.js",
+        "path": "ROLES.engineer"
       }
     },
     {
       "id": "scientist",
       "name": "Scientist",
       "skill": "Scientist",
-      "resource": "science",
-      "building": "school",
       "origin": {
         "file": "roles.js",
         "path": "ROLES.scientist"
@@ -1083,31 +1176,35 @@
   "startingResources": {
     "potatoes": {
       "amount": 0,
-      "capacity": 450
+      "capacity": 200
     },
     "meat": {
       "amount": 0,
-      "capacity": 150
+      "capacity": 100
     },
     "wood": {
       "amount": 0,
-      "capacity": 150
+      "capacity": 80
     },
     "stone": {
       "amount": 0,
-      "capacity": 80
+      "capacity": 50
     },
     "scrap": {
       "amount": 0,
-      "capacity": 80
+      "capacity": 60
     },
     "planks": {
       "amount": 0,
-      "capacity": 50
+      "capacity": 40
     },
     "metalParts": {
       "amount": 0,
-      "capacity": 20
+      "capacity": 24
+    },
+    "tools": {
+      "amount": 0,
+      "capacity": 24
     },
     "science": {
       "amount": 0,
@@ -1115,7 +1212,7 @@
     },
     "power": {
       "amount": 0,
-      "capacity": 2
+      "capacity": 20
     }
   },
   "startingBuildings": {


### PR DESCRIPTION
## Summary
- Regenerate economy report and snapshot.

## Testing
- `TS_NODE_TRANSPILE_ONLY=1 node --loader ts-node/esm scripts/generate-economy-report.mjs`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d1ede7c6083319d9f1d77e5380370