### PR TITLE
refactor: centralize food capacity calculation

### DIFF
--- a/src/engine/__tests__/economy.test.js
+++ b/src/engine/__tests__/economy.test.js
@@ -6,7 +6,7 @@ import { BUILDING_MAP, getBuildingCost } from '../../data/buildings.js';
 import { SEASON_DURATION } from '../time.js';
 import { deepClone } from '../../utils/clone.ts';
 import { BALANCE } from '../../data/balance.js';
-import { getFoodCapacity } from '../../state/selectors.js';
+import { calculateFoodCapacity } from '../../state/selectors.js';
 
 describe('economy basics', () => {
   test('spring potato field output', () => {
@@ -105,7 +105,7 @@ describe('economy basics', () => {
   test('food pool capacity shared across food types', () => {
     const state = deepClone(defaultState);
     state.buildings.potatoField.count = 1;
-    const cap = getFoodCapacity(state);
+    const cap = calculateFoodCapacity(state);
     state.resources.meat.amount = cap - 0.1;
     state.resources.potatoes.amount = 0;
     state.foodPool = { amount: cap - 0.1, capacity: cap };
@@ -116,7 +116,7 @@ describe('economy basics', () => {
 
   test('settlers consume from multiple food resources', () => {
     const state = deepClone(defaultState);
-    const cap = getFoodCapacity(state);
+    const cap = calculateFoodCapacity(state);
     state.resources.potatoes.amount = 0.3;
     state.resources.meat.amount = 1;
     state.foodPool = { amount: 1.3, capacity: cap };

--- a/src/engine/production.js
+++ b/src/engine/production.js
@@ -12,7 +12,7 @@ import {
 import { getSeason, getSeasonMultiplier } from './time.js';
 import {
   getCapacity,
-  getFoodCapacity,
+  calculateFoodCapacity,
   getResearchOutputBonus,
 } from '../state/selectors.js';
 import { clampResource } from './resources.js';
@@ -69,7 +69,8 @@ export function applyProduction(state, seconds = 1, roleBonuses = {}) {
           : 0),
       0,
     );
-  const foodCapacity = state.foodPool?.capacity ?? getFoodCapacity(state);
+  const foodCapacity =
+    state.foodPool?.capacity ?? calculateFoodCapacity(state);
 
   const active = PRODUCTION_BUILDINGS.filter((b) => {
     const entry = state.buildings?.[b.id];

--- a/src/engine/settlers.js
+++ b/src/engine/settlers.js
@@ -5,7 +5,7 @@ import {
   FOOD_VARIETY_BONUS,
   XP_MULTIPLIER_FROM_HAPPINESS,
 } from '../data/balance.js';
-import { getFoodCapacity, getSettlerCapacity } from '../state/selectors.js';
+import { calculateFoodCapacity, getSettlerCapacity } from '../state/selectors.js';
 import { SECONDS_PER_DAY } from './time.js';
 import { RESOURCES } from '../data/resources.js';
 import { clampResource } from './resources.js';
@@ -78,7 +78,8 @@ export function processSettlersTick(
   // Final food change per second after bonuses and consumption
   const netFoodPerSec = bonusGainPerSec - totalSettlersConsumption;
 
-  const foodCapacity = state.foodPool?.capacity ?? getFoodCapacity(state);
+  const foodCapacity =
+    state.foodPool?.capacity ?? calculateFoodCapacity(state);
   let foodAmount =
     state.foodPool?.amount ??
     Object.keys(state.resources).reduce(

--- a/src/state/__tests__/prepareLoadedState.test.js
+++ b/src/state/__tests__/prepareLoadedState.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { prepareLoadedState } from '../prepareLoadedState.ts';
 import { defaultState } from '../defaultState.js';
 import { deepClone } from '../../utils/clone.ts';
-import { getFoodCapacity } from '../selectors.js';
+import { calculateFoodCapacity } from '../selectors.js';
 
 // Test that offline gains produce log entries
 
@@ -46,6 +46,6 @@ describe('prepareLoadedState', () => {
     };
     const state = prepareLoadedState(loaded);
     expect(state.foodPool.amount).toBe(15);
-    expect(state.foodPool.capacity).toBe(getFoodCapacity(state));
+    expect(state.foodPool.capacity).toBe(calculateFoodCapacity(state));
   });
 });

--- a/src/state/__tests__/selectors.test.js
+++ b/src/state/__tests__/selectors.test.js
@@ -3,7 +3,7 @@ import {
   getResourceRates,
   getResourceSections,
   getPowerStatus,
-  getFoodCapacity,
+  calculateFoodCapacity,
   getCapacity,
 
 } from '../selectors.js';
@@ -76,12 +76,12 @@ describe('capacity calculations', () => {
     expect(getCapacity(state, 'planks')).toBe(140);
   });
 
-  it('getFoodCapacity sums base and storage', () => {
+  it('calculateFoodCapacity sums base and storage', () => {
     const state = deepClone(defaultState);
-    const base = getFoodCapacity(state);
+    const base = calculateFoodCapacity(state);
     expect(base).toBe(300);
     state.buildings.foodStorage = { count: 1 };
-    expect(getFoodCapacity(state)).toBe(525);
+    expect(calculateFoodCapacity(state)).toBe(525);
 
   });
 });

--- a/src/state/defaultState.js
+++ b/src/state/defaultState.js
@@ -5,7 +5,7 @@ import { buildInitialPowerTypeOrder } from '../engine/power.js';
 import { makeRandomSettler } from '../data/names.js';
 import { RADIO_BASE_SECONDS } from '../data/settlement.js';
 import { BALANCE } from '../data/balance.js';
-import { getFoodCapacity } from './selectors.js';
+import { calculateFoodCapacity } from './selectors.js';
 
 const initResources = () => {
   const obj = {};
@@ -47,7 +47,7 @@ const initFoodPool = () => {
       amount += resources[r.id]?.amount || 0;
     }
   });
-  const capacity = getFoodCapacity({ resources, buildings });
+  const capacity = calculateFoodCapacity({ resources, buildings });
   return { amount, capacity };
 };
 

--- a/src/state/hooks/__tests__/useGameTick.test.ts
+++ b/src/state/hooks/__tests__/useGameTick.test.ts
@@ -12,7 +12,7 @@ vi.mock('../../../engine/settlers.js', () => ({
 }));
 vi.mock('../../selectors.js', () => ({
   getResourceRates: vi.fn(),
-  getFoodCapacity: vi.fn(),
+  calculateFoodCapacity: vi.fn(),
 }));
 vi.mock('../../../data/resources.js', () => ({
   RESOURCES: {},
@@ -29,7 +29,7 @@ import { applyProduction, applySettlers, applyYearUpdate } from '../useGameTick'
 import { processTick } from '../../../engine/production.js';
 import { processResearchTick } from '../../../engine/research.js';
 import { processSettlersTick, computeRoleBonuses } from '../../../engine/settlers.js';
-import { getResourceRates, getFoodCapacity } from '../../selectors.js';
+import { getResourceRates, calculateFoodCapacity } from '../../selectors.js';
 import { updateRadio } from '../../../engine/radio.js';
 import { getYear, DAYS_PER_YEAR } from '../../../engine/time.js';
 import { RESOURCES } from '../../../data/resources.js';
@@ -52,7 +52,7 @@ describe('applyProduction', () => {
       potatoes: { perSec: 2 },
       metal: { perSec: 4 },
     });
-    (getFoodCapacity as any).mockReturnValue(100);
+    (calculateFoodCapacity as any).mockReturnValue(100);
     (RESOURCES as any).potatoes = { category: 'FOOD' };
     (RESOURCES as any).metal = { category: 'METAL' };
 
@@ -85,7 +85,7 @@ describe('applyProduction', () => {
     (getResourceRates as any).mockReturnValue({
       potatoes: { perSec: 1 },
     });
-    (getFoodCapacity as any).mockReturnValue(100);
+    (calculateFoodCapacity as any).mockReturnValue(100);
     (RESOURCES as any).potatoes = { category: 'FOOD' };
 
     const result = applyProduction({ population: { settlers: [] } }, 1);

--- a/src/state/hooks/useGameTick.tsx
+++ b/src/state/hooks/useGameTick.tsx
@@ -3,7 +3,7 @@ import { Dispatch, SetStateAction } from 'react';
 import useGameLoop from '../../engine/useGameLoop.tsx';
 import { processTick } from '../../engine/production.js';
 import { processResearchTick } from '../../engine/research.js';
-import { getResourceRates, getFoodCapacity } from '../selectors.js';
+import { getResourceRates, calculateFoodCapacity } from '../selectors.js';
 import { RESOURCES } from '../../data/resources.js';
 import {
   processSettlersTick,
@@ -32,7 +32,7 @@ export function applyProduction(prev: any, dt: number) {
 
   let state = withResearch;
   if (bonusFoodPerSec) {
-    const foodCapacity = getFoodCapacity(withResearch);
+    const foodCapacity = calculateFoodCapacity(withResearch);
     const currentPool = withResearch.foodPool?.amount || 0;
     const room = Math.max(0, foodCapacity - currentPool);
     const bonusGain = Math.min(bonusFoodPerSec * dt, room);

--- a/src/state/prepareLoadedState.ts
+++ b/src/state/prepareLoadedState.ts
@@ -7,7 +7,7 @@ import { RESOURCES } from '../data/resources.js';
 import { formatAmount } from '../utils/format.js';
 import { buildInitialPowerTypeOrder } from '../engine/power.js';
 import { deepClone } from '../utils/clone.ts';
-import { getFoodCapacity } from './selectors.js';
+import { calculateFoodCapacity } from './selectors.js';
 
 /* eslint-disable-next-line react-refresh/only-export-components */
 export function prepareLoadedState(loaded: any) {
@@ -34,7 +34,7 @@ export function prepareLoadedState(loaded: any) {
     }
     return sum;
   }, 0);
-  const foodCapacity = getFoodCapacity(base);
+  const foodCapacity = calculateFoodCapacity(base);
   base.foodPool = { amount: foodAmount, capacity: foodCapacity };
   base.population = { ...base.population, ...cloned.population };
   if (Array.isArray(cloned.population?.settlers)) {

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -49,7 +49,7 @@ export function getFoodPoolAmount(state) {
 /**
  * @param {GameState} state
  */
-export function getFoodPoolCapacity(state) {
+export function calculateFoodCapacity(state) {
   let total = 0;
   Object.keys(RESOURCES).forEach((id) => {
     if (RESOURCES[id].category !== 'FOOD') return;
@@ -71,13 +71,6 @@ export function getFoodPoolCapacity(state) {
     }
   });
   return total;
-}
-
-/**
- * @param {GameState} state
- */
-export function getFoodCapacity(state) {
-  return getFoodPoolCapacity(state);
 }
 
 /**
@@ -205,7 +198,8 @@ function aggregateBuildingRates(state, roleBonuses) {
         sum + (RESOURCES[id].category === 'FOOD' ? resources[id] : 0),
       0,
     );
-  const foodCapacity = state.foodPool?.capacity ?? getFoodCapacity(state);
+  const foodCapacity =
+    state.foodPool?.capacity ?? calculateFoodCapacity(state);
   PRODUCTION_BUILDINGS.forEach((b) => {
     const entry = state.buildings?.[b.id];
     const count = entry?.count || 0;


### PR DESCRIPTION
## Summary
- add `calculateFoodCapacity` selector to compute total food storage
- update state initialization, game tick logic, production, and settlers to use `calculateFoodCapacity`
- remove `getFoodPoolCapacity` and `getFoodCapacity` duplicates and adjust tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d39ff5a4c8331ad9ec0fe497578c5