### PR TITLE
Handle save version parsing and future versions

### DIFF
--- a/src/engine/__tests__/persistence.test.ts
+++ b/src/engine/__tests__/persistence.test.ts
@@ -73,4 +73,25 @@ describe('persistence migrations and validation', () => {
     expect(typeof state.log[0].id).toBe('string');
     expect(typeof state.log[0].time).toBe('number');
   });
+
+  it('parses string version numbers', () => {
+    const oldSave = {
+      version: '2',
+      resources: {},
+      buildings: {},
+      population: {},
+    };
+
+    const { state, migratedFrom } = load(JSON.stringify(oldSave));
+    expect(migratedFrom).toBe(2);
+    expect(state.version).toBe(CURRENT_SAVE_VERSION);
+  });
+
+  it('throws on future save versions', () => {
+    const futureVersion = CURRENT_SAVE_VERSION + 1;
+    const futureSave = { version: String(futureVersion) };
+    expect(() => load(JSON.stringify(futureSave))).toThrow(
+      `Save version ${futureVersion} is newer than supported version ${CURRENT_SAVE_VERSION}`,
+    );
+  });
 });

--- a/src/engine/persistence.ts
+++ b/src/engine/persistence.ts
@@ -234,7 +234,13 @@ export function save(state: any): any {
 
 export function load(raw: any): { state: any; migratedFrom: number | null } {
   const save = typeof raw === 'string' ? JSON.parse(raw) : deepClone(raw);
-  save.version = save.version ?? save.schemaVersion ?? 1;
+  const parsedVersion = Number(save.version ?? save.schemaVersion);
+  save.version = Number.isNaN(parsedVersion) ? 1 : parsedVersion;
+  if (save.version > CURRENT_SAVE_VERSION) {
+    throw new Error(
+      `Save version ${save.version} is newer than supported version ${CURRENT_SAVE_VERSION}`,
+    );
+  }
   validateSave(save);
   const start = save.version;
   applyMigrations(save);


### PR DESCRIPTION
## Summary
- Parse save version values with `Number(...)` and default to 1 on failure
- Throw descriptive error when loading a save newer than the current version
- Test string-based versions and future-version saves

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e44e05ad08331aec2d798825b3918