### PR TITLE
refactor resource handling with centralized helpers

### DIFF
--- a/src/engine/__tests__/resourceOps.test.ts
+++ b/src/engine/__tests__/resourceOps.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { addResource, consumeResource } from '../resourceOps.ts';
+import { defaultState } from '../../state/defaultState.js';
+import { deepClone } from '../../utils/clone.ts';
+
+describe('resourceOps helpers', () => {
+  it('handles non-food resources with clamping', () => {
+    const state = deepClone(defaultState);
+    const resources: any = { ...state.resources };
+    const foodPool = { ...state.foodPool };
+    addResource(state, resources, 'wood', 100, foodPool);
+    expect(resources.wood.amount).toBe(80); // wood capacity 80
+    expect(resources.wood.produced).toBe(80);
+    const consumed = consumeResource(state, resources, 'wood', 50, foodPool);
+    expect(consumed).toBe(50);
+    expect(resources.wood.amount).toBe(30);
+    expect(resources.wood.produced).toBe(80); // consumption doesn't change produced
+  });
+
+  it('updates food pool when adding and consuming food', () => {
+    const state = deepClone(defaultState);
+    const resources: any = { ...state.resources };
+    const foodPool = { ...state.foodPool };
+    addResource(state, resources, 'potatoes', 500, foodPool);
+    expect(foodPool.amount).toBe(foodPool.capacity);
+    expect(resources.potatoes.amount).toBe(foodPool.capacity);
+    const consumed = consumeResource(state, resources, 'potatoes', 50, foodPool);
+    expect(consumed).toBe(50);
+    expect(resources.potatoes.amount).toBe(foodPool.capacity - 50);
+    expect(foodPool.amount).toBe(foodPool.capacity - 50);
+  });
+});

--- a/src/engine/research.ts
+++ b/src/engine/research.ts
@@ -1,6 +1,6 @@
 import { RESEARCH_MAP } from '../data/research.js';
-import { clampResource } from './resources.ts';
-import { getCapacity, invalidateCapacityCache } from '../state/capacityCache.ts';
+import { addResource, consumeResource } from './resourceOps.ts';
+import { invalidateCapacityCache } from '../state/capacityCache.ts';
 
 export function startResearch(state: any, id: string): any {
   const node = RESEARCH_MAP[id];
@@ -10,7 +10,7 @@ export function startResearch(state: any, id: string): any {
   const have = state.resources.science?.amount || 0;
   if (have < cost) return state;
   const resources = { ...state.resources };
-  resources.science = { ...resources.science, amount: have - cost };
+  consumeResource(state, resources, 'science', cost);
   const progress = { ...state.research.progress, [id]: 0 };
   return {
     ...state,
@@ -25,14 +25,7 @@ export function cancelResearch(state: any): any {
   const node = RESEARCH_MAP[current.id];
   const refund = Math.floor((node.cost?.science || 0) * 0.5);
   const resources = { ...state.resources };
-  const capacity = getCapacity(state, 'science');
-  const entry = resources.science || { amount: 0, discovered: false };
-  const nextAmt = clampResource(entry.amount + refund, capacity);
-  resources.science = {
-    ...entry,
-    amount: nextAmt,
-    discovered: entry.discovered || nextAmt > 0,
-  };
+  addResource(state, resources, 'science', refund);
   const progress = { ...state.research.progress, [current.id]: 0 };
   return {
     ...state,

--- a/src/engine/resourceOps.ts
+++ b/src/engine/resourceOps.ts
@@ -1,0 +1,72 @@
+import { RESOURCES } from '../data/resources.js';
+import { clampResource } from './resources.ts';
+import { getCapacity } from '../state/capacityCache.ts';
+
+// Adds amount of resource, clamping to capacity and updating metadata.
+// For FOOD resources, updates the provided foodPool object { amount, capacity }.
+// Returns the actual amount added after clamping.
+export function addResource(
+  state: any,
+  resources: Record<string, any>,
+  id: string,
+  amount: number,
+  foodPool?: { amount: number; capacity: number },
+): number {
+  const entry = resources[id] || { amount: 0, discovered: false, produced: 0 };
+  const category = RESOURCES[id]?.category;
+  if (category === 'FOOD') {
+    const cap = foodPool?.capacity ?? 0;
+    const room = cap - (foodPool?.amount ?? 0);
+    const gain = Math.max(0, Math.min(amount, room));
+    const next = entry.amount + gain;
+    resources[id] = {
+      amount: next,
+      discovered: entry.discovered || next > 0,
+      produced: (entry.produced || 0) + Math.max(0, gain),
+    };
+    if (foodPool) foodPool.amount += gain;
+    return gain;
+  } else {
+    const capacity = getCapacity(state, id);
+    const next = clampResource(entry.amount + amount, capacity);
+    const actual = next - entry.amount;
+    resources[id] = {
+      amount: next,
+      discovered: entry.discovered || next > 0,
+      produced: (entry.produced || 0) + Math.max(0, actual),
+    };
+    return actual;
+  }
+}
+
+// Consumes amount of resource (not going below 0). For FOOD resources,
+// updates the provided foodPool. Returns the actual amount consumed.
+export function consumeResource(
+  state: any,
+  resources: Record<string, any>,
+  id: string,
+  amount: number,
+  foodPool?: { amount: number; capacity: number },
+): number {
+  const entry = resources[id] || { amount: 0, discovered: false, produced: 0 };
+  const category = RESOURCES[id]?.category;
+  const consume = Math.min(entry.amount, amount);
+  const remaining = Math.max(0, entry.amount - consume);
+  if (category === 'FOOD') {
+    resources[id] = {
+      ...entry,
+      amount: remaining,
+      discovered: entry.discovered || remaining > 0,
+    };
+    if (foodPool) foodPool.amount = Math.max(0, (foodPool.amount ?? 0) - consume);
+  } else {
+    resources[id] = {
+      ...entry,
+      amount: remaining,
+      discovered: entry.discovered || remaining > 0,
+    };
+  }
+  return consume;
+}
+
+export default { addResource, consumeResource };


### PR DESCRIPTION
## Summary
- add resourceOps utility with addResource and consumeResource helpers
- refactor production, research, and settlers to use centralized resource ops
- cover food and non-food paths with new resourceOps tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689de8298d00833185ba9af78e255797