### PR TITLE
Format resource rates in ResourceRow

### DIFF
--- a/src/components/ResourceRow.jsx
+++ b/src/components/ResourceRow.jsx
@@ -45,7 +45,9 @@ export default function ResourceRow({
             {capacity != null && ` / ${formatAmount(capacity)}`}
           </span>
         ) : rate != null ? (
-          <span className="text-xs text-muted-foreground">{rate}</span>
+          <span className="text-xs text-muted-foreground">
+            {formatRate(rate)}
+          </span>
         ) : null}
       </span>
     </li>
@@ -67,7 +69,7 @@ ResourceRow.propTypes = {
   amount: PropTypes.number.isRequired,
   capacity: PropTypes.number,
   capped: PropTypes.bool,
-  rate: PropTypes.string,
+  rate: PropTypes.number,
   tooltip: PropTypes.node,
   supply: PropTypes.number,
   demand: PropTypes.number,

--- a/src/components/__tests__/ResourceRow.test.jsx
+++ b/src/components/__tests__/ResourceRow.test.jsx
@@ -9,10 +9,12 @@ import { BALANCE } from '../../data/balance.js';
 
 describe('ResourceRow', () => {
   it('shows capacity when amount is within epsilon of cap', () => {
-    const createRng = (seed = 1) => () => {
-      seed = (seed * 16807) % 2147483647;
-      return (seed - 1) / 2147483646;
-    };
+    const createRng =
+      (seed = 1) =>
+      () => {
+        seed = (seed * 16807) % 2147483647;
+        return (seed - 1) / 2147483646;
+      };
     const rng = createRng();
     const state = deepClone(defaultState);
     const cap = 200;
@@ -29,5 +31,10 @@ describe('ResourceRow', () => {
       />,
     );
     expect(screen.getByText('200 / 200')).toBeTruthy();
+  });
+
+  it('formats numeric rate', () => {
+    render(<ResourceRow name="Wood" amount={10} rate={0.5} />);
+    expect(screen.getByText('+0.5/s')).toBeTruthy();
   });
 });

--- a/src/components/useResourceSections.test.js
+++ b/src/components/useResourceSections.test.js
@@ -62,5 +62,6 @@ describe('useResourceSections', () => {
     expect(powerRow.stored).toBe(5);
     expect(powerRow.capacity).toBe(10);
     expect(powerRow.status).toBe('charging');
+    expect(powerRow.rate).toBe(0);
   });
 });

--- a/src/state/__tests__/selectors.test.js
+++ b/src/state/__tests__/selectors.test.js
@@ -5,7 +5,6 @@ import {
   getPowerStatus,
   calculateFoodCapacity,
   getCapacity,
-
 } from '../selectors.js';
 import { defaultState } from '../defaultState.js';
 import { deepClone } from '../../utils/clone.ts';
@@ -64,9 +63,9 @@ describe('power selectors', () => {
     expect(row.demand).toBe(1);
     expect(row.amount).toBe(3);
     expect(row.capacity).toBe(10);
+    expect(row.rate).toBe(0);
   });
 });
-
 
 describe('capacity calculations', () => {
   it('getCapacity accounts for storage buildings', () => {
@@ -82,6 +81,5 @@ describe('capacity calculations', () => {
     expect(base).toBe(300);
     state.buildings.foodStorage = { count: 1 };
     expect(calculateFoodCapacity(state)).toBe(525);
-
   });
 });

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -143,8 +143,7 @@ function aggregateBuildingRates(state, roleBonuses) {
         sum + (RESOURCES[id].category === 'FOOD' ? resources[id] : 0),
       0,
     );
-  const foodCapacity =
-    state.foodPool?.capacity ?? calculateFoodCapacity(state);
+  const foodCapacity = state.foodPool?.capacity ?? calculateFoodCapacity(state);
   PRODUCTION_BUILDINGS.forEach((b) => {
     const entry = state.buildings?.[b.id];
     const count = entry?.count || 0;
@@ -234,11 +233,7 @@ function aggregateBuildingRates(state, roleBonuses) {
         const bonus = roleBonuses[role] || 0;
         const researchBonus = getResearchOutputBonus(state, resId);
         let gain =
-          base *
-          mult *
-          count *
-          (1 + bonus + researchBonus) *
-          factorRes;
+          base * mult * count * (1 + bonus + researchBonus) * factorRes;
         if (category === 'FOOD') {
           const room = foodCapacity - totalFoodAmount;
           gain = room > 0 ? Math.min(gain, room) : 0;
@@ -390,7 +385,7 @@ function buildResourceGroups(state, netRates, prodRates) {
         amount,
         capacity,
         capped,
-        rate: rateInfo.label,
+        rate: rateInfo.perSec,
         tooltip: undefined,
       };
       if (isPower) {
@@ -421,7 +416,7 @@ function createFoodTotalRow(state, foodIds, netRates) {
     name: 'Total',
     amount: totalAmount,
     capacity: totalCapacity,
-    rate: formatRate(totalNetRate),
+    rate: totalNetRate,
   };
 }
 


### PR DESCRIPTION
## Summary
- Accept numeric rate values in ResourceRow and format them internally
- Pass raw per-second rates from selectors instead of preformatted strings
- Expand tests to cover rate formatting and numeric rate values

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 47 files)*
- `npm run typecheck` *(fails: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fe7578f88331bb3fbcc870d5033e