### PR TITLE
Consolidate food storage capacity handling

### DIFF
--- a/src/components/BuildingRow.jsx
+++ b/src/components/BuildingRow.jsx
@@ -61,11 +61,12 @@ export default function BuildingRow({
               No Power
             </span>
           )}
-          {isDesiredOn && (resourceShortage || offlineReason === 'resources') && (
-            <span className="px-1 text-xs text-white bg-red-600 rounded">
-              No Resources
-            </span>
-          )}
+          {isDesiredOn &&
+            (resourceShortage || offlineReason === 'resources') && (
+              <span className="px-1 text-xs text-white bg-red-600 rounded">
+                No Resources
+              </span>
+            )}
         </div>
         <div className="space-x-2 flex items-center">
           <Switch checked={isDesiredOn} onCheckedChange={onToggle} />
@@ -131,12 +132,19 @@ export default function BuildingRow({
               <div>
                 <div className="text-xs font-medium">Increase:</div>
                 <div className="mt-2 flex flex-wrap gap-3 text-sm">
-                  {Object.entries(building.capacityAdd).map(([res, cap]) => (
-                    <span key={res} className="flex items-center gap-1">
-                      {RESOURCES[res].icon} +{formatAmount(cap)}{' '}
-                      {RESOURCES[res].name} capacity
-                    </span>
-                  ))}
+                  {building.cardTextOverride ? (
+                    <span>{building.cardTextOverride}</span>
+                  ) : (
+                    Object.entries(building.capacityAdd).map(([res, cap]) => {
+                      const resource = RESOURCES[res];
+                      return resource ? (
+                        <span key={res} className="flex items-center gap-1">
+                          {resource.icon} +{formatAmount(cap)} {resource.name}{' '}
+                          capacity
+                        </span>
+                      ) : null;
+                    })
+                  )}
                 </div>
               </div>
             )

--- a/src/components/BuildingRow.test.jsx
+++ b/src/components/BuildingRow.test.jsx
@@ -32,7 +32,6 @@ describe('BuildingRow', () => {
     );
 
     expect(screen.getByText('Increase:')).toBeTruthy();
-    expect(screen.getByText(/🍖 \+75 Meat capacity/)).toBeTruthy(); // changed: 150 -> 75
-    expect(screen.getByText(/🥔 \+150 Potatoes capacity/)).toBeTruthy(); // changed: 300 -> 150
+    expect(screen.getByText('Food Capacity +225')).toBeTruthy();
   });
 });

--- a/src/data/buildings.js
+++ b/src/data/buildings.js
@@ -174,7 +174,8 @@ export const BUILDINGS = [
     costBase: { wood: 20, scrap: 5, stone: 5 },
     costGrowth: 1.22, // changed: 1.2 -> 1.22
     refund: 0.5,
-    capacityAdd: { potatoes: 150, meat: 75 }, // changed: potatoes 300->150, meat 150->75
+    capacityAdd: { FOOD: 225 },
+    cardTextOverride: 'Food Capacity +225',
     description: 'Increases storage for harvested crops.',
   },
   {


### PR DESCRIPTION
## Summary
- Replace granular potato/meat capacity with unified FOOD capacity and add card text override on granary.
- Teach `BuildingRow` to display `cardTextOverride` or fall back to resource-based capacity icons.
- Update unit test for new food storage wording.

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 37 files)*
- `npm run typecheck` *(fails: multiple TS errors across repo)*
- `npm run report:economy` *(fails: Unknown file extension ".ts" for src/utils/clone.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689d2fa1fc388331b268cb2985ab65bb