### PR TITLE
feat: show research and candidate offline messages

### DIFF
--- a/src/components/OfflineProgressModal.jsx
+++ b/src/components/OfflineProgressModal.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useGame } from '../state/useGame.tsx';
 import { formatTime } from '../utils/time.js';
 import { Button } from './Button';
@@ -38,18 +39,18 @@ export default function OfflineProgressModal() {
                 ))}
               </div>
             )}
-            {info.research?.length > 0 && (
+            {(info.researchCompleted || info.research)?.length > 0 && (
               <div className="mb-2 space-y-1">
                 <div>Research completed:</div>
-                {info.research.map((r, i) => (
+                {(info.researchCompleted || info.research).map((r, i) => (
                   <div key={i}>{r}</div>
                 ))}
               </div>
             )}
-            {info.candidates?.length > 0 && (
+            {(info.candidateArrivals || info.candidates)?.length > 0 && (
               <div className="mb-2 space-y-1">
                 <div>Radio contact:</div>
-                {info.candidates.map((c, i) => (
+                {(info.candidateArrivals || info.candidates).map((c, i) => (
                   <div key={i}>{c}</div>
                 ))}
               </div>

--- a/src/components/OfflineProgressModal.test.jsx
+++ b/src/components/OfflineProgressModal.test.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import OfflineProgressModal from './OfflineProgressModal.jsx';
+import { GameContext } from '../state/useGame.tsx';
+
+describe('OfflineProgressModal', () => {
+  it('renders research and candidate messages from offline progress', () => {
+    const contextValue = {
+      state: {
+        ui: {
+          offlineProgress: {
+            elapsed: 60,
+            gains: {},
+            researchCompleted: ['Agriculture research complete'],
+            candidateArrivals: ['Someone responded to the radio'],
+          },
+        },
+      },
+      dismissOfflineModal: () => {},
+    };
+
+    render(
+      <GameContext.Provider value={contextValue}>
+        <OfflineProgressModal />
+      </GameContext.Provider>,
+    );
+
+    expect(
+      screen.getByText('Agriculture research complete'),
+    ).toBeTruthy();
+    expect(
+      screen.getByText('Someone responded to the radio'),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- display completed research and candidate arrival messages in offline progress modal
- add unit test covering offline research and candidate messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e0e75721083319cbedde9fdc9d46c