### PR TITLE
refactor: move game tick logic into engine

### DIFF
--- a/src/engine/__tests__/gameTick.test.ts
+++ b/src/engine/__tests__/gameTick.test.ts
@@ -1,38 +1,38 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('../../../engine/production.js', () => ({
+vi.mock('../production.js', () => ({
   processTick: vi.fn(),
 }));
-vi.mock('../../../engine/research.js', () => ({
+vi.mock('../research.js', () => ({
   processResearchTick: vi.fn(),
 }));
-vi.mock('../../../engine/settlers.js', () => ({
+vi.mock('../settlers.js', () => ({
   processSettlersTick: vi.fn(),
   computeRoleBonuses: vi.fn(),
 }));
-vi.mock('../../selectors.js', () => ({
+vi.mock('../../state/selectors.js', () => ({
   getResourceRates: vi.fn(),
   calculateFoodCapacity: vi.fn(),
 }));
-vi.mock('../../../data/resources.js', () => ({
+vi.mock('../../data/resources.js', () => ({
   RESOURCES: {},
 }));
-vi.mock('../../../engine/radio.js', () => ({
+vi.mock('../radio.js', () => ({
   updateRadio: vi.fn(),
 }));
-vi.mock('../../../engine/time.js', () => ({
+vi.mock('../time.js', () => ({
   getYear: vi.fn(),
   DAYS_PER_YEAR: 365,
 }));
 
-import { applyProduction, applySettlers, applyYearUpdate } from '../useGameTick';
-import { processTick } from '../../../engine/production.js';
-import { processResearchTick } from '../../../engine/research.js';
-import { processSettlersTick, computeRoleBonuses } from '../../../engine/settlers.js';
-import { getResourceRates, calculateFoodCapacity } from '../../selectors.js';
-import { updateRadio } from '../../../engine/radio.js';
-import { getYear, DAYS_PER_YEAR } from '../../../engine/time.js';
-import { RESOURCES } from '../../../data/resources.js';
+import { applyProduction, applySettlers, applyYearUpdate } from '../gameTick.ts';
+import { processTick } from '../production.js';
+import { processResearchTick } from '../research.js';
+import { processSettlersTick, computeRoleBonuses } from '../settlers.js';
+import { getResourceRates, calculateFoodCapacity } from '../../state/selectors.js';
+import { updateRadio } from '../radio.js';
+import { getYear, DAYS_PER_YEAR } from '../time.js';
+import { RESOURCES } from '../../data/resources.js';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -144,4 +144,3 @@ describe('applyYearUpdate', () => {
     expect(result.meta?.telemetry?.settlers).toBe(telemetry);
   });
 });
-

--- a/src/engine/gameTick.ts
+++ b/src/engine/gameTick.ts
@@ -1,0 +1,95 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { processTick } from './production.js';
+import { processResearchTick } from './research.js';
+import { getResourceRates, calculateFoodCapacity } from '../state/selectors.js';
+import { RESOURCES } from '../data/resources.js';
+import { processSettlersTick, computeRoleBonuses } from './settlers.js';
+import { updateRadio } from './radio.js';
+import { getYear, DAYS_PER_YEAR } from './time.js';
+
+export function applyProduction(prev: any, dt: number, roleBonuses: any) {
+  const productionBonuses = { ...roleBonuses };
+  const farmerBonus = productionBonuses.farmer || 0;
+  delete productionBonuses.farmer;
+
+  const afterTick = processTick(prev, dt, productionBonuses);
+  const withResearch = processResearchTick(afterTick, dt, roleBonuses);
+
+  const rates = getResourceRates(withResearch);
+  let totalFoodProdBase = 0;
+  Object.keys(RESOURCES).forEach((id) => {
+    if (RESOURCES[id].category === 'FOOD') {
+      totalFoodProdBase += rates[id]?.perSec || 0;
+    }
+  });
+  const bonusFoodPerSec = totalFoodProdBase * farmerBonus;
+
+  let state = withResearch;
+  if (bonusFoodPerSec) {
+    const foodCapacity = calculateFoodCapacity(withResearch);
+    const currentPool = withResearch.foodPool?.amount || 0;
+    const room = Math.max(0, foodCapacity - currentPool);
+    const bonusGain = Math.min(bonusFoodPerSec * dt, room);
+    if (bonusGain > 0) {
+      const currentEntry = withResearch.resources?.potatoes || {
+        amount: 0,
+        discovered: false,
+        produced: 0,
+      };
+      const nextAmount = currentEntry.amount + bonusGain;
+      state = {
+        ...withResearch,
+        resources: {
+          ...withResearch.resources,
+          potatoes: {
+            ...currentEntry,
+            amount: nextAmount,
+            discovered: currentEntry.discovered || nextAmount > 0,
+          },
+        },
+        foodPool: { amount: currentPool + bonusGain, capacity: foodCapacity },
+      };
+    }
+  }
+
+  return { state, roleBonuses, bonusFoodPerSec };
+}
+
+export function applySettlers(state: any, dt: number, rng = Math.random) {
+  const roleBonuses = computeRoleBonuses(state.population?.settlers || []);
+  const result = processSettlersTick(state, dt, 0, rng, roleBonuses);
+  return { ...result, roleBonuses };
+}
+
+export function applyYearUpdate(state: any, dt: number, telemetry: any) {
+  const { candidate, radioTimer } = updateRadio(state, dt);
+  const nextSeconds = (state.gameTime?.seconds || 0) + dt;
+  const computedYear = getYear({
+    ...state,
+    gameTime: { ...state.gameTime, seconds: nextSeconds },
+  });
+  let year = state.gameTime?.year || 1;
+  let settlers = state.population.settlers;
+  if (computedYear > year) {
+    const diff = computedYear - year;
+    year = computedYear;
+    settlers = settlers.map((s: any) => ({
+      ...s,
+      ageDays: (s.ageDays || 0) + diff * DAYS_PER_YEAR,
+    }));
+  }
+  return {
+    ...state,
+    population: { ...state.population, settlers, candidate },
+    colony: { ...state.colony, radioTimer },
+    gameTime: { seconds: nextSeconds, year },
+    meta: {
+      ...state.meta,
+      telemetry: {
+        ...state.meta?.telemetry,
+        settlers: telemetry,
+      },
+    },
+  };
+}
+

--- a/src/state/hooks/useGameTick.tsx
+++ b/src/state/hooks/useGameTick.tsx
@@ -1,102 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Dispatch, SetStateAction } from 'react';
 import useGameLoop from '../../engine/useGameLoop.tsx';
-import { processTick } from '../../engine/production.js';
-import { processResearchTick } from '../../engine/research.js';
-import { getResourceRates, calculateFoodCapacity } from '../selectors.js';
-import { RESOURCES } from '../../data/resources.js';
 import {
-  processSettlersTick,
-  computeRoleBonuses,
-} from '../../engine/settlers.js';
-import { updateRadio } from '../../engine/radio.js';
-import { getYear, DAYS_PER_YEAR } from '../../engine/time.js';
-
-export function applyProduction(prev: any, dt: number, roleBonuses: any) {
-  const productionBonuses = { ...roleBonuses };
-  const farmerBonus = productionBonuses.farmer || 0;
-  delete productionBonuses.farmer;
-
-  const afterTick = processTick(prev, dt, productionBonuses);
-  const withResearch = processResearchTick(afterTick, dt, roleBonuses);
-
-  const rates = getResourceRates(withResearch);
-  let totalFoodProdBase = 0;
-  Object.keys(RESOURCES).forEach((id) => {
-    if (RESOURCES[id].category === 'FOOD') {
-      totalFoodProdBase += rates[id]?.perSec || 0;
-    }
-  });
-  const bonusFoodPerSec = totalFoodProdBase * farmerBonus;
-
-  let state = withResearch;
-  if (bonusFoodPerSec) {
-    const foodCapacity = calculateFoodCapacity(withResearch);
-    const currentPool = withResearch.foodPool?.amount || 0;
-    const room = Math.max(0, foodCapacity - currentPool);
-    const bonusGain = Math.min(bonusFoodPerSec * dt, room);
-    if (bonusGain > 0) {
-      const currentEntry = withResearch.resources?.potatoes || {
-        amount: 0,
-        discovered: false,
-        produced: 0,
-      };
-      const nextAmount = currentEntry.amount + bonusGain;
-      state = {
-        ...withResearch,
-        resources: {
-          ...withResearch.resources,
-          potatoes: {
-            ...currentEntry,
-            amount: nextAmount,
-            discovered: currentEntry.discovered || nextAmount > 0,
-          },
-        },
-        foodPool: { amount: currentPool + bonusGain, capacity: foodCapacity },
-      };
-    }
-  }
-
-  return { state, roleBonuses, bonusFoodPerSec };
-}
-
-export function applySettlers(state: any, dt: number, rng = Math.random) {
-  const roleBonuses = computeRoleBonuses(state.population?.settlers || []);
-  const result = processSettlersTick(state, dt, 0, rng, roleBonuses);
-  return { ...result, roleBonuses };
-}
-
-export function applyYearUpdate(state: any, dt: number, telemetry: any) {
-  const { candidate, radioTimer } = updateRadio(state, dt);
-  const nextSeconds = (state.gameTime?.seconds || 0) + dt;
-  const computedYear = getYear({
-    ...state,
-    gameTime: { ...state.gameTime, seconds: nextSeconds },
-  });
-  let year = state.gameTime?.year || 1;
-  let settlers = state.population.settlers;
-  if (computedYear > year) {
-    const diff = computedYear - year;
-    year = computedYear;
-    settlers = settlers.map((s: any) => ({
-      ...s,
-      ageDays: (s.ageDays || 0) + diff * DAYS_PER_YEAR,
-    }));
-  }
-  return {
-    ...state,
-    population: { ...state.population, settlers, candidate },
-    colony: { ...state.colony, radioTimer },
-    gameTime: { seconds: nextSeconds, year },
-    meta: {
-      ...state.meta,
-      telemetry: {
-        ...state.meta?.telemetry,
-        settlers: telemetry,
-      },
-    },
-  };
-}
+  applyProduction,
+  applySettlers,
+  applyYearUpdate,
+} from '../../engine/gameTick.ts';
 
 export default function useGameTick(setState: Dispatch<SetStateAction<any>>) {
   useGameLoop((dt) => {


### PR DESCRIPTION
## Summary
- extract tick-processing functions into `src/engine/gameTick.ts`
- slim `useGameTick` hook to scheduling and state updates
- move and update unit tests to target new pure functions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d3b8f518c833180879a2730843f22