### PR TITLE
feat: chunk offline simulation

### DIFF
--- a/src/engine/__tests__/offlineTicks.test.ts
+++ b/src/engine/__tests__/offlineTicks.test.ts
@@ -1,5 +1,8 @@
 // @ts-nocheck
 import { describe, it, expect, vi } from 'vitest';
+import { getResourceRates } from '../../state/selectors.js';
+import { processSettlersTick } from '../settlers.ts';
+import { RESOURCES } from '../../data/resources.js';
 
 const createBaseState = () => ({
   buildings: { woodGenerator: { count: 1 }, radio: { count: 1 } },
@@ -18,12 +21,12 @@ const createRng = (seed = 1) => () => {
 };
 
 describe('offline progress', () => {
-  it('invokes processTick once per elapsed second', async () => {
+  it('invokes processTick in larger chunks', async () => {
     const mock = vi.fn((state: any) => state);
     vi.doMock('../production.ts', () => ({ processTick: mock }));
     const { applyOfflineProgress } = await import('../offline.ts');
     applyOfflineProgress(createBaseState(), 5, {}, createRng());
-    expect(mock).toHaveBeenCalledTimes(5);
+    expect(mock).toHaveBeenCalledTimes(1);
     vi.doUnmock('../production.ts');
     vi.resetModules();
   });
@@ -43,6 +46,49 @@ describe('offline progress', () => {
     }
     expect(offline.resources).toEqual(online.resources);
     expect(offline.powerStatus).toEqual(online.powerStatus);
+  });
+
+  it('matches per-second simulation over multiple hours', async () => {
+    const { applyOfflineProgress } = await import('../offline.ts');
+    const { processTick } = await import('../production.ts');
+    const base = {
+      buildings: { potatoField: { count: 2 }, largeGranary: { count: 100 } },
+      resources: { potatoes: { amount: 0, discovered: true, produced: 0 } },
+      population: { settlers: [{ id: 's1', isDead: false, role: null }], candidate: null },
+      colony: { radioTimer: 0, starvationTimerSeconds: 0 },
+    };
+    const seconds = 3 * 3600;
+    const rngOffline = createRng(3);
+    const offline = applyOfflineProgress(structuredClone(base), seconds, {}, rngOffline)
+      .state;
+
+    let online = structuredClone(base);
+    const rngOnline = createRng(3);
+    for (let i = 0; i < seconds; i += 1) {
+      online = processTick(online, 1);
+      const rates = getResourceRates(online);
+      let totalFoodProdBase = 0;
+      Object.keys(RESOURCES).forEach((id) => {
+        if (RESOURCES[id].category === 'FOOD') {
+          totalFoodProdBase += rates[id]?.perSec || 0;
+        }
+      });
+      const settlersResult = processSettlersTick(
+        online,
+        1,
+        totalFoodProdBase * 0,
+        rngOnline,
+        {},
+      );
+      online = settlersResult.state;
+    }
+
+    expect(offline.resources.potatoes.amount).toBeCloseTo(
+      online.resources.potatoes.amount,
+    );
+    expect(offline.population.settlers.length).toBe(
+      online.population.settlers.length,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- step offline progress in 60-second chunks instead of per-second
- normalize power status per-second and handle settlers, radio each chunk
- add regression tests for chunking and multi-hour parity

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ddbd09a2083319cf0d9bb3395ff2d