### PR TITLE
Guard console logs for production

### DIFF
--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -37,7 +37,7 @@ export default function Drawer() {
         const log = [createLogEntry(note), ...(loaded.log || [])].slice(0, 100);
         setState({ ...loaded, log });
       } catch (err) {
-        console.error(err);
+        if (import.meta.env.DEV) console.error(err);
         setState((prev) => ({
           ...prev,
           log: [

--- a/src/components/PowerPriorityModal.jsx
+++ b/src/components/PowerPriorityModal.jsx
@@ -44,7 +44,8 @@ export default function PowerPriorityModal({ onClose }) {
     order.forEach((id) => {
       if (powered.includes(id) && !cleaned.includes(id)) cleaned.push(id);
       else if (!powered.includes(id))
-        console.warn('Unknown or non-powered typeId in powerTypeOrder:', id);
+        if (import.meta.env.DEV)
+          console.warn('Unknown or non-powered typeId in powerTypeOrder:', id);
     });
     setState((prev) => ({ ...prev, powerTypeOrder: cleaned }));
     onClose();

--- a/src/dev/economyReporter.ts
+++ b/src/dev/economyReporter.ts
@@ -363,7 +363,7 @@ export function main(args = process.argv.slice(2)) {
   const opts = parseArgs(args);
   const outStr = generateReport(opts);
   if (opts.out) fs.writeFileSync(opts.out, outStr);
-  else console.log(outStr);
+  else if (process.env.NODE_ENV !== 'production') console.log(outStr);
 }
 
 if (pathToFileURL(process.argv[1] ?? '').href === import.meta.url) {

--- a/src/engine/persistence.ts
+++ b/src/engine/persistence.ts
@@ -248,7 +248,7 @@ export function saveGame(state: any): any {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
     return data;
   } catch (err) {
-    console.error('Save failed', err);
+    if (import.meta.env.DEV) console.error('Save failed', err);
     return state;
   }
 }
@@ -260,7 +260,7 @@ export function loadGame(): { state: any | null; error: any } {
     const { state } = load(raw);
     return { state, error: null };
   } catch (err) {
-    console.error('Load failed', err);
+    if (import.meta.env.DEV) console.error('Load failed', err);
     return { state: null, error: err };
   }
 }
@@ -269,7 +269,7 @@ export function deleteSave(): void {
   try {
     localStorage.removeItem(STORAGE_KEY);
   } catch (err) {
-    console.error('Delete failed', err);
+    if (import.meta.env.DEV) console.error('Delete failed', err);
   }
 }
 

--- a/src/state/GameContext.jsx
+++ b/src/state/GameContext.jsx
@@ -15,7 +15,7 @@ export function GameProvider({ children }) {
   const { state: loaded, error: loadErr } = loadGame();
   const [state, setState] = useState(() => {
     if (loadErr) {
-      console.warn('[loadGame] error:', loadErr);
+      if (import.meta.env.DEV) console.warn('[loadGame] error:', loadErr);
     }
     return loaded
       ? prepareLoadedState(loaded)


### PR DESCRIPTION
## Summary
- guard persistence error logs behind dev checks
- limit PowerPriority and Drawer warnings to development
- skip economy report output in production CLI runs

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 45 files. Run Prettier with --write to fix.)*

------
https://chatgpt.com/codex/tasks/task_e_689d95ed102c83319427d05fc4512733