### PR TITLE
feat: aggregate starting food pool

### DIFF
--- a/src/state/__tests__/prepareLoadedState.test.js
+++ b/src/state/__tests__/prepareLoadedState.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { prepareLoadedState } from '../prepareLoadedState.ts';
 import { defaultState } from '../defaultState.js';
 import { deepClone } from '../../utils/clone.ts';
+import { getFoodCapacity } from '../selectors.js';
 
 // Test that offline gains produce log entries
 
@@ -34,5 +35,17 @@ describe('prepareLoadedState', () => {
       stored: 0,
       capacity: 0,
     });
+  });
+
+  it('computes foodPool from resources when missing', () => {
+    const loaded = {
+      resources: {
+        potatoes: { amount: 10, discovered: true, produced: 0 },
+        meat: { amount: 5, discovered: true, produced: 0 },
+      },
+    };
+    const state = prepareLoadedState(loaded);
+    expect(state.foodPool.amount).toBe(15);
+    expect(state.foodPool.capacity).toBe(getFoodCapacity(state));
   });
 });

--- a/src/state/defaultState.js
+++ b/src/state/defaultState.js
@@ -5,6 +5,7 @@ import { buildInitialPowerTypeOrder } from '../engine/power.js';
 import { makeRandomSettler } from '../data/names.js';
 import { RADIO_BASE_SECONDS } from '../data/settlement.js';
 import { BALANCE } from '../data/balance.js';
+import { getFoodCapacity } from './selectors.js';
 
 const initResources = () => {
   const obj = {};
@@ -13,18 +14,6 @@ const initResources = () => {
     obj[r.id] = { amount: amt, discovered: amt > 0, produced: 0 };
   });
   return obj;
-};
-
-const initFoodPool = () => {
-  let amount = 0;
-  let capacity = 0;
-  Object.values(RESOURCES).forEach((r) => {
-    if (r.category === 'FOOD') {
-      amount += r.startingAmount || 0;
-      capacity += r.startingCapacity || 0;
-    }
-  });
-  return { amount, capacity };
 };
 
 const initBuildings = () => ({
@@ -48,14 +37,28 @@ const initColony = () => ({
 
 const initResearch = () => ({ current: null, completed: [], progress: {} });
 
+const resources = initResources();
+const buildings = initBuildings();
+
+const initFoodPool = () => {
+  let amount = 0;
+  Object.values(RESOURCES).forEach((r) => {
+    if (r.category === 'FOOD') {
+      amount += resources[r.id]?.amount || 0;
+    }
+  });
+  const capacity = getFoodCapacity({ resources, buildings });
+  return { amount, capacity };
+};
+
 export const defaultState = {
   version: CURRENT_SAVE_VERSION,
   gameTime: { seconds: 0 },
   meta: { seasons: initSeasons() },
   ui: { activeTab: 'base', drawerOpen: false, offlineProgress: null },
-  resources: initResources(),
+  resources,
   foodPool: initFoodPool(),
-  buildings: initBuildings(),
+  buildings,
   powerTypeOrder: initPowerTypeOrder(),
   research: initResearch(),
   population: { settlers: initSettlers(), candidate: null },

--- a/src/state/prepareLoadedState.ts
+++ b/src/state/prepareLoadedState.ts
@@ -7,6 +7,7 @@ import { RESOURCES } from '../data/resources.js';
 import { formatAmount } from '../utils/format.js';
 import { buildInitialPowerTypeOrder } from '../engine/power.js';
 import { deepClone } from '../utils/clone.ts';
+import { getFoodCapacity } from './selectors.js';
 
 /* eslint-disable-next-line react-refresh/only-export-components */
 export function prepareLoadedState(loaded: any) {
@@ -21,13 +22,20 @@ export function prepareLoadedState(loaded: any) {
   base.meta = { ...base.meta, ...cloned.meta, seasons: initSeasons() };
   base.ui = { ...base.ui, ...cloned.ui };
   base.resources = { ...base.resources, ...cloned.resources };
-  base.foodPool = { ...base.foodPool, ...cloned.foodPool };
   base.buildings = { ...base.buildings, ...cloned.buildings };
   Object.values(base.buildings).forEach((b: any) => {
     if (typeof b.isDesiredOn !== 'boolean') b.isDesiredOn = true;
   });
   base.powerTypeOrder = buildInitialPowerTypeOrder(cloned.powerTypeOrder || []);
   base.research = { ...base.research, ...cloned.research };
+  const foodAmount = Object.keys(RESOURCES).reduce((sum, id) => {
+    if (RESOURCES[id].category === 'FOOD') {
+      return sum + (base.resources[id]?.amount || 0);
+    }
+    return sum;
+  }, 0);
+  const foodCapacity = getFoodCapacity(base);
+  base.foodPool = { amount: foodAmount, capacity: foodCapacity };
   base.population = { ...base.population, ...cloned.population };
   if (Array.isArray(cloned.population?.settlers)) {
     base.population.settlers = cloned.population.settlers.map((s: any) => ({


### PR DESCRIPTION
## Summary
- derive initial food pool from starting resources and capacity
- compute food pool when loading saved games
- cover food pool initialization in prepareLoadedState tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d2e6a0b3483318b92622dd7445a99