### PR TITLE
Sync food pool with resource consumption

### DIFF
--- a/src/engine/settlers.js
+++ b/src/engine/settlers.js
@@ -120,9 +120,14 @@ export function processSettlersTick(
       entry.amount -= use;
       resources[id] = { ...entry };
       remaining -= use;
-      foodAmount -= use;
     }
   }
+
+  // Update food pool amount to match remaining food
+  foodAmount = foodIds.reduce(
+    (sum, id) => sum + (resources[id]?.amount || 0),
+    0,
+  );
 
   const finalFoodAmount = clampResource(foodAmount, foodCapacity);
   const overflow = foodAmount - finalFoodAmount;


### PR DESCRIPTION
## Summary
- Recalculate food pool after settlers consume food so pool amount reflects remaining resources
- Clamp food pool to its capacity after recalculation

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 37 files)*

------
https://chatgpt.com/codex/tasks/task_e_689d2f933ff88331bdd73d3eb542921a