### PR TITLE
Normalize happiness threshold checks

### DIFF
--- a/src/state/hooks/__tests__/useNotifications.test.tsx
+++ b/src/state/hooks/__tests__/useNotifications.test.tsx
@@ -257,4 +257,24 @@ describe('useNotifications', () => {
       description: 'Happiness increased above 50%',
     });
   });
+
+  it('does not toast for minor happiness fluctuations', () => {
+    const high = {
+      research: { current: null, completed: [] },
+      resources: {},
+      population: { candidate: null, settlers: [] },
+      buildings: {},
+      colony: { happiness: { value: 50.0001 } },
+    };
+    const low = {
+      research: { current: null, completed: [] },
+      resources: {},
+      population: { candidate: null, settlers: [] },
+      buildings: {},
+      colony: { happiness: { value: 49.9999 } },
+    };
+    const { rerender } = render(<Wrapper state={high} />);
+    rerender(<Wrapper state={low} />);
+    expect(toast).not.toHaveBeenCalled();
+  });
 });

--- a/src/state/hooks/useNotifications.tsx
+++ b/src/state/hooks/useNotifications.tsx
@@ -1,9 +1,4 @@
-import {
-  useEffect,
-  useRef,
-  type Dispatch,
-  type SetStateAction,
-} from 'react';
+import { useEffect, useRef, type Dispatch, type SetStateAction } from 'react';
 import { RESEARCH_MAP } from '../../data/research.js';
 import { RESOURCES } from '../../data/resources.js';
 import { BUILDING_MAP } from '../../data/buildings.js';
@@ -110,7 +105,8 @@ export default function useNotifications(
         resourceShortageNotified.current.add(id);
       }
       if (currReason !== 'power') powerNotified.current.delete(id);
-      if (currReason !== 'resources') resourceShortageNotified.current.delete(id);
+      if (currReason !== 'resources')
+        resourceShortageNotified.current.delete(id);
     });
 
     Object.entries(state.resources).forEach(([id, res]) => {
@@ -133,11 +129,13 @@ export default function useNotifications(
 
     const prevHappy = prev.colony?.happiness?.value || 0;
     const currHappy = state.colony?.happiness?.value || 0;
-    if (prevHappy >= 50 && currHappy < 50) {
+    const prevHappyRounded = Math.round(prevHappy);
+    const currHappyRounded = Math.round(currHappy);
+    if (prevHappyRounded >= 50 && currHappyRounded < 50) {
       const msg = 'Happiness dropped below 50%';
       toast({ description: msg });
       addLog(msg);
-    } else if (prevHappy < 50 && currHappy >= 50) {
+    } else if (prevHappyRounded < 50 && currHappyRounded >= 50) {
       const msg = 'Happiness increased above 50%';
       toast({ description: msg });
       addLog(msg);


### PR DESCRIPTION
## Summary
- round happiness values before comparing to 50 to avoid noise-triggered alerts
- test that tiny happiness fluctuations do not emit notifications

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 41 files. Run Prettier with --write to fix.)*


------
https://chatgpt.com/codex/tasks/task_e_689d3924859083318cc823249d92ca0d