### PR TITLE
Add tests for power status selector fallbacks

### DIFF
--- a/src/state/__tests__/selectors.test.js
+++ b/src/state/__tests__/selectors.test.js
@@ -15,7 +15,15 @@ describe('getResourceRates', () => {
 });
 
 describe('power selectors', () => {
-  it('returns power status with fallbacks', () => {
+  it('returns power status when present', () => {
+    const state = {
+      powerStatus: { supply: 1, demand: 2, stored: 3, capacity: 4 },
+    };
+    const ps = getPowerStatus(state);
+    expect(ps).toEqual({ supply: 1, demand: 2, stored: 3, capacity: 4 });
+  });
+
+  it('uses fallbacks when power status is missing', () => {
     const state = {
       resources: { power: { amount: 5 } },
       buildings: {},
@@ -23,6 +31,12 @@ describe('power selectors', () => {
     };
     const ps = getPowerStatus(state);
     expect(ps).toEqual({ supply: 0, demand: 0, stored: 5, capacity: 20 });
+  });
+
+  it('handles old saves without power resource', () => {
+    const state = { resources: {}, buildings: {}, research: { completed: [] } };
+    const ps = getPowerStatus(state);
+    expect(ps).toEqual({ supply: 0, demand: 0, stored: 0, capacity: 20 });
   });
 
   it('injects power status into energy section', () => {


### PR DESCRIPTION
## Summary
- add tests for getPowerStatus when power status is present and for old saves without the field
- verify power selector behaviour when power resource is missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d26f1209483319922aea4c62cfcee