### PR TITLE
feat: clamp offline progress

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -4,7 +4,7 @@
 
 - Idle colony sim built with React 19, Vite, and TailwindCSS v4.
 - Core loop: seasonal time system drives building harvest cycles and settler production.
-- Autosave every 10s; offline progress applied on load with capacity clamping.
+- Autosave every 10s; offline progress applied on load with capacity clamping (max 12h, min 15m).
 - Base view exposes food/resource buildings and event log; population view manages settler roles.
 
 ## Feature Matrix
@@ -13,7 +13,7 @@
 | ------------------------------------------------------- | ------------- |
 | Time, year and season tracking                          | ✅            |
 | Season modifiers affecting farming and wood             | ✅            |
-| Autosave & offline progress with capacity clamp         | ✅            |
+| Autosave & offline progress with time caps              | ✅            |
 | Resource sidebar with capacities & rates                | ✅            |
 | Building construction/demolition with cost & 50% refund | ✅            |
 | Population roles and basic stats                        | ✅            |

--- a/src/state/__tests__/prepareLoadedState.test.js
+++ b/src/state/__tests__/prepareLoadedState.test.js
@@ -3,7 +3,7 @@ import { prepareLoadedState } from '../prepareLoadedState.ts';
 import { defaultState } from '../defaultState.js';
 import { deepClone } from '../../utils/clone.ts';
 import { calculateFoodCapacity } from '../selectors.js';
-import { DAYS_PER_YEAR, SECONDS_PER_DAY } from '../../engine/time.ts';
+import { SECONDS_PER_DAY } from '../../engine/time.ts';
 
 const fakeCandidate = { id: 'cand1' };
 vi.mock('../../engine/candidates.ts', () => ({
@@ -15,7 +15,7 @@ vi.mock('../../engine/candidates.ts', () => ({
 describe('prepareLoadedState', () => {
   it('adds offline progress entries to log', () => {
     const loaded = deepClone(defaultState);
-    loaded.lastSaved = Date.now() - 10000; // 10 seconds offline
+    loaded.lastSaved = Date.now() - 20 * 60 * 1000; // 20 minutes offline
     const state = prepareLoadedState(loaded);
     expect(state.log.length).toBeGreaterThan(0);
     expect(state.log[0].text).toMatch(/while offline/);
@@ -28,7 +28,7 @@ describe('prepareLoadedState', () => {
       resources: { power: { amount: 0 }, wood: { amount: 100 } },
       population: { candidate: null },
       colony: { radioTimer: 3 },
-      lastSaved: now - 5000,
+      lastSaved: now - 20 * 60 * 1000,
     };
     const state = prepareLoadedState(loaded);
     expect(state.population.candidate).toEqual(fakeCandidate);
@@ -73,15 +73,30 @@ describe('prepareLoadedState', () => {
     expect(state.foodPool.capacity).toBe(calculateFoodCapacity(state));
   });
 
-  it('ages settlers and advances year after offline progress', () => {
+  it('caps offline progress and ages settlers accordingly', () => {
     const now = Date.now();
-    const elapsed = DAYS_PER_YEAR * SECONDS_PER_DAY; // one year
     const loaded = {
       population: { settlers: [{ id: 1, ageDays: 0 }] },
-      lastSaved: now - elapsed * 1000,
+      lastSaved: now - 6 * 24 * 60 * 60 * 1000, // 6 days offline
     };
     const state = prepareLoadedState(loaded);
-    expect(state.gameTime.year).toBe(2);
-    expect(state.population.settlers[0].ageDays).toBe(elapsed / SECONDS_PER_DAY);
+    const capped = 12 * 60 * 60; // 12 hours
+    expect(state.gameTime.seconds).toBe(capped);
+    expect(state.population.settlers[0].ageDays).toBe(capped / SECONDS_PER_DAY);
+  });
+
+  it('ignores short offline periods', () => {
+    const loaded = deepClone(defaultState);
+    loaded.lastSaved = Date.now() - 5 * 60 * 1000; // 5 minutes offline
+    const state = prepareLoadedState(loaded);
+    expect(state.ui.offlineProgress).toBeNull();
+    expect(state.log.length).toBe(0);
+  });
+
+  it('reports capped elapsed time', () => {
+    const loaded = deepClone(defaultState);
+    loaded.lastSaved = Date.now() - 24 * 60 * 60 * 1000; // 24 hours offline
+    const state = prepareLoadedState(loaded);
+    expect(state.ui.offlineProgress?.elapsed).toBe(12 * 60 * 60);
   });
 });


### PR DESCRIPTION
## Summary
- cap offline progress to 12h and ignore gaps under 15m
- document offline progress limits
- expand offline progress tests

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 44 files. Run Prettier with --write to fix.)*

------
https://chatgpt.com/codex/tasks/task_e_689e22e8e1e88331bdbd43da9c446ecf