### PR TITLE
Use fractional role bonuses

### DIFF
--- a/src/components/BuildingRow.test.jsx
+++ b/src/components/BuildingRow.test.jsx
@@ -8,8 +8,8 @@ describe('BuildingRow', () => {
     const building = {
       name: 'Granary',
       description: 'Increases food storage.',
-      capacityAdd: { FOOD: 100 },
-      cardTextOverride: '+100 Food capacity',
+      capacityAdd: { FOOD: 225 },
+      cardTextOverride: 'Food Capacity +225',
     };
 
     render(

--- a/src/engine/__tests__/settlers.test.js
+++ b/src/engine/__tests__/settlers.test.js
@@ -33,7 +33,7 @@ describe('settlers tick', () => {
       }
     });
     const bonusFoodPerSec =
-      totalFoodProdBase * ((roleBonuses['farmer'] || 0) / 100);
+      totalFoodProdBase * (roleBonuses['farmer'] || 0);
 
     const { state: final } = processSettlersTick(afterTick, 1, bonusFoodPerSec);
 

--- a/src/engine/offline.js
+++ b/src/engine/offline.js
@@ -23,7 +23,7 @@ export function applyOfflineProgress(state, elapsedSeconds, roleBonuses = {}) {
       }
     });
     const bonusFoodPerSec =
-      totalFoodProdBase * ((roleBonuses['farmer'] || 0) / 100);
+      totalFoodProdBase * (roleBonuses['farmer'] || 0);
     const settlersResult = processSettlersTick(
       current,
       1,

--- a/src/engine/production.js
+++ b/src/engine/production.js
@@ -109,13 +109,13 @@ export function applyProduction(state, seconds = 1, roleBonuses = {}) {
         mult = b.seasonProfile[season.id] ?? 1;
       else mult = getSeasonMultiplier(season, category);
       const role = ROLE_BY_RESOURCE[res];
-      const bonusPercent = roleBonuses[role] || 0;
+      const bonus = roleBonuses[role] || 0;
       const researchBonus = getResearchOutputBonus(state, res);
       const gain =
         base *
         mult *
         count *
-        (1 + bonusPercent / 100 + researchBonus) *
+        (1 + bonus + researchBonus) *
         seconds *
         capFactor;
       const currentEntry = resources[res] || { amount: 0, discovered: false };

--- a/src/engine/research.js
+++ b/src/engine/research.js
@@ -46,8 +46,8 @@ export function processResearchTick(state, seconds = 1, roleBonuses = {}) {
   if (!current) return state;
   const node = RESEARCH_MAP[current.id];
   const prev = state.research.progress[current.id] || 0;
-  const bonusPercent = roleBonuses['scientist'] || 0;
-  const next = prev + seconds * (1 + bonusPercent / 100);
+  const bonus = roleBonuses['scientist'] || 0;
+  const next = prev + seconds * (1 + bonus);
   const progress = { ...state.research.progress, [current.id]: next };
   if (next >= node.timeSec) {
     const completed = [...state.research.completed, current.id];

--- a/src/engine/settlers.js
+++ b/src/engine/settlers.js
@@ -16,7 +16,7 @@ export function computeRoleBonuses(settlers) {
   settlers.forEach((s) => {
     if (s.isDead || !s.role) return;
     const skill = s.skills?.[s.role] || { level: 0 };
-    const bonus = ROLE_BONUS_PER_SETTLER(skill.level) * 100; // TODO: bonus already fractional; remove ×100 in application
+    const bonus = ROLE_BONUS_PER_SETTLER(skill.level);
     bonuses[s.role] = (bonuses[s.role] || 0) + bonus;
   });
   return bonuses;
@@ -70,7 +70,7 @@ export function processSettlersTick(
 
   // Compute bonuses
   const bonuses = roleBonuses || computeRoleBonuses(living);
-  const totalFoodBonusPercent = bonuses['farmer'] || 0;
+  const totalFoodBonusPercent = (bonuses['farmer'] || 0) * 100;
 
   const bonusGainPerSec = bonusFoodPerSec;
   const totalSettlersConsumption =

--- a/src/state/hooks/__tests__/useGameTick.test.ts
+++ b/src/state/hooks/__tests__/useGameTick.test.ts
@@ -41,7 +41,7 @@ beforeEach(() => {
 
 describe('applyProduction', () => {
   it('calculates bonuses and adds farmer bonus after consumption', () => {
-    (computeRoleBonuses as any).mockReturnValue({ farmer: 10, builder: 5 });
+    (computeRoleBonuses as any).mockReturnValue({ farmer: 0.1, builder: 0.05 });
     (processTick as any).mockReturnValue('after');
     (processResearchTick as any).mockReturnValue({
       resources: { potatoes: { amount: 1, produced: 0, discovered: true } },
@@ -61,7 +61,7 @@ describe('applyProduction', () => {
     expect(processTick).toHaveBeenCalledWith(
       { population: { settlers: [] } },
       1,
-      { builder: 5 },
+      { builder: 0.05 },
     );
     expect(result).toEqual({
       state: {
@@ -69,13 +69,13 @@ describe('applyProduction', () => {
         population: { settlers: [] },
         foodPool: { amount: 1.2, capacity: 100 },
       },
-      roleBonuses: { farmer: 10, builder: 5 },
+      roleBonuses: { farmer: 0.1, builder: 0.05 },
       bonusFoodPerSec: 0.2,
     });
   });
 
   it('clamps bonus food to capacity', () => {
-    (computeRoleBonuses as any).mockReturnValue({ farmer: 100 });
+    (computeRoleBonuses as any).mockReturnValue({ farmer: 1 });
     (processTick as any).mockReturnValue('after');
     (processResearchTick as any).mockReturnValue({
       resources: { potatoes: { amount: 99.5, produced: 0, discovered: true } },

--- a/src/state/hooks/useGameTick.tsx
+++ b/src/state/hooks/useGameTick.tsx
@@ -28,7 +28,7 @@ export function applyProduction(prev: any, dt: number) {
       totalFoodProdBase += rates[id]?.perSec || 0;
     }
   });
-  const bonusFoodPerSec = totalFoodProdBase * (farmerBonus / 100);
+  const bonusFoodPerSec = totalFoodProdBase * farmerBonus;
 
   let state = withResearch;
   if (bonusFoodPerSec) {

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -50,7 +50,6 @@ export function getFoodPoolAmount(state) {
  * @param {GameState} state
  */
 export function getFoodPoolCapacity(state) {
-  if (state.foodPool?.capacity != null) return state.foodPool.capacity;
   let total = 0;
   Object.keys(RESOURCES).forEach((id) => {
     if (RESOURCES[id].category !== 'FOOD') return;
@@ -64,6 +63,12 @@ export function getFoodPoolCapacity(state) {
     });
     const bonus = getResearchStorageBonus(state, id);
     total += Math.floor((base + fromBuildings) * (1 + bonus));
+  });
+  BUILDINGS.forEach((b) => {
+    const count = state.buildings?.[b.id]?.count || 0;
+    if (count > 0 && b.capacityAdd?.FOOD) {
+      total += b.capacityAdd.FOOD * count;
+    }
   });
   return total;
 }
@@ -278,13 +283,13 @@ function aggregateBuildingRates(state, roleBonuses) {
           mult = b.seasonProfile[season.id] ?? 1;
         else mult = getSeasonMultiplier(season, category);
         const role = ROLE_BY_RESOURCE[res];
-        const bonusPercent = roleBonuses[role] || 0;
+        const bonus = roleBonuses[role] || 0;
         const researchBonus = getResearchOutputBonus(state, res);
         let gain =
           base *
           mult *
           count *
-          (1 + bonusPercent / 100 + researchBonus) *
+          (1 + bonus + researchBonus) *
           factor;
         if (category === 'FOOD') {
           const room = foodCapacity - totalFoodAmount;

--- a/src/views/PopulationView.jsx
+++ b/src/views/PopulationView.jsx
@@ -45,7 +45,7 @@ export default function PopulationView() {
               </CardTitle>
             </CardHeader>
             <CardContent className="p-0 text-lg font-semibold">
-              +{Math.round(bonuses[r.id] || 0)}%
+              +{Math.round((bonuses[r.id] || 0) * 100)}%
             </CardContent>
           </Card>
         ))}


### PR DESCRIPTION
## Summary
- Return fractional values from `computeRoleBonuses`
- Update production, research, offline progress and UI to handle fractions
- Fix food capacity calculation and update tests

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 41 files. Run Prettier with --write to fix.)*

------
https://chatgpt.com/codex/tasks/task_e_689d366868cc8331bc1fb7f474ada7ab