### PR TITLE
Pass role bonuses from settlers to production

### DIFF
--- a/src/state/hooks/useGameTick.tsx
+++ b/src/state/hooks/useGameTick.tsx
@@ -12,8 +12,7 @@ import {
 import { updateRadio } from '../../engine/radio.js';
 import { getYear, DAYS_PER_YEAR } from '../../engine/time.js';
 
-export function applyProduction(prev: any, dt: number) {
-  const roleBonuses = computeRoleBonuses(prev.population?.settlers || []);
+export function applyProduction(prev: any, dt: number, roleBonuses: any) {
   const productionBonuses = { ...roleBonuses };
   const farmerBonus = productionBonuses.farmer || 0;
   delete productionBonuses.farmer;
@@ -62,7 +61,9 @@ export function applyProduction(prev: any, dt: number) {
 }
 
 export function applySettlers(state: any, dt: number, rng = Math.random) {
-  return processSettlersTick(state, dt, 0, rng, null);
+  const roleBonuses = computeRoleBonuses(state.population?.settlers || []);
+  const result = processSettlersTick(state, dt, 0, rng, roleBonuses);
+  return { ...result, roleBonuses };
 }
 
 export function applyYearUpdate(state: any, dt: number, telemetry: any) {
@@ -100,11 +101,15 @@ export function applyYearUpdate(state: any, dt: number, telemetry: any) {
 export default function useGameTick(setState: Dispatch<SetStateAction<any>>) {
   useGameLoop((dt) => {
     setState((prev) => {
-      const { state: settlersProcessed, telemetry } = applySettlers(prev, dt);
+      const {
+        state: settlersProcessed,
+        telemetry,
+        roleBonuses,
+      } = applySettlers(prev, dt);
       const {
         state: withProduction,
         bonusFoodPerSec,
-      } = applyProduction(settlersProcessed, dt);
+      } = applyProduction(settlersProcessed, dt, roleBonuses);
       const updatedTelemetry = {
         ...telemetry,
         bonusFoodPerSec,


### PR DESCRIPTION
## Summary
- compute role bonuses in `applySettlers` and return them
- accept precomputed bonuses in `applyProduction`
- update hook and tests to pass bonuses through once

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 41 files)*

------
https://chatgpt.com/codex/tasks/task_e_689d390a0da08331a633dc258e217907