### PR TITLE
refactor: add typings to production

### DIFF
--- a/src/engine/__tests__/radio.test.ts
+++ b/src/engine/__tests__/radio.test.ts
@@ -42,7 +42,7 @@ describe('radio building production', () => {
       buildings: { radio: { count: 1 } },
       resources: { power: { amount: 1 } },
     };
-    const next = applyProduction(state, 5);
+    const next = applyProduction(state, 5, {});
     expect(next.resources.power.amount).toBeCloseTo(0.5, 5);
   });
 
@@ -64,6 +64,6 @@ describe('buildings without inputs or outputs', () => {
 
   it('do not crash production calculations', () => {
     const state = { buildings: { shelter: { count: 1 } }, resources: {} };
-    expect(() => applyProduction(state, 5)).not.toThrow();
+    expect(() => applyProduction(state, 5, {})).not.toThrow();
   });
 });

--- a/src/engine/settlers.ts
+++ b/src/engine/settlers.ts
@@ -13,6 +13,8 @@ import { RESOURCES } from '../data/resources.js';
 import { addResource, consumeResource } from './resourceOps.ts';
 import { createLogEntry } from '../utils/log.js';
 
+export type RoleBonusMap = Record<string, number>;
+
 export function computeRoleBonuses(settlers: any[]): Record<string, number> {
   const bonuses: Record<string, number> = {};
   settlers.forEach((s) => {


### PR DESCRIPTION
## Summary
- remove `@ts-nocheck` and add type-safe imports to production engine
- expose `RoleBonusMap` and refactor production helpers with typed records
- adjust radio tests for new production signature

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a101cfa1108331a99ffd024649b36d