### PR TITLE
Fix duplicate settler aging on offline load

### DIFF
--- a/src/state/__tests__/prepareLoadedState.test.js
+++ b/src/state/__tests__/prepareLoadedState.test.js
@@ -3,6 +3,7 @@ import { prepareLoadedState } from '../prepareLoadedState.ts';
 import { defaultState } from '../defaultState.js';
 import { deepClone } from '../../utils/clone.ts';
 import { calculateFoodCapacity } from '../selectors.js';
+import { DAYS_PER_YEAR, SECONDS_PER_DAY } from '../../engine/time.ts';
 
 const fakeCandidate = { id: 'cand1' };
 vi.mock('../../engine/candidates.ts', () => ({
@@ -70,5 +71,17 @@ describe('prepareLoadedState', () => {
     const state = prepareLoadedState(loaded);
     expect(state.foodPool.amount).toBe(15);
     expect(state.foodPool.capacity).toBe(calculateFoodCapacity(state));
+  });
+
+  it('ages settlers and advances year after offline progress', () => {
+    const now = Date.now();
+    const elapsed = DAYS_PER_YEAR * SECONDS_PER_DAY; // one year
+    const loaded = {
+      population: { settlers: [{ id: 1, ageDays: 0 }] },
+      lastSaved: now - elapsed * 1000,
+    };
+    const state = prepareLoadedState(loaded);
+    expect(state.gameTime.year).toBe(2);
+    expect(state.population.settlers[0].ageDays).toBe(elapsed / SECONDS_PER_DAY);
   });
 });

--- a/src/state/prepareLoadedState.ts
+++ b/src/state/prepareLoadedState.ts
@@ -81,7 +81,6 @@ export function prepareLoadedState(loaded: any) {
     });
     const settlers = progressed.population.settlers.map((s: any) => ({
       ...s,
-      ageDays: (s.ageDays || 0) + elapsed / SECONDS_PER_DAY,
     }));
     const show =
       Object.keys(gains).length > 0 ||


### PR DESCRIPTION
## Summary
- avoid double aging settlers when calculating offline progress
- test year/age consistency for offline loading

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689df7345dc88331932f9aae988bcce6