### PR TITLE
feat: cache resource capacities

### DIFF
--- a/src/engine/research.ts
+++ b/src/engine/research.ts
@@ -1,6 +1,6 @@
 import { RESEARCH_MAP } from '../data/research.js';
 import { clampResource } from './resources.ts';
-import { getCapacity } from '../state/selectors.js';
+import { getCapacity, invalidateCapacityCache } from '../state/capacityCache.ts';
 
 export function startResearch(state: any, id: string): any {
   const node = RESEARCH_MAP[id];
@@ -66,11 +66,16 @@ export function processResearchTick(
         resources[resId] = { ...entry, discovered: true };
       });
     }
-    return {
+    const nextState = {
       ...state,
       resources,
       research: { current: null, completed, progress },
     };
+    const effects = Array.isArray(node.effects) ? node.effects : [node.effects];
+    if (effects.some((e: any) => e.type === 'storage')) {
+      invalidateCapacityCache();
+    }
+    return nextState;
   }
   return { ...state, research: { ...state.research, progress, current } };
 }

--- a/src/engine/settlers.ts
+++ b/src/engine/settlers.ts
@@ -6,7 +6,8 @@ import {
   FOOD_VARIETY_BONUS,
   XP_MULTIPLIER_FROM_HAPPINESS,
 } from '../data/balance.js';
-import { calculateFoodCapacity, getSettlerCapacity } from '../state/selectors.js';
+import { getSettlerCapacity } from '../state/selectors.js';
+import { calculateFoodCapacity, ensureCapacityCache } from '../state/capacityCache.ts';
 import { SECONDS_PER_DAY } from './time.ts';
 import { RESOURCES } from '../data/resources.js';
 import { clampResource } from './resources.ts';
@@ -36,6 +37,7 @@ export function processSettlersTick(
   rng: () => number = Math.random,
   roleBonuses: Record<string, number> | null = null,
 ): { state: any; telemetry: any; events: any[] } {
+  ensureCapacityCache(state);
   const settlers = state.population?.settlers
     ? [...state.population.settlers]
     : [];

--- a/src/state/capacityCache.ts
+++ b/src/state/capacityCache.ts
@@ -1,0 +1,122 @@
+// @ts-nocheck
+import { RESOURCES } from '../data/resources.js';
+import { BUILDINGS } from '../data/buildings.js';
+import { RESEARCH_MAP } from '../data/research.js';
+
+interface GameState {
+  resources?: Record<string, any>;
+  buildings?: Record<string, any>;
+  research?: any;
+}
+
+interface Effect { type?: string; percent?: number; category?: string; resource?: string; }
+
+let lastState: any = null;
+let lastBuildingsHash = '';
+let lastResearch: any = null;
+let capacities: Record<string, number> = {};
+let foodCapacity = 0;
+
+function gatherStorageEffects(state: GameState): Effect[] {
+  const completed = state.research?.completed || [];
+  const effects: Effect[] = [];
+  completed.forEach((id: string) => {
+    const r = RESEARCH_MAP[id];
+    if (!r?.effects) return;
+    const list = Array.isArray(r.effects) ? r.effects : [r.effects];
+    list.forEach((e: any) => {
+      if (e.type === 'storage') effects.push(e);
+    });
+  });
+  return effects;
+}
+
+function effectApplies(e: Effect, resId: string): boolean {
+  if (e.resource && e.resource === resId) return true;
+  if (e.category) {
+    if (e.category === 'WOOD') return ['wood', 'planks'].includes(resId);
+    if (e.category === 'SCRAP') return ['scrap', 'metalParts'].includes(resId);
+    if (e.category === 'RAW') return RESOURCES[resId]?.category === 'RAW';
+    if (e.category === 'CONSTRUCTION_MATERIALS')
+      return RESOURCES[resId]?.category === 'CONSTRUCTION_MATERIALS';
+  }
+  return false;
+}
+
+function getResearchStorageBonus(state: GameState, resId: string): number {
+  let bonus = 0;
+  gatherStorageEffects(state).forEach((e) => {
+    if (effectApplies(e, resId)) bonus += e.percent || 0;
+  });
+  return bonus;
+}
+
+function recompute(state: GameState) {
+  capacities = {};
+  Object.keys(RESOURCES).forEach((id) => {
+    if (RESOURCES[id].category === 'FOOD') return;
+    const base = RESOURCES[id]?.startingCapacity || 0;
+    let fromBuildings = 0;
+    BUILDINGS.forEach((b) => {
+      const count = state.buildings?.[b.id]?.count || 0;
+      if (count > 0 && b.capacityAdd?.[id]) {
+        fromBuildings += b.capacityAdd[id] * count;
+      }
+    });
+    const bonus = getResearchStorageBonus(state, id);
+    capacities[id] = Math.floor((base + fromBuildings) * (1 + bonus));
+  });
+
+  foodCapacity = 0;
+  Object.keys(RESOURCES).forEach((id) => {
+    if (RESOURCES[id].category !== 'FOOD') return;
+    const base = RESOURCES[id]?.startingCapacity || 0;
+    let fromBuildings = 0;
+    BUILDINGS.forEach((b) => {
+      const count = state.buildings?.[b.id]?.count || 0;
+      if (count > 0 && b.capacityAdd?.[id]) {
+        fromBuildings += b.capacityAdd[id] * count;
+      }
+    });
+    const bonus = getResearchStorageBonus(state, id);
+    foodCapacity += Math.floor((base + fromBuildings) * (1 + bonus));
+  });
+  BUILDINGS.forEach((b) => {
+    const count = state.buildings?.[b.id]?.count || 0;
+    if (count > 0 && b.capacityAdd?.FOOD) {
+      foodCapacity += b.capacityAdd.FOOD * count;
+    }
+  });
+  lastState = state;
+  lastBuildingsHash = JSON.stringify(state.buildings || {});
+  lastResearch = state.research?.completed;
+}
+
+export function ensureCapacityCache(state: GameState) {
+  const buildingsHash = JSON.stringify(state.buildings || {});
+  if (
+    state !== lastState ||
+    buildingsHash !== lastBuildingsHash ||
+    state.research?.completed !== lastResearch
+  ) {
+    recompute(state);
+  }
+}
+
+export function getCapacity(state: GameState, resourceId: string): number {
+  ensureCapacityCache(state);
+  if (RESOURCES[resourceId]?.category === 'FOOD') return Infinity;
+  return capacities[resourceId] || 0;
+}
+
+export function calculateFoodCapacity(state: GameState): number {
+  ensureCapacityCache(state);
+  return foodCapacity;
+}
+
+export function invalidateCapacityCache() {
+  lastState = null;
+  lastBuildingsHash = '';
+  lastResearch = null;
+}
+

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -11,30 +11,10 @@ import { formatRate } from '../utils/format.js';
 import { BALANCE } from '../data/balance.js';
 import { ROLE_BY_RESOURCE } from '../data/roles.js';
 import { SHELTER_MAX } from '../data/settlement.js';
+import { getCapacity, calculateFoodCapacity } from './capacityCache.ts';
+export { getCapacity, calculateFoodCapacity } from './capacityCache.ts';
 
 /** @typedef {import('./useGame.tsx').GameState} GameState */
-
-/**
- * @param {GameState} state
- * @param {string} resourceId
- */
-export function getCapacity(state, resourceId) {
-  if (RESOURCES[resourceId]?.category === 'FOOD') return Infinity;
-  const base = RESOURCES[resourceId]?.startingCapacity || 0;
-  let fromBuildings = 0;
-  BUILDINGS.forEach((b) => {
-    const count = state.buildings?.[b.id]?.count || 0;
-    if (count > 0 && b.capacityAdd?.[resourceId]) {
-      fromBuildings += b.capacityAdd[resourceId] * count;
-    }
-  });
-  const bonus = getResearchStorageBonus(state, resourceId);
-  return Math.floor((base + fromBuildings) * (1 + bonus));
-}
-
-/**
- * @param {GameState} state
- */
 
 export function getFoodPoolAmount(state) {
   if (state.foodPool?.amount != null) return state.foodPool.amount;
@@ -44,33 +24,6 @@ export function getFoodPoolAmount(state) {
     }
     return sum;
   }, 0);
-}
-
-/**
- * @param {GameState} state
- */
-export function calculateFoodCapacity(state) {
-  let total = 0;
-  Object.keys(RESOURCES).forEach((id) => {
-    if (RESOURCES[id].category !== 'FOOD') return;
-    const base = RESOURCES[id]?.startingCapacity || 0;
-    let fromBuildings = 0;
-    BUILDINGS.forEach((b) => {
-      const count = state.buildings?.[b.id]?.count || 0;
-      if (count > 0 && b.capacityAdd?.[id]) {
-        fromBuildings += b.capacityAdd[id] * count;
-      }
-    });
-    const bonus = getResearchStorageBonus(state, id);
-    total += Math.floor((base + fromBuildings) * (1 + bonus));
-  });
-  BUILDINGS.forEach((b) => {
-    const count = state.buildings?.[b.id]?.count || 0;
-    if (count > 0 && b.capacityAdd?.FOOD) {
-      total += b.capacityAdd.FOOD * count;
-    }
-  });
-  return total;
 }
 
 /**


### PR DESCRIPTION
## Summary
- centralize capacity calculation in a new cache
- use cached capacities across production, research, and settlers
- refresh capacity cache when buildings or research change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689dce0c08408331b632a18b1396dd17