### PR TITLE
refactor: type game tick helpers

### DIFF
--- a/src/engine/__tests__/gameTick.test.ts
+++ b/src/engine/__tests__/gameTick.test.ts
@@ -56,10 +56,14 @@ describe('applyProduction', () => {
     (RESOURCES as any).metal = { category: 'METAL' };
 
     const roleBonuses = { farmer: 0.1, builder: 0.05 };
-    const result = applyProduction({ population: { settlers: [] } }, 1, roleBonuses);
+    const result = applyProduction(
+      { population: { settlers: [] } } as any,
+      1,
+      roleBonuses,
+    );
 
     expect(processTick).toHaveBeenCalledWith(
-      { population: { settlers: [] } },
+      { population: { settlers: [] } } as any,
       1,
       { builder: 0.05 },
     );
@@ -87,11 +91,15 @@ describe('applyProduction', () => {
     (calculateFoodCapacity as any).mockReturnValue(100);
     (RESOURCES as any).potatoes = { category: 'FOOD' };
 
-    const result = applyProduction({ population: { settlers: [] } }, 1, {
-      farmer: 1,
-    });
+    const result = applyProduction(
+      { population: { settlers: [] } } as any,
+      1,
+      {
+        farmer: 1,
+      },
+    );
 
-    expect(result.state.resources.potatoes.amount).toBe(100);
+    expect((result.state as any).resources.potatoes.amount).toBe(100);
   });
 });
 
@@ -101,9 +109,14 @@ describe('applySettlers', () => {
     (processSettlersTick as any).mockReturnValue({
       state: 'settlersProcessed',
       telemetry: 'tele',
+      events: [],
     });
     const rng = () => 0.5;
-    const result = applySettlers({ population: { settlers: [] } }, 1, rng);
+    const result = applySettlers(
+      { population: { settlers: [] } } as any,
+      1,
+      rng,
+    );
     expect(computeRoleBonuses).toHaveBeenCalledWith([]);
     expect(processSettlersTick).toHaveBeenCalledWith(
       { population: { settlers: [] } },
@@ -115,6 +128,7 @@ describe('applySettlers', () => {
     expect(result).toEqual({
       state: 'settlersProcessed',
       telemetry: 'tele',
+      events: [],
       roleBonuses: { farmer: 0.2 },
     });
   });
@@ -133,14 +147,14 @@ describe('applyYearUpdate', () => {
       colony: {},
       meta: {},
     };
-    const telemetry = { some: 'data' };
+    const telemetry = { some: 'data' } as any;
     const result = applyYearUpdate(state as any, 10, telemetry);
-    expect(result.population).toMatchObject({
+    expect((result as any).population).toMatchObject({
       settlers: [{ id: 1, ageDays: DAYS_PER_YEAR }],
       candidate: 'cand',
     });
-    expect(result.colony.radioTimer).toBe(5);
-    expect(result.gameTime).toEqual({ seconds: 10, year: 2 });
-    expect(result.meta?.telemetry?.settlers).toBe(telemetry);
+    expect((result as any).colony.radioTimer).toBe(5);
+    expect((result as any).gameTime).toEqual({ seconds: 10, year: 2 });
+    expect((result as any).meta?.telemetry?.settlers).toBe(telemetry);
   });
 });

--- a/src/engine/gameTick.ts
+++ b/src/engine/gameTick.ts
@@ -1,5 +1,3 @@
-// @ts-nocheck
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { processTick } from './production.ts';
 import { processResearchTick } from './research.ts';
 import { getResourceRates, calculateFoodCapacity } from '../state/selectors.js';
@@ -7,9 +5,17 @@ import { RESOURCES } from '../data/resources.js';
 import { processSettlersTick, computeRoleBonuses } from './settlers.ts';
 import { updateRadio } from './radio.ts';
 import { getYear, DAYS_PER_YEAR } from './time.ts';
+import type { GameState } from '../state/useGame.tsx';
+import type { RoleBonusMap } from './settlers.ts';
+import type { TickTelemetry, TickEvents } from './gameTick.types.ts';
+import type { Settler } from './candidates.ts';
 
-export function applyProduction(prev: any, dt: number, roleBonuses: any) {
-  const productionBonuses = { ...roleBonuses };
+export function applyProduction(
+  prev: GameState,
+  dt: number,
+  roleBonuses: RoleBonusMap,
+): { state: GameState; roleBonuses: RoleBonusMap; bonusFoodPerSec: number } {
+  const productionBonuses: RoleBonusMap = { ...roleBonuses };
   const farmerBonus = productionBonuses.farmer || 0;
   delete productionBonuses.farmer;
 
@@ -18,14 +24,15 @@ export function applyProduction(prev: any, dt: number, roleBonuses: any) {
 
   const rates = getResourceRates(withResearch);
   let totalFoodProdBase = 0;
-  Object.keys(RESOURCES).forEach((id) => {
-    if (RESOURCES[id].category === 'FOOD') {
+  const resourceMap = RESOURCES as Record<string, any>;
+  Object.keys(resourceMap).forEach((id) => {
+    if (resourceMap[id].category === 'FOOD') {
       totalFoodProdBase += rates[id]?.perSec || 0;
     }
   });
   const bonusFoodPerSec = totalFoodProdBase * farmerBonus;
 
-  let state = withResearch;
+  let state: GameState = withResearch;
   if (bonusFoodPerSec) {
     const foodCapacity = calculateFoodCapacity(withResearch);
     const currentPool = withResearch.foodPool?.amount || 0;
@@ -56,41 +63,62 @@ export function applyProduction(prev: any, dt: number, roleBonuses: any) {
   return { state, roleBonuses, bonusFoodPerSec };
 }
 
-export function applySettlers(state: any, dt: number, rng = Math.random) {
+export function applySettlers(
+  state: GameState,
+  dt: number,
+  rng = Math.random,
+): {
+  state: GameState;
+  telemetry: TickTelemetry;
+  events: TickEvents;
+  roleBonuses: RoleBonusMap;
+} {
   const roleBonuses = computeRoleBonuses(state.population?.settlers || []);
-  const result = processSettlersTick(state, dt, 0, rng, roleBonuses);
-  return { ...result, roleBonuses };
+  const result = processSettlersTick(state, dt, 0, rng, roleBonuses) as {
+    state: GameState;
+    telemetry: TickTelemetry;
+    events?: TickEvents;
+  };
+  return {
+    ...result,
+    events: result.events || [],
+    roleBonuses,
+  };
 }
 
-export function applyYearUpdate(state: any, dt: number, telemetry: any) {
+export function applyYearUpdate(
+  state: GameState,
+  dt: number,
+  telemetry: TickTelemetry,
+): GameState {
   const { candidate, radioTimer } = updateRadio(state, dt);
   const nextSeconds = (state.gameTime?.seconds || 0) + dt;
   const computedYear = getYear({
     ...state,
     gameTime: { ...state.gameTime, seconds: nextSeconds },
   });
-  let year = state.gameTime?.year || 1;
-  let settlers = state.population.settlers;
+  let year = (state.gameTime as any)?.year || 1;
+  let settlers: GameState['population']['settlers'] = state.population.settlers;
   if (computedYear > year) {
     const diff = computedYear - year;
     year = computedYear;
-    settlers = settlers.map((s: any) => ({
+    settlers = settlers.map((s: Settler) => ({
       ...s,
       ageDays: (s.ageDays || 0) + diff * DAYS_PER_YEAR,
-    }));
+    })) as GameState['population']['settlers'];
   }
   return {
     ...state,
-    population: { ...state.population, settlers, candidate },
-    colony: { ...state.colony, radioTimer },
-    gameTime: { seconds: nextSeconds, year },
+    population: { ...state.population, settlers, candidate } as GameState['population'],
+    colony: { ...state.colony, radioTimer } as GameState['colony'],
+    gameTime: { seconds: nextSeconds, year } as GameState['gameTime'],
     meta: {
       ...state.meta,
       telemetry: {
-        ...state.meta?.telemetry,
+        ...(state.meta as any)?.telemetry,
         settlers: telemetry,
       },
-    },
-  };
+    } as GameState['meta'],
+  } as GameState;
 }
 

--- a/src/engine/gameTick.types.ts
+++ b/src/engine/gameTick.types.ts
@@ -1,0 +1,19 @@
+import type { RoleBonusMap } from './settlers.ts';
+
+export interface TickTelemetry {
+  netFoodPerSec: number;
+  bonusFoodPerSec: number;
+  totalFoodBonusPercent: number;
+  totalSettlersConsumption: number;
+  potatoes: number;
+  starvationTimerSeconds: number;
+  roleBonuses: RoleBonusMap;
+}
+
+export interface TickEvent {
+  id: string;
+  text: string;
+  time: number;
+}
+
+export type TickEvents = TickEvent[];

--- a/src/engine/production.ts
+++ b/src/engine/production.ts
@@ -43,7 +43,7 @@ const ROLE_BUILDINGS_MAP = ROLE_BUILDINGS as Record<string, string[]>;
 export function applyProduction(
   state: GameState,
   seconds = 1,
-  roleBonuses: RoleBonusMap,
+  roleBonuses: RoleBonusMap = {},
 ): GameState {
   ensureCapacityCache(state);
   const season = getSeason(state);
@@ -283,7 +283,7 @@ export function applyProduction(
 export function processTick(
   state: GameState,
   seconds = 1,
-  roleBonuses: RoleBonusMap,
+  roleBonuses: RoleBonusMap = {},
 ): GameState {
   return applyProduction(state, seconds, roleBonuses);
 }


### PR DESCRIPTION
## Summary
- add `TickTelemetry` and `TickEvents` interfaces
- type `applyProduction`, `applySettlers`, and `applyYearUpdate`
- default `roleBonuses` in production helpers

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a108c794648331950b260bb39bd34b