### PR TITLE
feat: add mason role

### DIFF
--- a/docs/ECONOMY_REPORT.md
+++ b/docs/ECONOMY_REPORT.md
@@ -72,6 +72,7 @@ Each tick represents 1 second. For each building: base production is modified by
 | gatherer | Gatherer | Gathering | undefined | undefined | roles.js:ROLES.gatherer |
 | carpenter | Carpenter | Carpentry | undefined | undefined | roles.js:ROLES.carpenter |
 | metalworker | Metalworker | Metalworking | undefined | undefined | roles.js:ROLES.metalworker |
+| mason | Mason | Masonry | undefined | undefined | roles.js:ROLES.mason |
 | toolsmith | Toolsmith | Toolsmithing | undefined | undefined | roles.js:ROLES.toolsmith |
 | engineer | Engineer | Engineering | undefined | undefined | roles.js:ROLES.engineer |
 | scientist | Scientist | Scientist | undefined | undefined | roles.js:ROLES.scientist |

--- a/docs/economy-snapshot.json
+++ b/docs/economy-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "version": "35f35aa12e885b89cd28e6978415732365573f45",
+  "version": "e412e0e8b37cb9b8933bf57d647d6e698fd6a0f1",
   "saveVersion": 7,
   "tickSeconds": 1,
   "seasons": {
@@ -1088,6 +1088,15 @@
       "origin": {
         "file": "roles.js",
         "path": "ROLES.metalworker"
+      }
+    },
+    {
+      "id": "mason",
+      "name": "Mason",
+      "skill": "Masonry",
+      "origin": {
+        "file": "roles.js",
+        "path": "ROLES.mason"
       }
     },
     {

--- a/src/data/roles.js
+++ b/src/data/roles.js
@@ -34,6 +34,13 @@ export const ROLES = {
     resources: ['metalParts'],
     buildings: ['metalWorkshop'],
   },
+  mason: {
+    id: 'mason',
+    name: 'Mason',
+    skill: 'Masonry',
+    resources: ['bricks'],
+    buildings: ['brickKiln'],
+  },
   toolsmith: {
     id: 'toolsmith',
     name: 'Toolsmith',


### PR DESCRIPTION
## Summary
- add mason role producing bricks in the brick kiln
- update economy report and snapshot with new role

## Testing
- `npx eslint src/data/roles.js`
- `npm test`
- `npm run lint` *(fails: Code style issues in 37 files)*
- `npm run report:economy --` *(fails: Unknown file extension ".ts" for clone.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689d2d366c38833180ef7a6f1ec3be51