### PR TITLE
Normalize happiness threshold handling

### DIFF
--- a/src/state/hooks/__tests__/useNotifications.test.tsx
+++ b/src/state/hooks/__tests__/useNotifications.test.tsx
@@ -277,4 +277,24 @@ describe('useNotifications', () => {
     rerender(<Wrapper state={low} />);
     expect(toast).not.toHaveBeenCalled();
   });
+
+  it('does not toast when happiness stays below 50%', () => {
+    const lower = {
+      research: { current: null, completed: [] },
+      resources: {},
+      population: { candidate: null, settlers: [] },
+      buildings: {},
+      colony: { happiness: { value: 49.4 } },
+    };
+    const slightlyHigher = {
+      research: { current: null, completed: [] },
+      resources: {},
+      population: { candidate: null, settlers: [] },
+      buildings: {},
+      colony: { happiness: { value: 49.6 } },
+    };
+    const { rerender } = render(<Wrapper state={lower} />);
+    rerender(<Wrapper state={slightlyHigher} />);
+    expect(toast).not.toHaveBeenCalled();
+  });
 });

--- a/src/state/hooks/useNotifications.tsx
+++ b/src/state/hooks/useNotifications.tsx
@@ -129,13 +129,14 @@ export default function useNotifications(
 
     const prevHappy = prev.colony?.happiness?.value || 0;
     const currHappy = state.colony?.happiness?.value || 0;
-    const prevHappyRounded = Math.round(prevHappy);
-    const currHappyRounded = Math.round(currHappy);
-    if (prevHappyRounded >= 50 && currHappyRounded < 50) {
+    const normalize = (v: number): number => Math.round(v * 100) / 100;
+    const prevHappyNormalized = normalize(prevHappy);
+    const currHappyNormalized = normalize(currHappy);
+    if (prevHappyNormalized >= 50 && currHappyNormalized < 50) {
       const msg = 'Happiness dropped below 50%';
       toast({ description: msg });
       addLog(msg);
-    } else if (prevHappyRounded < 50 && currHappyRounded >= 50) {
+    } else if (prevHappyNormalized < 50 && currHappyNormalized >= 50) {
       const msg = 'Happiness increased above 50%';
       toast({ description: msg });
       addLog(msg);


### PR DESCRIPTION
## Summary
- Normalize happiness values to two decimals before threshold comparison
- Add regression test ensuring sub-50% fluctuations don't trigger toasts

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 39 files)*

------
https://chatgpt.com/codex/tasks/task_e_689d3c180ab88331802f21bcd839cf2e