### PR TITLE
Handle offline progress on visibility change

### DIFF
--- a/src/state/hooks/useGameTick.tsx
+++ b/src/state/hooks/useGameTick.tsx
@@ -1,13 +1,46 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, useEffect, useRef } from 'react';
 import useGameLoop from '../../engine/useGameLoop.tsx';
 import {
   applyProduction,
   applySettlers,
   applyYearUpdate,
 } from '../../engine/gameTick.ts';
+import { applyOfflineProgress } from '../../engine/offline.ts';
+import { computeRoleBonuses } from '../../engine/settlers.ts';
 
 export default function useGameTick(setState: Dispatch<SetStateAction<any>>) {
+  const hiddenAt = useRef<number | null>(
+    document.visibilityState === 'hidden' ? Date.now() : null,
+  );
+
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (document.visibilityState === 'hidden') {
+        hiddenAt.current = Date.now();
+      } else if (document.visibilityState === 'visible') {
+        const now = Date.now();
+        const last = hiddenAt.current;
+        hiddenAt.current = now;
+        if (last != null) {
+          const elapsed = (now - last) / 1000;
+          if (elapsed > 0) {
+            setState((prev: any) => {
+              const bonuses = computeRoleBonuses(
+                prev.population?.settlers || [],
+              );
+              const { state } = applyOfflineProgress(prev, elapsed, bonuses);
+              return state;
+            });
+          }
+        }
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () =>
+      document.removeEventListener('visibilitychange', handleVisibility);
+  }, [setState]);
+
   useGameLoop((dt) => {
     setState((prev: any) => {
       const {
@@ -15,10 +48,11 @@ export default function useGameTick(setState: Dispatch<SetStateAction<any>>) {
         telemetry,
         roleBonuses,
       } = applySettlers(prev, dt);
-      const {
-        state: withProduction,
-        bonusFoodPerSec,
-      } = applyProduction(settlersProcessed, dt, roleBonuses);
+      const { state: withProduction, bonusFoodPerSec } = applyProduction(
+        settlersProcessed,
+        dt,
+        roleBonuses,
+      );
       const updatedTelemetry = {
         ...telemetry,
         bonusFoodPerSec,


### PR DESCRIPTION
## Summary
- track page hide time and apply offline progress when returning
- update game state to reflect background progress immediately

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 47 files. Run Prettier with --write to fix.)*

------
https://chatgpt.com/codex/tasks/task_e_689fa3e91cb48331850efe3cc80ba17c