### PR TITLE
Clamp food after combined changes

### DIFF
--- a/src/components/ResourceRow.jsx
+++ b/src/components/ResourceRow.jsx
@@ -14,6 +14,13 @@ export default function ResourceRow({
   demand,
   stored,
 }) {
+  const displayAmount =
+    capacity != null && Math.abs(amount - capacity) < 1e-6 ? capacity : amount;
+  const displayStored =
+    stored != null && capacity != null && Math.abs(stored - capacity) < 1e-6
+      ? capacity
+      : stored ?? amount;
+
   const content = (
     <li className="flex items-center justify-between text-sm tabular-nums">
       <span className="flex items-center gap-2">
@@ -27,13 +34,13 @@ export default function ResourceRow({
           </span>
         ) : (
           <span className={capped ? 'text-orange-500' : undefined}>
-            {formatAmount(amount)}
+            {formatAmount(displayAmount)}
             {capacity != null && ` / ${formatAmount(capacity)}`}
           </span>
         )}
         {supply != null && demand != null ? (
           <span className="text-xs text-muted-foreground">
-            {formatAmount(stored ?? amount)}
+            {formatAmount(displayStored)}
             {capacity != null && ` / ${formatAmount(capacity)}`}
           </span>
         ) : rate != null ? (

--- a/src/components/__tests__/ResourceRow.test.jsx
+++ b/src/components/__tests__/ResourceRow.test.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import ResourceRow from '../ResourceRow.jsx';
+import { processSettlersTick } from '../../engine/settlers.js';
+import { defaultState } from '../../state/defaultState.js';
+import { deepClone } from '../../utils/clone.ts';
+import { BALANCE } from '../../data/balance.js';
+
+describe('ResourceRow', () => {
+  it('shows capacity when amount is within epsilon of cap', () => {
+    const state = deepClone(defaultState);
+    const cap = 200;
+    state.resources.potatoes.amount = cap;
+    state.foodPool = { amount: cap, capacity: cap };
+    state.population.settlers = [{ id: 's1' }];
+    const bonusPerSec = BALANCE.FOOD_CONSUMPTION_PER_SETTLER + 0.1;
+    const { state: next } = processSettlersTick(state, 1, bonusPerSec);
+    render(
+      <ResourceRow
+        name="Potatoes"
+        amount={next.resources.potatoes.amount}
+        capacity={cap}
+      />,
+    );
+    expect(screen.getByText('200 / 200')).toBeTruthy();
+  });
+});

--- a/src/engine/__tests__/settlers.test.js
+++ b/src/engine/__tests__/settlers.test.js
@@ -44,4 +44,16 @@ describe('settlers tick', () => {
 
     expect(final.resources.potatoes.amount).toBeCloseTo(expected, 5);
   });
+
+  it('clamps food once after bonus and consumption', () => {
+    const state = deepClone(defaultState);
+    const cap = 200;
+    state.resources.potatoes.amount = cap;
+    state.foodPool = { amount: cap, capacity: cap };
+    state.population.settlers = [{ id: 's1' }];
+    const bonusPerSec = BALANCE.FOOD_CONSUMPTION_PER_SETTLER + 0.1;
+    const { state: next } = processSettlersTick(state, 1, bonusPerSec);
+    expect(next.foodPool.amount).toBe(cap);
+    expect(next.resources.potatoes.amount).toBe(cap);
+  });
 });

--- a/src/engine/settlers.js
+++ b/src/engine/settlers.js
@@ -8,6 +8,7 @@ import {
 import { getFoodCapacity, getSettlerCapacity } from '../state/selectors.js';
 import { SECONDS_PER_DAY } from './time.js';
 import { RESOURCES } from '../data/resources.js';
+import { clampResource } from './resources.js';
 import { createLogEntry } from '../utils/log.js';
 
 export function computeRoleBonuses(settlers) {
@@ -89,10 +90,7 @@ export function processSettlersTick(
       0,
     );
 
-  const bonusGain = Math.min(
-    Math.max(0, bonusGainPerSec * seconds),
-    Math.max(0, foodCapacity - foodAmount),
-  );
+  const bonusGain = Math.max(0, bonusGainPerSec * seconds);
   foodAmount += bonusGain;
   const currentEntry = state.resources.potatoes || {
     amount: 0,
@@ -125,6 +123,15 @@ export function processSettlersTick(
       foodAmount -= use;
     }
   }
+
+  const finalFoodAmount = clampResource(foodAmount, foodCapacity);
+  const overflow = foodAmount - finalFoodAmount;
+  if (overflow > 0) {
+    const entry = resources.potatoes || { amount: 0, discovered: false, produced: 0 };
+    entry.amount = Math.max(0, entry.amount - overflow);
+    resources.potatoes = { ...entry };
+  }
+  foodAmount = finalFoodAmount;
 
   let starvationTimer = state.colony?.starvationTimerSeconds || 0;
   if (foodAmount > 0) {


### PR DESCRIPTION
## Summary
- Clamp food after applying farming bonuses and consumption so net positives at capacity stay capped
- Display resource amounts as capacity when within epsilon of cap
- Test food clamping and capacity display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d2969f1c48331a413d93a30aa0416