### PR TITLE
feat: sanitize log output

### DIFF
--- a/src/components/EventLog.jsx
+++ b/src/components/EventLog.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ScrollArea } from './ui/scroll-area';
 import { Card, CardContent } from './ui/card';
+import { sanitize } from '../utils/sanitize.js';
 
 export default function EventLog({ log = [] }) {
   return (
@@ -14,7 +15,9 @@ export default function EventLog({ log = [] }) {
                 <span className="text-muted-foreground mr-2">
                   {new Date(entry.time).toLocaleString()}
                 </span>
-                {entry.text}
+                <span
+                  dangerouslySetInnerHTML={{ __html: sanitize(entry.text) }}
+                />
               </li>
             ))}
           </ul>

--- a/src/components/EventLog.test.jsx
+++ b/src/components/EventLog.test.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
 import EventLog from './EventLog.jsx';
+
+afterEach(cleanup);
 
 describe('EventLog', () => {
   it('renders without log prop', () => {
@@ -26,5 +28,13 @@ describe('EventLog', () => {
       /Second entry/,
     );
     expect(screen.getAllByRole('listitem')).toHaveLength(1);
+  });
+
+  it('sanitizes malicious text', () => {
+    const malicious = '<img src=x onerror="alert(1)">';
+    render(<EventLog log={[{ id: 'x', text: malicious, time: 0 }]} />);
+    const item = screen.getByRole('listitem');
+    expect(item.innerHTML).not.toContain('<img');
+    expect(item.textContent).toContain(malicious);
   });
 });

--- a/src/components/OfflineProgressModal.jsx
+++ b/src/components/OfflineProgressModal.jsx
@@ -3,6 +3,7 @@ import { useGame } from '../state/useGame.tsx';
 import { formatTime } from '../utils/time.js';
 import { Button } from './Button';
 import { RESOURCES } from '../data/resources.js';
+import { sanitize } from '../utils/sanitize.js';
 import {
   Dialog,
   DialogContent,
@@ -52,19 +53,14 @@ export default function OfflineProgressModal() {
                 <h3 className="text-lg font-semibold">Resources</h3>
                 <ul className="space-y-1 text-sm">
                   {resources.map(([res, amt]) => (
-                    <li
-                      key={res}
-                      className="flex items-center justify-between"
-                    >
+                    <li key={res} className="flex items-center justify-between">
                       <span className="flex items-center gap-2">
                         {RESOURCES[res]?.icon && (
                           <span>{RESOURCES[res].icon}</span>
                         )}
                         <span>{RESOURCES[res]?.name || res}</span>
                       </span>
-                      <span className="font-mono">
-                        {Math.floor(amt)}
-                      </span>
+                      <span className="font-mono">{Math.floor(amt)}</span>
                     </li>
                   ))}
                 </ul>
@@ -79,7 +75,11 @@ export default function OfflineProgressModal() {
                     <h4 className="font-medium">{e.title}</h4>
                     <ul className="list-disc space-y-1 pl-5 text-sm">
                       {e.items.map((text, i) => (
-                        <li key={i}>{text}</li>
+                        <li key={i}>
+                          <span
+                            dangerouslySetInnerHTML={{ __html: sanitize(text) }}
+                          />
+                        </li>
                       ))}
                     </ul>
                   </div>

--- a/src/utils/sanitize.js
+++ b/src/utils/sanitize.js
@@ -1,0 +1,10 @@
+export function sanitize(text = '') {
+  const map = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  };
+  return String(text).replace(/[&<>"']/g, (char) => map[char]);
+}

--- a/src/utils/sanitize.test.js
+++ b/src/utils/sanitize.test.js
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { sanitize } from './sanitize.js';
+
+describe('sanitize', () => {
+  it('escapes HTML special characters', () => {
+    const input = `<img src=x onerror="alert(1)">&"'`;
+    const expected =
+      '&lt;img src=x onerror=&quot;alert(1)&quot;&gt;&amp;&quot;&#39;';
+    expect(sanitize(input)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- add sanitize helper to escape HTML special characters
- sanitize log text in EventLog and OfflineProgressModal
- test that log sanitizer neutralizes malicious content

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 48 files)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ff6f43108331b82dc00f76df2ad9