### PR TITLE
Use food pool totals and card text for food capacity buildings

### DIFF
--- a/src/components/BuildingRow.jsx
+++ b/src/components/BuildingRow.jsx
@@ -41,6 +41,9 @@ export default function BuildingRow({
         ? 'grid-cols-2'
         : 'grid-cols-1';
 
+  const capacityEntries = Object.entries(building.capacityAdd || {});
+  const hasFoodCapacity = capacityEntries.some(([res]) => res === 'FOOD');
+
   return (
     <Container className="space-y-3 shadow-none">
       <div className="flex items-center justify-between">
@@ -131,12 +134,18 @@ export default function BuildingRow({
               <div>
                 <div className="text-xs font-medium">Increase:</div>
                 <div className="mt-2 flex flex-wrap gap-3 text-sm">
-                  {Object.entries(building.capacityAdd).map(([res, cap]) => (
-                    <span key={res} className="flex items-center gap-1">
-                      {RESOURCES[res].icon} +{formatAmount(cap)}{' '}
-                      {RESOURCES[res].name} capacity
-                    </span>
-                  ))}
+                  {hasFoodCapacity && building.cardTextOverride
+                    ? (
+                        <span className="flex items-center gap-1">
+                          {building.cardTextOverride}
+                        </span>
+                      )
+                    : capacityEntries.map(([res, cap]) => (
+                        <span key={res} className="flex items-center gap-1">
+                          {RESOURCES[res].icon} +{formatAmount(cap)}{' '}
+                          {RESOURCES[res].name} capacity
+                        </span>
+                      ))}
                 </div>
               </div>
             )

--- a/src/components/BuildingRow.test.jsx
+++ b/src/components/BuildingRow.test.jsx
@@ -1,38 +1,32 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
-import BuildingRow from './BuildingRowContainer.jsx';
-import { BUILDING_MAP } from '../data/buildings.js';
-import { GameContext } from '../state/useGame.tsx';
-import { defaultState } from '../state/defaultState.js';
+import { describe, it, expect } from 'vitest';
+import BuildingRow from './BuildingRow.jsx';
 
 describe('BuildingRow', () => {
-  it('shows capacity increase for storage buildings', () => {
-    const ctx = {
-      state: defaultState,
-      setState: vi.fn(),
-      setActiveTab: vi.fn(),
-      toggleDrawer: vi.fn(),
-      setSettlerRole: vi.fn(),
-      beginResearch: vi.fn(),
-      abortResearch: vi.fn(),
-      dismissOfflineModal: vi.fn(),
-      resetGame: vi.fn(),
-      loadError: false,
-      retryLoad: vi.fn(),
+  it('shows cardTextOverride for food capacity', () => {
+    const building = {
+      name: 'Granary',
+      description: 'Increases food storage.',
+      capacityAdd: { FOOD: 100 },
+      cardTextOverride: '+100 Food capacity',
     };
 
     render(
-      <GameContext.Provider value={ctx}>
-        <BuildingRow
-          building={BUILDING_MAP.foodStorage}
-          completedResearch={[]}
-        />
-      </GameContext.Provider>,
+      <BuildingRow
+        building={building}
+        costEntries={[]}
+        perOutputs={[]}
+        perInputs={[]}
+        canAfford
+        unlocked
+        onBuild={() => {}}
+        onDemolish={() => {}}
+        onToggle={() => {}}
+      />,
     );
 
     expect(screen.getByText('Increase:')).toBeTruthy();
-    expect(screen.getByText(/🍖 \+75 Meat capacity/)).toBeTruthy(); // changed: 150 -> 75
-    expect(screen.getByText(/🥔 \+150 Potatoes capacity/)).toBeTruthy(); // changed: 300 -> 150
+    expect(screen.getByText('+100 Food capacity')).toBeTruthy();
   });
 });

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -426,11 +426,8 @@ function buildResourceGroups(state, netRates, prodRates) {
  * @param {Record<string,{perSec:number,label:string}>} netRates
  */
 function createFoodTotalRow(state, foodIds, netRates) {
-  const totalAmount =
-    state.foodPool?.amount ??
-    foodIds.reduce((sum, id) => sum + (state.resources[id]?.amount || 0), 0);
-  const totalCapacity =
-    state.foodPool?.capacity ?? getFoodCapacity(state);
+  const totalAmount = state.foodPool?.amount || 0;
+  const totalCapacity = state.foodPool?.capacity || 0;
   const totalNetRate = foodIds.reduce(
     (sum, id) => sum + (netRates[id]?.perSec || 0),
     0,
@@ -438,7 +435,7 @@ function createFoodTotalRow(state, foodIds, netRates) {
   return {
     id: 'food-total',
     name: 'Total',
-    amount: state.foodPool?.amount ?? totalAmount,
+    amount: totalAmount,
     capacity: totalCapacity,
     rate: formatRate(totalNetRate),
   };


### PR DESCRIPTION
## Summary
- Show `cardTextOverride` when a building adds FOOD capacity
- Display total food capacity using `foodPool.capacity` and `foodPool.amount`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d2f9a332483318db8b071656c4590