### PR TITLE
Use stable ids for resource sections

### DIFF
--- a/src/components/ResourceSidebar.jsx
+++ b/src/components/ResourceSidebar.jsx
@@ -18,14 +18,14 @@ export default function ResourceSidebar() {
       {sections.map((g, i) =>
         g.settlers ? (
           <SettlerSection
-            key={g.title}
+            key={g.id || g.title}
             title={g.title}
             info={settlersInfo}
             noBottomBorder={i === sections.length - 1}
           />
         ) : g.happiness ? (
           <Accordion
-            key={g.title}
+            key={g.id || g.title}
             title={g.title}
             contentClassName="p-0"
             noBottomBorder={i === sections.length - 1}
@@ -60,7 +60,7 @@ export default function ResourceSidebar() {
           </Accordion>
         ) : (
           <Accordion
-            key={g.title}
+            key={g.id || g.title}
             title={g.title}
             defaultOpen={g.defaultOpen}
             contentClassName="p-0"

--- a/src/components/useResourceSections.js
+++ b/src/components/useResourceSections.js
@@ -110,12 +110,12 @@ export function useResourceSections(state) {
       }
       rendered.push(section);
       if (hasRadioResearch && g.title === 'Science')
-        rendered.push({ title: 'Settlers', settlers: true });
+        rendered.push({ id: 'settlers', title: 'Settlers', settlers: true });
     });
     if (hasRadioResearch && !rendered.some((e) => e.title === 'Settlers'))
-      rendered.push({ title: 'Settlers', settlers: true });
-    rendered.push({ title: 'Happiness', happiness: true });
-    return rendered;
+      rendered.push({ id: 'settlers', title: 'Settlers', settlers: true });
+    rendered.push({ id: 'happiness', title: 'Happiness', happiness: true });
+    return rendered.map((s, i) => ({ ...s, id: s.id ?? String(i) }));
   }, [resourceSections, hasRadioResearch, powerStatus, powerMessage]);
 
   const settlersInfo = {

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -442,6 +442,7 @@ export function getResourceSections(state) {
   }
 
   return Object.entries(groups).map(([cat, items]) => ({
+    id: cat,
     title: CATEGORY_LABELS[cat] || cat,
     items,
     defaultOpen: true,


### PR DESCRIPTION
## Summary
- ensure resource sections expose stable `id`s and fallback to index if missing
- use section `id` for React keys in `ResourceSidebar`

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 46 files)*

------
https://chatgpt.com/codex/tasks/task_e_68a054aaedb883318805e767bad16fda