### PR TITLE
Add large storage buildings and pooled food capacity

### DIFF
--- a/docs/economy-snapshot.json
+++ b/docs/economy-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "version": "e412e0e8b37cb9b8933bf57d647d6e698fd6a0f1",
+  "version": "8a6d229320f1a7982a87555fff24acef870857b9",
   "saveVersion": 7,
   "tickSeconds": 1,
   "seasons": {
@@ -575,6 +575,34 @@
       }
     },
     {
+      "id": "largeGranary",
+      "name": "Large Granary",
+      "type": "storage",
+      "cost": {
+        "wood": 35,
+        "stone": 20,
+        "bricks": 20
+      },
+      "costGrowth": 1.15,
+      "refund": 0.5,
+      "storage": {
+        "FOOD": 600
+      },
+      "outputsPerSec": {},
+      "inputsPerSec": {},
+      "requiresResearch": "masonry2",
+      "seasonMults": {
+        "spring": 1,
+        "summer": 1,
+        "autumn": 1,
+        "winter": 1
+      },
+      "origin": {
+        "file": "buildings.js",
+        "path": "BUILDINGS[13]"
+      }
+    },
+    {
       "id": "rawStorage",
       "name": "Warehouse",
       "type": "storage",
@@ -601,7 +629,37 @@
       },
       "origin": {
         "file": "buildings.js",
-        "path": "BUILDINGS[13]"
+        "path": "BUILDINGS[14]"
+      }
+    },
+    {
+      "id": "largeWarehouse",
+      "name": "Large Warehouse",
+      "type": "storage",
+      "cost": {
+        "wood": 40,
+        "stone": 30,
+        "bricks": 20
+      },
+      "costGrowth": 1.15,
+      "refund": 0.5,
+      "storage": {
+        "wood": 400,
+        "stone": 160,
+        "scrap": 240
+      },
+      "outputsPerSec": {},
+      "inputsPerSec": {},
+      "requiresResearch": "masonry2",
+      "seasonMults": {
+        "spring": 1,
+        "summer": 1,
+        "autumn": 1,
+        "winter": 1
+      },
+      "origin": {
+        "file": "buildings.js",
+        "path": "BUILDINGS[15]"
       }
     },
     {
@@ -630,7 +688,37 @@
       },
       "origin": {
         "file": "buildings.js",
-        "path": "BUILDINGS[14]"
+        "path": "BUILDINGS[16]"
+      }
+    },
+    {
+      "id": "largeMaterialsDepot",
+      "name": "Large Materials Depot",
+      "type": "storage",
+      "cost": {
+        "wood": 35,
+        "bricks": 25,
+        "scrap": 15
+      },
+      "costGrowth": 1.15,
+      "refund": 0.5,
+      "storage": {
+        "planks": 180,
+        "metalParts": 90,
+        "bricks": 180
+      },
+      "outputsPerSec": {},
+      "inputsPerSec": {},
+      "requiresResearch": "masonry2",
+      "seasonMults": {
+        "spring": 1,
+        "summer": 1,
+        "autumn": 1,
+        "winter": 1
+      },
+      "origin": {
+        "file": "buildings.js",
+        "path": "BUILDINGS[17]"
       }
     },
     {
@@ -659,7 +747,7 @@
       },
       "origin": {
         "file": "buildings.js",
-        "path": "BUILDINGS[15]"
+        "path": "BUILDINGS[18]"
       }
     }
   ],

--- a/src/data/buildings.js
+++ b/src/data/buildings.js
@@ -163,6 +163,19 @@ export const BUILDINGS = [
     description: 'Increases storage for harvested crops.',
   },
   {
+    id: 'largeGranary',
+    name: 'Large Granary',
+    domain: 'STORAGE',
+    type: 'storage',
+    requiresResearch: 'masonry2',
+    costBase: { wood: 35, stone: 20, bricks: 20 },
+    costGrowth: 1.15,
+    refund: 0.5,
+    capacityAdd: { FOOD: 600 },
+    cardTextOverride: 'Food Capacity +600',
+    description: 'Increases total Food capacity across all food types.',
+  },
+  {
     id: 'rawStorage',
     name: 'Warehouse',
     type: 'storage',
@@ -171,6 +184,18 @@ export const BUILDINGS = [
     refund: 0.5,
     capacityAdd: { wood: 120, scrap: 80, stone: 60 }, // changed: wood 200->120, scrap 90->80, stone 80->60
     description: 'Increases storage for wood, stone and scrap.',
+  },
+  {
+    id: 'largeWarehouse',
+    name: 'Large Warehouse',
+    domain: 'STORAGE',
+    type: 'storage',
+    requiresResearch: 'masonry2',
+    costBase: { wood: 40, stone: 30, bricks: 20 },
+    costGrowth: 1.15,
+    refund: 0.5,
+    capacityAdd: { wood: 400, stone: 160, scrap: 240 },
+    description: 'Expanded storage for raw materials.',
   },
   {
     id: 'materialsDepot',
@@ -182,6 +207,18 @@ export const BUILDINGS = [
     refund: 0.5,
     capacityAdd: { planks: 100, metalParts: 40 }, // changed: planks 300->100, metalParts 240->40
     description: 'Stores processed construction materials.',
+  },
+  {
+    id: 'largeMaterialsDepot',
+    name: 'Large Materials Depot',
+    domain: 'STORAGE',
+    type: 'storage',
+    requiresResearch: 'masonry2',
+    costBase: { wood: 35, bricks: 25, scrap: 15 },
+    costGrowth: 1.15,
+    refund: 0.5,
+    capacityAdd: { planks: 180, metalParts: 90, bricks: 180 },
+    description: 'Expanded storage for processed construction materials.',
   },
   {
     id: 'battery',

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -35,12 +35,19 @@ export function getCapacity(state, resourceId) {
  * @param {GameState} state
  */
 export function getFoodCapacity(state) {
-  return Object.keys(RESOURCES).reduce((sum, id) => {
+  let total = Object.keys(RESOURCES).reduce((sum, id) => {
     if (RESOURCES[id].category === 'FOOD') {
       sum += getCapacity(state, id);
     }
     return sum;
   }, 0);
+  BUILDINGS.forEach((b) => {
+    const count = state.buildings?.[b.id]?.count || 0;
+    if (count > 0 && b.capacityAdd?.FOOD) {
+      total += b.capacityAdd.FOOD * count;
+    }
+  });
+  return total;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add Large Granary, Large Warehouse, and Large Materials Depot storage structures
- support category-wide FOOD capacity increases
- refresh economy snapshot

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 37 files)*
- `npm run report:economy --silent` *(fails: ERR_UNKNOWN_FILE_EXTENSION for clone.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689d2f563b1483318d271a4aef9eedee