### PR TITLE
Allow injecting RNG

### DIFF
--- a/docs/ECONOMY_REPORT.md
+++ b/docs/ECONOMY_REPORT.md
@@ -1,7 +1,7 @@
 # Economy Report
 
 ## 1) Overview
-Economy generated from commit **3e16fe7f83c545b4bb1e6f98364f6f8dbdf154da** on 2025-08-14 03:33:59 +0200. Save version: **7**.
+Economy generated from commit **4cfa11f4a328e554d2317b78e8d24cc3c0616ad3** on 2025-08-14 09:33:20 +0200. Save version: **7**.
 Each tick represents 1 second. For each building: base production is modified by season multipliers, summed, then clamped to capacity. Offline progress processes in 60-second chunks.
 
 ## 2) Resources

--- a/docs/economy-snapshot.json
+++ b/docs/economy-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "version": "3e16fe7f83c545b4bb1e6f98364f6f8dbdf154da",
+  "version": "4cfa11f4a328e554d2317b78e8d24cc3c0616ad3",
   "saveVersion": 7,
   "tickSeconds": 1,
   "seasons": {

--- a/src/components/__tests__/ResourceRow.test.jsx
+++ b/src/components/__tests__/ResourceRow.test.jsx
@@ -9,13 +9,18 @@ import { BALANCE } from '../../data/balance.js';
 
 describe('ResourceRow', () => {
   it('shows capacity when amount is within epsilon of cap', () => {
+    const createRng = (seed = 1) => () => {
+      seed = (seed * 16807) % 2147483647;
+      return (seed - 1) / 2147483646;
+    };
+    const rng = createRng();
     const state = deepClone(defaultState);
     const cap = 200;
     state.resources.potatoes.amount = cap;
     state.foodPool = { amount: cap, capacity: cap };
     state.population.settlers = [{ id: 's1' }];
     const bonusPerSec = BALANCE.FOOD_CONSUMPTION_PER_SETTLER + 0.1;
-    const { state: next } = processSettlersTick(state, 1, bonusPerSec);
+    const { state: next } = processSettlersTick(state, 1, bonusPerSec, rng);
     render(
       <ResourceRow
         name="Potatoes"

--- a/src/data/names.js
+++ b/src/data/names.js
@@ -139,15 +139,17 @@ export const LAST_NAMES = [
 import { DAYS_PER_YEAR } from '../engine/time.ts';
 import { BALANCE } from './balance.js';
 
-export function makeRandomSettler({ sex, randomizeAge = false } = {}) {
-  const chosenSex = sex || (Math.random() < 0.5 ? 'M' : 'F');
+export function makeRandomSettler({
+  sex,
+  randomizeAge = false,
+  rng = Math.random,
+} = {}) {
+  const chosenSex = sex || (rng() < 0.5 ? 'M' : 'F');
   const firstPool = FIRST_NAMES[chosenSex];
-  const firstName = firstPool[Math.floor(Math.random() * firstPool.length)];
-  const lastName = LAST_NAMES[Math.floor(Math.random() * LAST_NAMES.length)];
+  const firstName = firstPool[Math.floor(rng() * firstPool.length)];
+  const lastName = LAST_NAMES[Math.floor(rng() * LAST_NAMES.length)];
   const baseAge = 18 * DAYS_PER_YEAR;
-  const randomDays = randomizeAge
-    ? Math.floor(Math.random() * DAYS_PER_YEAR)
-    : 0;
+  const randomDays = randomizeAge ? Math.floor(rng() * DAYS_PER_YEAR) : 0;
   return {
     id: globalThis.crypto?.randomUUID
       ? globalThis.crypto.randomUUID()

--- a/src/engine/__tests__/economy.test.ts
+++ b/src/engine/__tests__/economy.test.ts
@@ -9,6 +9,11 @@ import { deepClone } from '../../utils/clone.ts';
 import { BALANCE } from '../../data/balance.js';
 import { calculateFoodCapacity } from '../../state/selectors.js';
 
+const createRng = (seed = 1) => () => {
+  seed = (seed * 16807) % 2147483647;
+  return (seed - 1) / 2147483646;
+};
+
 describe('economy basics', () => {
   test('spring potato field output', () => {
     const state = deepClone(defaultState);
@@ -122,7 +127,8 @@ describe('economy basics', () => {
     state.resources.meat.amount = 1;
     state.foodPool = { amount: 1.3, capacity: cap };
     state.population.settlers = [{ id: 's1' }, { id: 's2' }];
-    const { state: after } = processSettlersTick(state, 1, 0);
+    const rng = createRng();
+    const { state: after } = processSettlersTick(state, 1, 0, rng);
     const consumption = 2 * BALANCE.FOOD_CONSUMPTION_PER_SETTLER;
     expect(after.resources.potatoes.amount).toBeCloseTo(
       Math.max(0, 0.3 - consumption),

--- a/src/engine/__tests__/offlineTicks.test.ts
+++ b/src/engine/__tests__/offlineTicks.test.ts
@@ -12,12 +12,17 @@ const createBaseState = () => ({
   colony: { radioTimer: 0, starvationTimerSeconds: 0 },
 });
 
+const createRng = (seed = 1) => () => {
+  seed = (seed * 16807) % 2147483647;
+  return (seed - 1) / 2147483646;
+};
+
 describe('offline progress', () => {
   it('invokes processTick once per elapsed second', async () => {
     const mock = vi.fn((state: any) => state);
     vi.doMock('../production.ts', () => ({ processTick: mock }));
     const { applyOfflineProgress } = await import('../offline.ts');
-    applyOfflineProgress(createBaseState(), 5);
+    applyOfflineProgress(createBaseState(), 5, {}, createRng());
     expect(mock).toHaveBeenCalledTimes(5);
     vi.doUnmock('../production.ts');
     vi.resetModules();
@@ -26,7 +31,12 @@ describe('offline progress', () => {
   it('matches online ticks for storage and power status', async () => {
     const { applyOfflineProgress } = await import('../offline.ts');
     const { processTick } = await import('../production.ts');
-    const offline = applyOfflineProgress(createBaseState(), 100).state;
+    const offline = applyOfflineProgress(
+      createBaseState(),
+      100,
+      {},
+      createRng(2),
+    ).state;
     let online = createBaseState();
     for (let i = 0; i < 100; i += 1) {
       online = processTick(online, 1);

--- a/src/engine/__tests__/settlers.test.ts
+++ b/src/engine/__tests__/settlers.test.ts
@@ -8,8 +8,14 @@ import { RESOURCES } from '../../data/resources.js';
 import { BALANCE } from '../../data/balance.js';
 import { deepClone } from '../../utils/clone.ts';
 
+const createRng = (seed = 1) => () => {
+  seed = (seed * 16807) % 2147483647;
+  return (seed - 1) / 2147483646;
+};
+
 describe('settlers tick', () => {
   it('keeps potato totals consistent with farming bonus and consumption', () => {
+    const rng = createRng();
     const state = deepClone(defaultState);
     state.buildings.potatoField.count = 1;
     state.resources.potatoes.amount = 0;
@@ -36,7 +42,7 @@ describe('settlers tick', () => {
     const bonusFoodPerSec =
       totalFoodProdBase * (roleBonuses['farmer'] || 0);
 
-    const { state: final } = processSettlersTick(afterTick, 1, bonusFoodPerSec);
+    const { state: final } = processSettlersTick(afterTick, 1, bonusFoodPerSec, rng);
 
     const expected =
       afterTick.resources.potatoes.amount +
@@ -47,13 +53,14 @@ describe('settlers tick', () => {
   });
 
   it('clamps food once after bonus and consumption', () => {
+    const rng2 = createRng(2);
     const state = deepClone(defaultState);
     const cap = 200;
     state.resources.potatoes.amount = cap;
     state.foodPool = { amount: cap, capacity: cap };
     state.population.settlers = [{ id: 's1' }];
     const bonusPerSec = BALANCE.FOOD_CONSUMPTION_PER_SETTLER + 0.1;
-    const { state: next } = processSettlersTick(state, 1, bonusPerSec);
+    const { state: next } = processSettlersTick(state, 1, bonusPerSec, rng2);
     expect(next.foodPool.amount).toBe(cap);
     expect(next.resources.potatoes.amount).toBe(cap);
   });

--- a/src/engine/offline.ts
+++ b/src/engine/offline.ts
@@ -10,6 +10,7 @@ export function applyOfflineProgress(
   state: any,
   elapsedSeconds: number,
   roleBonuses: Record<string, number> = {},
+  rng: () => number = Math.random,
 ): { state: any; gains: Record<string, number>; events: any[] } {
   if (elapsedSeconds <= 0) return { state, gains: {}, events: [] };
   const before = deepClone(state.resources);
@@ -33,7 +34,7 @@ export function applyOfflineProgress(
       current,
       1,
       bonusFoodPerSec,
-      Math.random,
+      rng,
       roleBonuses,
     );
     current = settlersResult.state;


### PR DESCRIPTION
## Summary
- allow makeRandomSettler and applyOfflineProgress to accept custom RNGs
- use seeded RNGs in tests for deterministic behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d9293ba048331bf7df6b937010967