### PR TITLE
Handle per-resource output capacity

### DIFF
--- a/src/state/__tests__/resourceRates.test.js
+++ b/src/state/__tests__/resourceRates.test.js
@@ -1,8 +1,9 @@
 import { describe, expect, test } from 'vitest';
 import { getResourceRates } from '../selectors.js';
+import { PRODUCTION_BUILDINGS, BUILDING_MAP } from '../../data/buildings.js';
 import { defaultState } from '../defaultState.js';
 import { deepClone } from '../../utils/clone.ts';
-import { getOutputCapacityFactor } from '../../engine/capacity.ts';
+import { getOutputCapacityFactors } from '../../engine/capacity.ts';
 import { ensureCapacityCache } from '../capacityCache.ts';
 
 describe('getResourceRates', () => {
@@ -19,9 +20,32 @@ describe('getResourceRates', () => {
   test('capacity utility works with numeric resources', () => {
     const state = deepClone(defaultState);
     ensureCapacityCache(state);
-    const resources = { wood: 79.8 };
-    const desired = { wood: 1 };
-    const factor = getOutputCapacityFactor(state, resources, desired, 0, 0);
-    expect(factor).toBeCloseTo(0.2, 5);
+    const resources = { wood: 79.8, stone: 0 };
+    const desired = { wood: 1, stone: 1 };
+    const factors = getOutputCapacityFactors(state, resources, desired, 0, 0);
+    expect(factors.wood).toBeCloseTo(0.2, 5);
+    expect(factors.stone).toBeCloseTo(1, 5);
+  });
+
+  test('rates handle multi-output buildings', () => {
+    const state = deepClone(defaultState);
+    const dual = {
+      id: 'dual',
+      outputsPerSecBase: { wood: 1, stone: 1 },
+    };
+    PRODUCTION_BUILDINGS.push(dual);
+    BUILDING_MAP[dual.id] = dual;
+    state.buildings = { dual: { count: 1 } };
+    state.gameTime.seconds = 270; // summer for neutral multipliers
+    state.population = { settlers: [] };
+    state.resources.wood.amount = 79.5;
+    state.resources.wood.discovered = true;
+    state.resources.stone.amount = 0;
+    state.resources.stone.discovered = true;
+    const rates = getResourceRates(state);
+    expect(rates.wood.perSec).toBeCloseTo(0.5, 5);
+    expect(rates.stone.perSec).toBeCloseTo(1, 5);
+    PRODUCTION_BUILDINGS.pop();
+    delete BUILDING_MAP[dual.id];
   });
 });


### PR DESCRIPTION
## Summary
- Clamp each output resource individually when computing production capacity
- Derive per-resource factors for building production and resource rate calculations
- Test partial production for buildings with multiple outputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689de37724188331ae8398b0e6417cc4