### PR TITLE
refactor: add typing to notifications hook

### DIFF
--- a/src/engine/candidates.ts
+++ b/src/engine/candidates.ts
@@ -2,11 +2,11 @@ import { FIRST_NAMES, LAST_NAMES } from '../data/names.js';
 import { ROLE_LIST } from '../data/roles.js';
 import { DAYS_PER_YEAR } from './time.ts';
 
-interface SkillEntry {
+export interface SkillEntry {
   level: number;
 }
 
-type SkillMap = Record<string, SkillEntry>;
+export type SkillMap = Record<string, SkillEntry>;
 
 export interface Candidate {
   id: string;

--- a/src/state/useGame.tsx
+++ b/src/state/useGame.tsx
@@ -14,6 +14,12 @@ export interface BuildingEntry {
   offlineReason?: string;
 }
 
+export interface ResourceState {
+  amount: number;
+  discovered?: boolean;
+  produced?: number;
+}
+
 export interface GameContextValue {
   state: GameState;
   setActiveTab: (tab: string) => void;


### PR DESCRIPTION
## Summary
- remove ts-nocheck and add strict typing to `useNotifications`
- export shared types for resources and skills

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a10036f03c8331ad1875317fcc3ac7