### PR TITLE
Refine offline progress modal layout

### DIFF
--- a/src/components/OfflineProgressModal.jsx
+++ b/src/components/OfflineProgressModal.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useGame } from '../state/useGame.tsx';
 import { formatTime } from '../utils/time.js';
 import { Button } from './Button';
+import { RESOURCES } from '../data/resources.js';
 import {
   Dialog,
   DialogContent,
@@ -14,6 +15,21 @@ import {
 export default function OfflineProgressModal() {
   const { state, dismissOfflineModal } = useGame();
   const info = state.ui.offlineProgress;
+
+  const resources = Object.entries(info?.gains || {});
+
+  const events = [];
+  if (info?.deaths?.length) {
+    events.push({ title: 'Settler deaths', items: info.deaths });
+  }
+  const research = info?.researchCompleted || info?.research;
+  if (research?.length) {
+    events.push({ title: 'Research completed', items: research });
+  }
+  const arrivals = info?.candidateArrivals || info?.candidates;
+  if (arrivals?.length) {
+    events.push({ title: 'Radio contact', items: arrivals });
+  }
 
   return (
     <Dialog
@@ -30,36 +46,46 @@ export default function OfflineProgressModal() {
               You were gone for {formatTime(info.elapsed)}
             </DialogDescription>
           </DialogHeader>
-          <div className="space-y-1">
-            {info.deaths?.length > 0 && (
-              <div className="mb-2 space-y-1">
-                <div>The following settlers died:</div>
-                {info.deaths.map((d, i) => (
-                  <div key={i}>{d}</div>
-                ))}
-              </div>
+          <div className="space-y-6">
+            {resources.length > 0 && (
+              <section className="space-y-2">
+                <h3 className="text-lg font-semibold">Resources</h3>
+                <ul className="space-y-1 text-sm">
+                  {resources.map(([res, amt]) => (
+                    <li
+                      key={res}
+                      className="flex items-center justify-between"
+                    >
+                      <span className="flex items-center gap-2">
+                        {RESOURCES[res]?.icon && (
+                          <span>{RESOURCES[res].icon}</span>
+                        )}
+                        <span>{RESOURCES[res]?.name || res}</span>
+                      </span>
+                      <span className="font-mono">
+                        {Math.floor(amt)}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </section>
             )}
-            {(info.researchCompleted || info.research)?.length > 0 && (
-              <div className="mb-2 space-y-1">
-                <div>Research completed:</div>
-                {(info.researchCompleted || info.research).map((r, i) => (
-                  <div key={i}>{r}</div>
+
+            {events.length > 0 && (
+              <section className="space-y-4">
+                <h3 className="text-lg font-semibold">Events</h3>
+                {events.map((e, idx) => (
+                  <div key={idx} className="space-y-1">
+                    <h4 className="font-medium">{e.title}</h4>
+                    <ul className="list-disc space-y-1 pl-5 text-sm">
+                      {e.items.map((text, i) => (
+                        <li key={i}>{text}</li>
+                      ))}
+                    </ul>
+                  </div>
                 ))}
-              </div>
+              </section>
             )}
-            {(info.candidateArrivals || info.candidates)?.length > 0 && (
-              <div className="mb-2 space-y-1">
-                <div>Radio contact:</div>
-                {(info.candidateArrivals || info.candidates).map((c, i) => (
-                  <div key={i}>{c}</div>
-                ))}
-              </div>
-            )}
-            {Object.entries(info.gains).map(([res, amt]) => (
-              <div key={res}>
-                {res}: {Math.floor(amt)}
-              </div>
-            ))}
           </div>
           <DialogFooter>
             <Button onClick={dismissOfflineModal}>Continue</Button>


### PR DESCRIPTION
## Summary
- show offline resources with icons and separate resource section
- group deaths, research, and arrivals into an events section with headings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e2aeb2c648331801fc70dea01f9c4