### PR TITLE
chore: refresh economy reports

### DIFF
--- a/docs/ECONOMY_REPORT.md
+++ b/docs/ECONOMY_REPORT.md
@@ -1,7 +1,7 @@
 # Economy Report
 
 ## 1) Overview
-Economy generated from commit **4cfa11f4a328e554d2317b78e8d24cc3c0616ad3** on 2025-08-14 09:33:20 +0200. Save version: **7**.
+Economy generated from commit **1b5f7109aeab326544a4b683f2c570a0e9933e3d** on 2025-08-17 00:52:21 +0200. Save version: **7**.
 Each tick represents 1 second. For each building: base production is modified by season multipliers, summed, then clamped to capacity. Offline progress processes in 60-second chunks.
 
 ## 2) Resources

--- a/docs/economy-snapshot.js
+++ b/docs/economy-snapshot.js
@@ -1,4 +1,4 @@
-{
+export default {
   "version": "1b5f7109aeab326544a4b683f2c570a0e9933e3d",
   "saveVersion": 7,
   "tickSeconds": 1,
@@ -1475,3 +1475,4 @@
     "shelter": 1
   }
 }
+

--- a/reports/economy/20250816230044/CHANGELOG.md
+++ b/reports/economy/20250816230044/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+_No changes recorded for this report._

--- a/reports/economy/20250816230044/baseline.json
+++ b/reports/economy/20250816230044/baseline.json
@@ -1,0 +1,566 @@
+{
+  "meta": {
+    "analyzed": 20,
+    "season": "average",
+    "weights": {
+      "wood": 1,
+      "stone": 1.3,
+      "scrap": 2.2,
+      "planks": 4,
+      "metalParts": 6,
+      "power": 1,
+      "potatoes": 0.9,
+      "meat": 1.4,
+      "science": 2.5
+    },
+    "targets": [
+      1,
+      10,
+      50
+    ],
+    "thresholds": {
+      "generators": {
+        "pbt1": [
+          60,
+          120
+        ],
+        "pbt10": [
+          180,
+          480
+        ],
+        "pbt50": [
+          900,
+          2700
+        ]
+      },
+      "converters": {
+        "pbt1": [
+          90,
+          150
+        ],
+        "pbt10": [
+          240,
+          600
+        ],
+        "pbt50": [
+          1200,
+          3600
+        ]
+      }
+    },
+    "outliers": {
+      "tooFast": 0,
+      "tooSlow": 15
+    }
+  },
+  "buildings": [
+    {
+      "id": "potatoField",
+      "category": "Food",
+      "type": "production",
+      "growth": 1.12,
+      "pbt": {
+        "1": 64.99402628434886,
+        "10": 183.51254480286735,
+        "50": 16772.28195937873
+      },
+      "outputs": {
+        "potatoes": 0.375
+      },
+      "inputs": {}
+    },
+    {
+      "id": "huntersHut",
+      "category": "Food",
+      "type": "production",
+      "growth": 1.15,
+      "pbt": {
+        "1": 193.001443001443,
+        "10": 687.5901875901876,
+        "50": 181877.34487734488
+      },
+      "outputs": {
+        "meat": 0.22
+      },
+      "inputs": {}
+    },
+    {
+      "id": "loggingCamp",
+      "category": "Raw Materials",
+      "type": "production",
+      "growth": 1.12,
+      "pbt": {
+        "1": 115.78947368421053,
+        "10": 324.21052631578954,
+        "50": 29881.403508771935
+      },
+      "outputs": {
+        "wood": 0.3
+      },
+      "inputs": {}
+    },
+    {
+      "id": "scrapyard",
+      "category": "Raw Materials",
+      "type": "production",
+      "growth": 1.12,
+      "pbt": {
+        "1": 71.77033492822966,
+        "10": 203.3492822966507,
+        "50": 18522.727272727272
+      },
+      "outputs": {
+        "scrap": 0.08
+      },
+      "inputs": {}
+    },
+    {
+      "id": "quarry",
+      "category": "Raw Materials",
+      "type": "production",
+      "growth": 1.12,
+      "pbt": {
+        "1": 209.17678812415656,
+        "10": 585.6950067476384,
+        "50": 53989.20377867747
+      },
+      "outputs": {
+        "stone": 0.12
+      },
+      "inputs": {}
+    },
+    {
+      "id": "brickKiln",
+      "category": "Construction Materials",
+      "type": "processing",
+      "growth": 1.13,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {
+        "bricks": 0.4
+      },
+      "inputs": {
+        "stone": 0.4,
+        "wood": 0.3
+      }
+    },
+    {
+      "id": "sawmill",
+      "category": "Construction Materials",
+      "type": "processing",
+      "growth": 1.13,
+      "pbt": {
+        "1": 94.91666666666667,
+        "10": 288.50000000000006,
+        "50": 37862.00000000001
+      },
+      "outputs": {
+        "planks": 0.5
+      },
+      "inputs": {
+        "wood": 0.8
+      }
+    },
+    {
+      "id": "metalWorkshop",
+      "category": "Construction Materials",
+      "type": "processing",
+      "growth": 1.13,
+      "pbt": {
+        "1": 98.02631578947367,
+        "10": 299.67105263157896,
+        "50": 39102.697368421046
+      },
+      "outputs": {
+        "metalParts": 0.4
+      },
+      "inputs": {
+        "scrap": 0.4
+      }
+    },
+    {
+      "id": "toolsmithy",
+      "category": "Construction Materials",
+      "type": "processing",
+      "growth": 1.13,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {
+        "tools": 0.18
+      },
+      "inputs": {
+        "planks": 0.25,
+        "metalParts": 0.15,
+        "power": 0.4
+      }
+    },
+    {
+      "id": "school",
+      "category": "Science",
+      "type": "production",
+      "growth": 1.13,
+      "pbt": {
+        "1": 64,
+        "10": 196,
+        "50": 25530.222222222223
+      },
+      "outputs": {
+        "science": 0.45
+      },
+      "inputs": {}
+    },
+    {
+      "id": "woodGenerator",
+      "category": "Energy",
+      "type": "production",
+      "growth": 1.13,
+      "pbt": {
+        "1": 270.6666666666667,
+        "10": 828.4,
+        "50": 107968.93333333333
+      },
+      "outputs": {
+        "power": 1
+      },
+      "inputs": {
+        "wood": 0.25
+      }
+    },
+    {
+      "id": "shelter",
+      "category": "Settlement",
+      "type": "production",
+      "growth": 1.8,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    },
+    {
+      "id": "radio",
+      "category": "Utilities",
+      "type": "production",
+      "growth": 1,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {
+        "power": 0.1
+      }
+    },
+    {
+      "id": "foodStorage",
+      "category": "",
+      "type": "storage",
+      "growth": 1.22,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    },
+    {
+      "id": "largeGranary",
+      "category": "",
+      "type": "storage",
+      "growth": 1.15,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    },
+    {
+      "id": "rawStorage",
+      "category": "",
+      "type": "storage",
+      "growth": 1.22,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    },
+    {
+      "id": "largeWarehouse",
+      "category": "",
+      "type": "storage",
+      "growth": 1.15,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    },
+    {
+      "id": "materialsDepot",
+      "category": "",
+      "type": "storage",
+      "growth": 1.22,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    },
+    {
+      "id": "largeMaterialsDepot",
+      "category": "",
+      "type": "storage",
+      "growth": 1.15,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    },
+    {
+      "id": "battery",
+      "category": "",
+      "type": "storage",
+      "growth": 1.22,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    }
+  ],
+  "converters": [
+    {
+      "id": "brickKiln",
+      "growth": 1.13,
+      "inputs": {
+        "stone": 0.4,
+        "wood": 0.3
+      },
+      "outputs": {
+        "bricks": 0.4
+      },
+      "ratio": 0,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "mode": "all-or-nothing"
+    },
+    {
+      "id": "sawmill",
+      "growth": 1.13,
+      "inputs": {
+        "wood": 0.8
+      },
+      "outputs": {
+        "planks": 0.5
+      },
+      "ratio": 2.5,
+      "pbt": {
+        "1": 94.91666666666667,
+        "10": 288.50000000000006,
+        "50": 37862.00000000001
+      },
+      "mode": "all-or-nothing"
+    },
+    {
+      "id": "metalWorkshop",
+      "growth": 1.13,
+      "inputs": {
+        "scrap": 0.4
+      },
+      "outputs": {
+        "metalParts": 0.4
+      },
+      "ratio": 2.7272727272727275,
+      "pbt": {
+        "1": 98.02631578947367,
+        "10": 299.67105263157896,
+        "50": 39102.697368421046
+      },
+      "mode": "all-or-nothing"
+    },
+    {
+      "id": "toolsmithy",
+      "growth": 1.13,
+      "inputs": {
+        "planks": 0.25,
+        "metalParts": 0.15,
+        "power": 0.4
+      },
+      "outputs": {
+        "tools": 0.18
+      },
+      "ratio": 0,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "mode": "all-or-nothing"
+    }
+  ],
+  "storage": [
+    {
+      "id": "foodStorage",
+      "growth": 1.22,
+      "capacity": {
+        "FOOD": 225
+      }
+    },
+    {
+      "id": "largeGranary",
+      "growth": 1.15,
+      "capacity": {
+        "FOOD": 600
+      }
+    },
+    {
+      "id": "rawStorage",
+      "growth": 1.22,
+      "capacity": {
+        "wood": 120,
+        "scrap": 80,
+        "stone": 60
+      }
+    },
+    {
+      "id": "largeWarehouse",
+      "growth": 1.15,
+      "capacity": {
+        "wood": 400,
+        "stone": 160,
+        "scrap": 240
+      }
+    },
+    {
+      "id": "materialsDepot",
+      "growth": 1.22,
+      "capacity": {
+        "planks": 100,
+        "metalParts": 40
+      }
+    },
+    {
+      "id": "largeMaterialsDepot",
+      "growth": 1.15,
+      "capacity": {
+        "planks": 180,
+        "metalParts": 90,
+        "bricks": 180
+      }
+    },
+    {
+      "id": "battery",
+      "growth": 1.22,
+      "capacity": {
+        "power": 40
+      }
+    }
+  ],
+  "outliers": {
+    "tooFast": [],
+    "tooSlow": [
+      {
+        "id": "potatoField",
+        "target": 50,
+        "value": 16772.28195937873
+      },
+      {
+        "id": "huntersHut",
+        "target": 1,
+        "value": 193.001443001443
+      },
+      {
+        "id": "huntersHut",
+        "target": 10,
+        "value": 687.5901875901876
+      },
+      {
+        "id": "huntersHut",
+        "target": 50,
+        "value": 181877.34487734488
+      },
+      {
+        "id": "loggingCamp",
+        "target": 50,
+        "value": 29881.403508771935
+      },
+      {
+        "id": "scrapyard",
+        "target": 50,
+        "value": 18522.727272727272
+      },
+      {
+        "id": "quarry",
+        "target": 1,
+        "value": 209.17678812415656
+      },
+      {
+        "id": "quarry",
+        "target": 10,
+        "value": 585.6950067476384
+      },
+      {
+        "id": "quarry",
+        "target": 50,
+        "value": 53989.20377867747
+      },
+      {
+        "id": "sawmill",
+        "target": 50,
+        "value": 37862.00000000001
+      },
+      {
+        "id": "metalWorkshop",
+        "target": 50,
+        "value": 39102.697368421046
+      },
+      {
+        "id": "school",
+        "target": 50,
+        "value": 25530.222222222223
+      },
+      {
+        "id": "woodGenerator",
+        "target": 1,
+        "value": 270.6666666666667
+      },
+      {
+        "id": "woodGenerator",
+        "target": 10,
+        "value": 828.4
+      },
+      {
+        "id": "woodGenerator",
+        "target": 50,
+        "value": 107968.93333333333
+      }
+    ]
+  }
+}

--- a/reports/economy/20250816230044/baseline.md
+++ b/reports/economy/20250816230044/baseline.md
@@ -1,0 +1,68 @@
+# Economy Report
+
+## Summary
+Analyzed **20** buildings. Season mode: **average**.
+Weights: {"wood":1,"stone":1.3,"scrap":2.2,"planks":4,"metalParts":6,"power":1,"potatoes":0.9,"meat":1.4,"science":2.5}. Targets: 1, 10, 50.
+Outliers – too fast: 0, too slow: 15.
+
+## Buildings
+| id | category | type | growth | PBT@1 | PBT@10 | PBT@50 | out/s (base) | in/s (base) |
+| - | - | - | - | - | - | - | - | - |
+| potatoField | Food | production | 1.12 | 64.99 | 183.51 | 16,772.28 | potatoes:0.375 | - |
+| huntersHut | Food | production | 1.15 | 193 | 687.59 | 181,877.34 | meat:0.22 | - |
+| loggingCamp | Raw Materials | production | 1.12 | 115.79 | 324.21 | 29,881.4 | wood:0.3 | - |
+| scrapyard | Raw Materials | production | 1.12 | 71.77 | 203.35 | 18,522.73 | scrap:0.08 | - |
+| quarry | Raw Materials | production | 1.12 | 209.18 | 585.7 | 53,989.2 | stone:0.12 | - |
+| brickKiln | Construction Materials | processing | 1.13 | — | — | — | bricks:0.4 | stone:0.4,wood:0.3 |
+| sawmill | Construction Materials | processing | 1.13 | 94.92 | 288.5 | 37,862 | planks:0.5 | wood:0.8 |
+| metalWorkshop | Construction Materials | processing | 1.13 | 98.03 | 299.67 | 39,102.7 | metalParts:0.4 | scrap:0.4 |
+| toolsmithy | Construction Materials | processing | 1.13 | — | — | — | tools:0.18 | planks:0.25,metalParts:0.15,power:0.4 |
+| school | Science | production | 1.13 | 64 | 196 | 25,530.22 | science:0.45 | - |
+| woodGenerator | Energy | production | 1.13 | 270.67 | 828.4 | 107,968.93 | power:1 | wood:0.25 |
+| shelter | Settlement | production | 1.8 | — | — | — | - | - |
+| radio | Utilities | production | 1 | — | — | — | - | power:0.1 |
+| foodStorage |  | storage | 1.22 | — | — | — | - | - |
+| largeGranary |  | storage | 1.15 | — | — | — | - | - |
+| rawStorage |  | storage | 1.22 | — | — | — | - | - |
+| largeWarehouse |  | storage | 1.15 | — | — | — | - | - |
+| materialsDepot |  | storage | 1.22 | — | — | — | - | - |
+| largeMaterialsDepot |  | storage | 1.15 | — | — | — | - | - |
+| battery |  | storage | 1.22 | — | — | — | - | - |
+
+## Converters
+| id | growth | in/s | out/s | ratio(out/in) | PBT@1 | PBT@10 | PBT@50 | mode |
+| - | - | - | - | - | - | - | - | - |
+| brickKiln | 1.13 | stone:0.4,wood:0.3 | bricks:0.4 | 0 | — | — | — | all-or-nothing |
+| sawmill | 1.13 | wood:0.8 | planks:0.5 | 2.5 | 94.92 | 288.5 | 37,862 | all-or-nothing |
+| metalWorkshop | 1.13 | scrap:0.4 | metalParts:0.4 | 2.73 | 98.03 | 299.67 | 39,102.7 | all-or-nothing |
+| toolsmithy | 1.13 | planks:0.25,metalParts:0.15,power:0.4 | tools:0.18 | 0 | — | — | — | all-or-nothing |
+
+## Storage
+| id | growth | +capacity |
+| - | - | - |
+| foodStorage | 1.22 | FOOD:225 |
+| largeGranary | 1.15 | FOOD:600 |
+| rawStorage | 1.22 | wood:120,scrap:80,stone:60 |
+| largeWarehouse | 1.15 | wood:400,stone:160,scrap:240 |
+| materialsDepot | 1.22 | planks:100,metalParts:40 |
+| largeMaterialsDepot | 1.15 | planks:180,metalParts:90,bricks:180 |
+| battery | 1.22 | power:40 |
+
+## Outliers
+### Too Slow
+- potatoField @50: 16,772.28 sec
+- huntersHut @1: 193 sec
+- huntersHut @10: 687.59 sec
+- huntersHut @50: 181,877.34 sec
+- loggingCamp @50: 29,881.4 sec
+- scrapyard @50: 18,522.73 sec
+- quarry @1: 209.18 sec
+- quarry @10: 585.7 sec
+- quarry @50: 53,989.2 sec
+- sawmill @50: 37,862 sec
+- metalWorkshop @50: 39,102.7 sec
+- school @50: 25,530.22 sec
+- woodGenerator @1: 270.67 sec
+- woodGenerator @10: 828.4 sec
+- woodGenerator @50: 107,968.93 sec
+

--- a/reports/economy/20250816230044/baseline_after.json
+++ b/reports/economy/20250816230044/baseline_after.json
@@ -1,0 +1,566 @@
+{
+  "meta": {
+    "analyzed": 20,
+    "season": "average",
+    "weights": {
+      "wood": 1,
+      "stone": 1.3,
+      "scrap": 2.2,
+      "planks": 4,
+      "metalParts": 6,
+      "power": 1,
+      "potatoes": 0.9,
+      "meat": 1.4,
+      "science": 2.5
+    },
+    "targets": [
+      1,
+      10,
+      50
+    ],
+    "thresholds": {
+      "generators": {
+        "pbt1": [
+          60,
+          120
+        ],
+        "pbt10": [
+          180,
+          480
+        ],
+        "pbt50": [
+          900,
+          2700
+        ]
+      },
+      "converters": {
+        "pbt1": [
+          90,
+          150
+        ],
+        "pbt10": [
+          240,
+          600
+        ],
+        "pbt50": [
+          1200,
+          3600
+        ]
+      }
+    },
+    "outliers": {
+      "tooFast": 0,
+      "tooSlow": 15
+    }
+  },
+  "buildings": [
+    {
+      "id": "potatoField",
+      "category": "Food",
+      "type": "production",
+      "growth": 1.12,
+      "pbt": {
+        "1": 64.99402628434886,
+        "10": 183.51254480286735,
+        "50": 16772.28195937873
+      },
+      "outputs": {
+        "potatoes": 0.375
+      },
+      "inputs": {}
+    },
+    {
+      "id": "huntersHut",
+      "category": "Food",
+      "type": "production",
+      "growth": 1.15,
+      "pbt": {
+        "1": 193.001443001443,
+        "10": 687.5901875901876,
+        "50": 181877.34487734488
+      },
+      "outputs": {
+        "meat": 0.22
+      },
+      "inputs": {}
+    },
+    {
+      "id": "loggingCamp",
+      "category": "Raw Materials",
+      "type": "production",
+      "growth": 1.12,
+      "pbt": {
+        "1": 115.78947368421053,
+        "10": 324.21052631578954,
+        "50": 29881.403508771935
+      },
+      "outputs": {
+        "wood": 0.3
+      },
+      "inputs": {}
+    },
+    {
+      "id": "scrapyard",
+      "category": "Raw Materials",
+      "type": "production",
+      "growth": 1.12,
+      "pbt": {
+        "1": 71.77033492822966,
+        "10": 203.3492822966507,
+        "50": 18522.727272727272
+      },
+      "outputs": {
+        "scrap": 0.08
+      },
+      "inputs": {}
+    },
+    {
+      "id": "quarry",
+      "category": "Raw Materials",
+      "type": "production",
+      "growth": 1.12,
+      "pbt": {
+        "1": 209.17678812415656,
+        "10": 585.6950067476384,
+        "50": 53989.20377867747
+      },
+      "outputs": {
+        "stone": 0.12
+      },
+      "inputs": {}
+    },
+    {
+      "id": "brickKiln",
+      "category": "Construction Materials",
+      "type": "processing",
+      "growth": 1.13,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {
+        "bricks": 0.4
+      },
+      "inputs": {
+        "stone": 0.4,
+        "wood": 0.3
+      }
+    },
+    {
+      "id": "sawmill",
+      "category": "Construction Materials",
+      "type": "processing",
+      "growth": 1.13,
+      "pbt": {
+        "1": 94.91666666666667,
+        "10": 288.50000000000006,
+        "50": 37862.00000000001
+      },
+      "outputs": {
+        "planks": 0.5
+      },
+      "inputs": {
+        "wood": 0.8
+      }
+    },
+    {
+      "id": "metalWorkshop",
+      "category": "Construction Materials",
+      "type": "processing",
+      "growth": 1.13,
+      "pbt": {
+        "1": 98.02631578947367,
+        "10": 299.67105263157896,
+        "50": 39102.697368421046
+      },
+      "outputs": {
+        "metalParts": 0.4
+      },
+      "inputs": {
+        "scrap": 0.4
+      }
+    },
+    {
+      "id": "toolsmithy",
+      "category": "Construction Materials",
+      "type": "processing",
+      "growth": 1.13,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {
+        "tools": 0.18
+      },
+      "inputs": {
+        "planks": 0.25,
+        "metalParts": 0.15,
+        "power": 0.4
+      }
+    },
+    {
+      "id": "school",
+      "category": "Science",
+      "type": "production",
+      "growth": 1.13,
+      "pbt": {
+        "1": 64,
+        "10": 196,
+        "50": 25530.222222222223
+      },
+      "outputs": {
+        "science": 0.45
+      },
+      "inputs": {}
+    },
+    {
+      "id": "woodGenerator",
+      "category": "Energy",
+      "type": "production",
+      "growth": 1.13,
+      "pbt": {
+        "1": 270.6666666666667,
+        "10": 828.4,
+        "50": 107968.93333333333
+      },
+      "outputs": {
+        "power": 1
+      },
+      "inputs": {
+        "wood": 0.25
+      }
+    },
+    {
+      "id": "shelter",
+      "category": "Settlement",
+      "type": "production",
+      "growth": 1.8,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    },
+    {
+      "id": "radio",
+      "category": "Utilities",
+      "type": "production",
+      "growth": 1,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {
+        "power": 0.1
+      }
+    },
+    {
+      "id": "foodStorage",
+      "category": "",
+      "type": "storage",
+      "growth": 1.22,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    },
+    {
+      "id": "largeGranary",
+      "category": "",
+      "type": "storage",
+      "growth": 1.15,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    },
+    {
+      "id": "rawStorage",
+      "category": "",
+      "type": "storage",
+      "growth": 1.22,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    },
+    {
+      "id": "largeWarehouse",
+      "category": "",
+      "type": "storage",
+      "growth": 1.15,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    },
+    {
+      "id": "materialsDepot",
+      "category": "",
+      "type": "storage",
+      "growth": 1.22,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    },
+    {
+      "id": "largeMaterialsDepot",
+      "category": "",
+      "type": "storage",
+      "growth": 1.15,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    },
+    {
+      "id": "battery",
+      "category": "",
+      "type": "storage",
+      "growth": 1.22,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "outputs": {},
+      "inputs": {}
+    }
+  ],
+  "converters": [
+    {
+      "id": "brickKiln",
+      "growth": 1.13,
+      "inputs": {
+        "stone": 0.4,
+        "wood": 0.3
+      },
+      "outputs": {
+        "bricks": 0.4
+      },
+      "ratio": 0,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "mode": "all-or-nothing"
+    },
+    {
+      "id": "sawmill",
+      "growth": 1.13,
+      "inputs": {
+        "wood": 0.8
+      },
+      "outputs": {
+        "planks": 0.5
+      },
+      "ratio": 2.5,
+      "pbt": {
+        "1": 94.91666666666667,
+        "10": 288.50000000000006,
+        "50": 37862.00000000001
+      },
+      "mode": "all-or-nothing"
+    },
+    {
+      "id": "metalWorkshop",
+      "growth": 1.13,
+      "inputs": {
+        "scrap": 0.4
+      },
+      "outputs": {
+        "metalParts": 0.4
+      },
+      "ratio": 2.7272727272727275,
+      "pbt": {
+        "1": 98.02631578947367,
+        "10": 299.67105263157896,
+        "50": 39102.697368421046
+      },
+      "mode": "all-or-nothing"
+    },
+    {
+      "id": "toolsmithy",
+      "growth": 1.13,
+      "inputs": {
+        "planks": 0.25,
+        "metalParts": 0.15,
+        "power": 0.4
+      },
+      "outputs": {
+        "tools": 0.18
+      },
+      "ratio": 0,
+      "pbt": {
+        "1": null,
+        "10": null,
+        "50": null
+      },
+      "mode": "all-or-nothing"
+    }
+  ],
+  "storage": [
+    {
+      "id": "foodStorage",
+      "growth": 1.22,
+      "capacity": {
+        "FOOD": 225
+      }
+    },
+    {
+      "id": "largeGranary",
+      "growth": 1.15,
+      "capacity": {
+        "FOOD": 600
+      }
+    },
+    {
+      "id": "rawStorage",
+      "growth": 1.22,
+      "capacity": {
+        "wood": 120,
+        "scrap": 80,
+        "stone": 60
+      }
+    },
+    {
+      "id": "largeWarehouse",
+      "growth": 1.15,
+      "capacity": {
+        "wood": 400,
+        "stone": 160,
+        "scrap": 240
+      }
+    },
+    {
+      "id": "materialsDepot",
+      "growth": 1.22,
+      "capacity": {
+        "planks": 100,
+        "metalParts": 40
+      }
+    },
+    {
+      "id": "largeMaterialsDepot",
+      "growth": 1.15,
+      "capacity": {
+        "planks": 180,
+        "metalParts": 90,
+        "bricks": 180
+      }
+    },
+    {
+      "id": "battery",
+      "growth": 1.22,
+      "capacity": {
+        "power": 40
+      }
+    }
+  ],
+  "outliers": {
+    "tooFast": [],
+    "tooSlow": [
+      {
+        "id": "potatoField",
+        "target": 50,
+        "value": 16772.28195937873
+      },
+      {
+        "id": "huntersHut",
+        "target": 1,
+        "value": 193.001443001443
+      },
+      {
+        "id": "huntersHut",
+        "target": 10,
+        "value": 687.5901875901876
+      },
+      {
+        "id": "huntersHut",
+        "target": 50,
+        "value": 181877.34487734488
+      },
+      {
+        "id": "loggingCamp",
+        "target": 50,
+        "value": 29881.403508771935
+      },
+      {
+        "id": "scrapyard",
+        "target": 50,
+        "value": 18522.727272727272
+      },
+      {
+        "id": "quarry",
+        "target": 1,
+        "value": 209.17678812415656
+      },
+      {
+        "id": "quarry",
+        "target": 10,
+        "value": 585.6950067476384
+      },
+      {
+        "id": "quarry",
+        "target": 50,
+        "value": 53989.20377867747
+      },
+      {
+        "id": "sawmill",
+        "target": 50,
+        "value": 37862.00000000001
+      },
+      {
+        "id": "metalWorkshop",
+        "target": 50,
+        "value": 39102.697368421046
+      },
+      {
+        "id": "school",
+        "target": 50,
+        "value": 25530.222222222223
+      },
+      {
+        "id": "woodGenerator",
+        "target": 1,
+        "value": 270.6666666666667
+      },
+      {
+        "id": "woodGenerator",
+        "target": 10,
+        "value": 828.4
+      },
+      {
+        "id": "woodGenerator",
+        "target": 50,
+        "value": 107968.93333333333
+      }
+    ]
+  }
+}

--- a/reports/economy/20250816230044/baseline_after.md
+++ b/reports/economy/20250816230044/baseline_after.md
@@ -1,0 +1,68 @@
+# Economy Report
+
+## Summary
+Analyzed **20** buildings. Season mode: **average**.
+Weights: {"wood":1,"stone":1.3,"scrap":2.2,"planks":4,"metalParts":6,"power":1,"potatoes":0.9,"meat":1.4,"science":2.5}. Targets: 1, 10, 50.
+Outliers – too fast: 0, too slow: 15.
+
+## Buildings
+| id | category | type | growth | PBT@1 | PBT@10 | PBT@50 | out/s (base) | in/s (base) |
+| - | - | - | - | - | - | - | - | - |
+| potatoField | Food | production | 1.12 | 64.99 | 183.51 | 16,772.28 | potatoes:0.375 | - |
+| huntersHut | Food | production | 1.15 | 193 | 687.59 | 181,877.34 | meat:0.22 | - |
+| loggingCamp | Raw Materials | production | 1.12 | 115.79 | 324.21 | 29,881.4 | wood:0.3 | - |
+| scrapyard | Raw Materials | production | 1.12 | 71.77 | 203.35 | 18,522.73 | scrap:0.08 | - |
+| quarry | Raw Materials | production | 1.12 | 209.18 | 585.7 | 53,989.2 | stone:0.12 | - |
+| brickKiln | Construction Materials | processing | 1.13 | — | — | — | bricks:0.4 | stone:0.4,wood:0.3 |
+| sawmill | Construction Materials | processing | 1.13 | 94.92 | 288.5 | 37,862 | planks:0.5 | wood:0.8 |
+| metalWorkshop | Construction Materials | processing | 1.13 | 98.03 | 299.67 | 39,102.7 | metalParts:0.4 | scrap:0.4 |
+| toolsmithy | Construction Materials | processing | 1.13 | — | — | — | tools:0.18 | planks:0.25,metalParts:0.15,power:0.4 |
+| school | Science | production | 1.13 | 64 | 196 | 25,530.22 | science:0.45 | - |
+| woodGenerator | Energy | production | 1.13 | 270.67 | 828.4 | 107,968.93 | power:1 | wood:0.25 |
+| shelter | Settlement | production | 1.8 | — | — | — | - | - |
+| radio | Utilities | production | 1 | — | — | — | - | power:0.1 |
+| foodStorage |  | storage | 1.22 | — | — | — | - | - |
+| largeGranary |  | storage | 1.15 | — | — | — | - | - |
+| rawStorage |  | storage | 1.22 | — | — | — | - | - |
+| largeWarehouse |  | storage | 1.15 | — | — | — | - | - |
+| materialsDepot |  | storage | 1.22 | — | — | — | - | - |
+| largeMaterialsDepot |  | storage | 1.15 | — | — | — | - | - |
+| battery |  | storage | 1.22 | — | — | — | - | - |
+
+## Converters
+| id | growth | in/s | out/s | ratio(out/in) | PBT@1 | PBT@10 | PBT@50 | mode |
+| - | - | - | - | - | - | - | - | - |
+| brickKiln | 1.13 | stone:0.4,wood:0.3 | bricks:0.4 | 0 | — | — | — | all-or-nothing |
+| sawmill | 1.13 | wood:0.8 | planks:0.5 | 2.5 | 94.92 | 288.5 | 37,862 | all-or-nothing |
+| metalWorkshop | 1.13 | scrap:0.4 | metalParts:0.4 | 2.73 | 98.03 | 299.67 | 39,102.7 | all-or-nothing |
+| toolsmithy | 1.13 | planks:0.25,metalParts:0.15,power:0.4 | tools:0.18 | 0 | — | — | — | all-or-nothing |
+
+## Storage
+| id | growth | +capacity |
+| - | - | - |
+| foodStorage | 1.22 | FOOD:225 |
+| largeGranary | 1.15 | FOOD:600 |
+| rawStorage | 1.22 | wood:120,scrap:80,stone:60 |
+| largeWarehouse | 1.15 | wood:400,stone:160,scrap:240 |
+| materialsDepot | 1.22 | planks:100,metalParts:40 |
+| largeMaterialsDepot | 1.15 | planks:180,metalParts:90,bricks:180 |
+| battery | 1.22 | power:40 |
+
+## Outliers
+### Too Slow
+- potatoField @50: 16,772.28 sec
+- huntersHut @1: 193 sec
+- huntersHut @10: 687.59 sec
+- huntersHut @50: 181,877.34 sec
+- loggingCamp @50: 29,881.4 sec
+- scrapyard @50: 18,522.73 sec
+- quarry @1: 209.18 sec
+- quarry @10: 585.7 sec
+- quarry @50: 53,989.2 sec
+- sawmill @50: 37,862 sec
+- metalWorkshop @50: 39,102.7 sec
+- school @50: 25,530.22 sec
+- woodGenerator @1: 270.67 sec
+- woodGenerator @10: 828.4 sec
+- woodGenerator @50: 107,968.93 sec
+

--- a/reports/economy/20250816230044/per-season.md
+++ b/reports/economy/20250816230044/per-season.md
@@ -1,0 +1,50 @@
+# Economy Report
+
+## Summary
+Analyzed **20** buildings. Season mode: **all**.
+Weights: {"wood":1,"stone":1.3,"scrap":2.2,"planks":4,"metalParts":6,"power":1,"potatoes":0.9,"meat":1.4,"science":2.5}. Targets: 1, 10, 50.
+Outliers – too fast: 0, too slow: 0.
+
+## Buildings
+| id | category | type | growth | PBT@1[spring] | PBT@1[summer] | PBT@1[autumn] | PBT@1[winter] | PBT@10[spring] | PBT@10[summer] | PBT@10[autumn] | PBT@10[winter] | PBT@50[spring] | PBT@50[summer] | PBT@50[autumn] | PBT@50[winter] | out/s (base) | in/s (base) |
+| - | - | - | - | - | - | - | - | - | - | - | - | - | - | - | - | - | - |
+| potatoField | Food | production | 1.12 | 40.3 | 50.37 | 59.26 | — | 113.78 | 142.22 | 167.32 | — | 10,398.81 | 12,998.52 | 15,292.37 | — | potatoes:0.375 | - |
+| huntersHut | Food | production | 1.15 | 157.91 | 173.7 | 193 | 289.5 | 562.57 | 618.83 | 687.59 | 1,031.39 | 148,808.74 | 163,689.61 | 181,877.34 | 272,816.02 | meat:0.22 | - |
+| loggingCamp | Raw Materials | production | 1.12 | 100 | 110 | 122.22 | 137.5 | 280 | 308 | 342.22 | 385 | 25,806.67 | 28,387.33 | 31,541.48 | 35,484.17 | wood:0.3 | - |
+| scrapyard | Raw Materials | production | 1.12 | 61.98 | 68.18 | 75.76 | 85.23 | 175.62 | 193.18 | 214.65 | 241.48 | 15,996.9 | 17,596.59 | 19,551.77 | 21,995.74 | scrap:0.08 | - |
+| quarry | Raw Materials | production | 1.12 | 180.65 | 198.72 | 220.8 | 248.4 | 505.83 | 556.41 | 618.23 | 695.51 | 46,627.04 | 51,289.74 | 56,988.6 | 64,112.18 | stone:0.12 | - |
+| brickKiln | Construction Materials | processing | 1.13 | — | — | — | — | — | — | — | — | — | — | — | — | bricks:0.4 | stone:0.4,wood:0.3 |
+| sawmill | Construction Materials | processing | 1.13 | 94.92 | 94.92 | 94.92 | 94.92 | 288.5 | 288.5 | 288.5 | 288.5 | 37,862 | 37,862 | 37,862 | 37,862 | planks:0.5 | wood:0.8 |
+| metalWorkshop | Construction Materials | processing | 1.13 | 98.03 | 98.03 | 98.03 | 98.03 | 299.67 | 299.67 | 299.67 | 299.67 | 39,102.7 | 39,102.7 | 39,102.7 | 39,102.7 | metalParts:0.4 | scrap:0.4 |
+| toolsmithy | Construction Materials | processing | 1.13 | — | — | — | — | — | — | — | — | — | — | — | — | tools:0.18 | planks:0.25,metalParts:0.15,power:0.4 |
+| school | Science | production | 1.13 | 64 | 64 | 64 | 64 | 196 | 196 | 196 | 196 | 25,530.22 | 25,530.22 | 25,530.22 | 25,530.22 | science:0.45 | - |
+| woodGenerator | Energy | production | 1.13 | 270.67 | 270.67 | 270.67 | 270.67 | 828.4 | 828.4 | 828.4 | 828.4 | 107,968.93 | 107,968.93 | 107,968.93 | 107,968.93 | power:1 | wood:0.25 |
+| shelter | Settlement | production | 1.8 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+| radio | Utilities | production | 1 | — | — | — | — | — | — | — | — | — | — | — | — | - | power:0.1 |
+| foodStorage |  | storage | 1.22 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+| largeGranary |  | storage | 1.15 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+| rawStorage |  | storage | 1.22 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+| largeWarehouse |  | storage | 1.15 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+| materialsDepot |  | storage | 1.22 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+| largeMaterialsDepot |  | storage | 1.15 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+| battery |  | storage | 1.22 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+
+## Converters
+| id | growth | in/s | out/s | ratio(out/in) | PBT@1 | PBT@10 | PBT@50 | mode |
+| - | - | - | - | - | - | - | - | - |
+| brickKiln | 1.13 | stone:0.4,wood:0.3 | bricks:0.4 | 0 | — | — | — | all-or-nothing |
+| sawmill | 1.13 | wood:0.8 | planks:0.5 | 2.5 | — | — | — | all-or-nothing |
+| metalWorkshop | 1.13 | scrap:0.4 | metalParts:0.4 | 2.73 | — | — | — | all-or-nothing |
+| toolsmithy | 1.13 | planks:0.25,metalParts:0.15,power:0.4 | tools:0.18 | 0 | — | — | — | all-or-nothing |
+
+## Storage
+| id | growth | +capacity |
+| - | - | - |
+| foodStorage | 1.22 | FOOD:225 |
+| largeGranary | 1.15 | FOOD:600 |
+| rawStorage | 1.22 | wood:120,scrap:80,stone:60 |
+| largeWarehouse | 1.15 | wood:400,stone:160,scrap:240 |
+| materialsDepot | 1.22 | planks:100,metalParts:40 |
+| largeMaterialsDepot | 1.15 | planks:180,metalParts:90,bricks:180 |
+| battery | 1.22 | power:40 |
+

--- a/reports/economy/20250816230044/per-season_after.md
+++ b/reports/economy/20250816230044/per-season_after.md
@@ -1,0 +1,50 @@
+# Economy Report
+
+## Summary
+Analyzed **20** buildings. Season mode: **all**.
+Weights: {"wood":1,"stone":1.3,"scrap":2.2,"planks":4,"metalParts":6,"power":1,"potatoes":0.9,"meat":1.4,"science":2.5}. Targets: 1, 10, 50.
+Outliers – too fast: 0, too slow: 0.
+
+## Buildings
+| id | category | type | growth | PBT@1[spring] | PBT@1[summer] | PBT@1[autumn] | PBT@1[winter] | PBT@10[spring] | PBT@10[summer] | PBT@10[autumn] | PBT@10[winter] | PBT@50[spring] | PBT@50[summer] | PBT@50[autumn] | PBT@50[winter] | out/s (base) | in/s (base) |
+| - | - | - | - | - | - | - | - | - | - | - | - | - | - | - | - | - | - |
+| potatoField | Food | production | 1.12 | 40.3 | 50.37 | 59.26 | — | 113.78 | 142.22 | 167.32 | — | 10,398.81 | 12,998.52 | 15,292.37 | — | potatoes:0.375 | - |
+| huntersHut | Food | production | 1.15 | 157.91 | 173.7 | 193 | 289.5 | 562.57 | 618.83 | 687.59 | 1,031.39 | 148,808.74 | 163,689.61 | 181,877.34 | 272,816.02 | meat:0.22 | - |
+| loggingCamp | Raw Materials | production | 1.12 | 100 | 110 | 122.22 | 137.5 | 280 | 308 | 342.22 | 385 | 25,806.67 | 28,387.33 | 31,541.48 | 35,484.17 | wood:0.3 | - |
+| scrapyard | Raw Materials | production | 1.12 | 61.98 | 68.18 | 75.76 | 85.23 | 175.62 | 193.18 | 214.65 | 241.48 | 15,996.9 | 17,596.59 | 19,551.77 | 21,995.74 | scrap:0.08 | - |
+| quarry | Raw Materials | production | 1.12 | 180.65 | 198.72 | 220.8 | 248.4 | 505.83 | 556.41 | 618.23 | 695.51 | 46,627.04 | 51,289.74 | 56,988.6 | 64,112.18 | stone:0.12 | - |
+| brickKiln | Construction Materials | processing | 1.13 | — | — | — | — | — | — | — | — | — | — | — | — | bricks:0.4 | stone:0.4,wood:0.3 |
+| sawmill | Construction Materials | processing | 1.13 | 94.92 | 94.92 | 94.92 | 94.92 | 288.5 | 288.5 | 288.5 | 288.5 | 37,862 | 37,862 | 37,862 | 37,862 | planks:0.5 | wood:0.8 |
+| metalWorkshop | Construction Materials | processing | 1.13 | 98.03 | 98.03 | 98.03 | 98.03 | 299.67 | 299.67 | 299.67 | 299.67 | 39,102.7 | 39,102.7 | 39,102.7 | 39,102.7 | metalParts:0.4 | scrap:0.4 |
+| toolsmithy | Construction Materials | processing | 1.13 | — | — | — | — | — | — | — | — | — | — | — | — | tools:0.18 | planks:0.25,metalParts:0.15,power:0.4 |
+| school | Science | production | 1.13 | 64 | 64 | 64 | 64 | 196 | 196 | 196 | 196 | 25,530.22 | 25,530.22 | 25,530.22 | 25,530.22 | science:0.45 | - |
+| woodGenerator | Energy | production | 1.13 | 270.67 | 270.67 | 270.67 | 270.67 | 828.4 | 828.4 | 828.4 | 828.4 | 107,968.93 | 107,968.93 | 107,968.93 | 107,968.93 | power:1 | wood:0.25 |
+| shelter | Settlement | production | 1.8 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+| radio | Utilities | production | 1 | — | — | — | — | — | — | — | — | — | — | — | — | - | power:0.1 |
+| foodStorage |  | storage | 1.22 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+| largeGranary |  | storage | 1.15 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+| rawStorage |  | storage | 1.22 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+| largeWarehouse |  | storage | 1.15 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+| materialsDepot |  | storage | 1.22 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+| largeMaterialsDepot |  | storage | 1.15 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+| battery |  | storage | 1.22 | — | — | — | — | — | — | — | — | — | — | — | — | - | - |
+
+## Converters
+| id | growth | in/s | out/s | ratio(out/in) | PBT@1 | PBT@10 | PBT@50 | mode |
+| - | - | - | - | - | - | - | - | - |
+| brickKiln | 1.13 | stone:0.4,wood:0.3 | bricks:0.4 | 0 | — | — | — | all-or-nothing |
+| sawmill | 1.13 | wood:0.8 | planks:0.5 | 2.5 | — | — | — | all-or-nothing |
+| metalWorkshop | 1.13 | scrap:0.4 | metalParts:0.4 | 2.73 | — | — | — | all-or-nothing |
+| toolsmithy | 1.13 | planks:0.25,metalParts:0.15,power:0.4 | tools:0.18 | 0 | — | — | — | all-or-nothing |
+
+## Storage
+| id | growth | +capacity |
+| - | - | - |
+| foodStorage | 1.22 | FOOD:225 |
+| largeGranary | 1.15 | FOOD:600 |
+| rawStorage | 1.22 | wood:120,scrap:80,stone:60 |
+| largeWarehouse | 1.15 | wood:400,stone:160,scrap:240 |
+| materialsDepot | 1.22 | planks:100,metalParts:40 |
+| largeMaterialsDepot | 1.15 | planks:180,metalParts:90,bricks:180 |
+| battery | 1.22 | power:40 |
+

--- a/reports/economy/20250816230044/winter.md
+++ b/reports/economy/20250816230044/winter.md
@@ -1,0 +1,68 @@
+# Economy Report
+
+## Summary
+Analyzed **20** buildings. Season mode: **winter**.
+Weights: {"wood":1,"stone":1.3,"scrap":2.2,"planks":4,"metalParts":6,"power":1,"potatoes":0.9,"meat":1.4,"science":2.5}. Targets: 1, 10, 50.
+Outliers – too fast: 0, too slow: 15.
+
+## Buildings
+| id | category | type | growth | PBT@1 | PBT@10 | PBT@50 | out/s (base) | in/s (base) |
+| - | - | - | - | - | - | - | - | - |
+| potatoField | Food | production | 1.12 | — | — | — | potatoes:0.375 | - |
+| huntersHut | Food | production | 1.15 | 289.5 | 1,031.39 | 272,816.02 | meat:0.22 | - |
+| loggingCamp | Raw Materials | production | 1.12 | 137.5 | 385 | 35,484.17 | wood:0.3 | - |
+| scrapyard | Raw Materials | production | 1.12 | 85.23 | 241.48 | 21,995.74 | scrap:0.08 | - |
+| quarry | Raw Materials | production | 1.12 | 248.4 | 695.51 | 64,112.18 | stone:0.12 | - |
+| brickKiln | Construction Materials | processing | 1.13 | — | — | — | bricks:0.4 | stone:0.4,wood:0.3 |
+| sawmill | Construction Materials | processing | 1.13 | 94.92 | 288.5 | 37,862 | planks:0.5 | wood:0.8 |
+| metalWorkshop | Construction Materials | processing | 1.13 | 98.03 | 299.67 | 39,102.7 | metalParts:0.4 | scrap:0.4 |
+| toolsmithy | Construction Materials | processing | 1.13 | — | — | — | tools:0.18 | planks:0.25,metalParts:0.15,power:0.4 |
+| school | Science | production | 1.13 | 64 | 196 | 25,530.22 | science:0.45 | - |
+| woodGenerator | Energy | production | 1.13 | 270.67 | 828.4 | 107,968.93 | power:1 | wood:0.25 |
+| shelter | Settlement | production | 1.8 | — | — | — | - | - |
+| radio | Utilities | production | 1 | — | — | — | - | power:0.1 |
+| foodStorage |  | storage | 1.22 | — | — | — | - | - |
+| largeGranary |  | storage | 1.15 | — | — | — | - | - |
+| rawStorage |  | storage | 1.22 | — | — | — | - | - |
+| largeWarehouse |  | storage | 1.15 | — | — | — | - | - |
+| materialsDepot |  | storage | 1.22 | — | — | — | - | - |
+| largeMaterialsDepot |  | storage | 1.15 | — | — | — | - | - |
+| battery |  | storage | 1.22 | — | — | — | - | - |
+
+## Converters
+| id | growth | in/s | out/s | ratio(out/in) | PBT@1 | PBT@10 | PBT@50 | mode |
+| - | - | - | - | - | - | - | - | - |
+| brickKiln | 1.13 | stone:0.4,wood:0.3 | bricks:0.4 | 0 | — | — | — | all-or-nothing |
+| sawmill | 1.13 | wood:0.8 | planks:0.5 | 2.5 | 94.92 | 288.5 | 37,862 | all-or-nothing |
+| metalWorkshop | 1.13 | scrap:0.4 | metalParts:0.4 | 2.73 | 98.03 | 299.67 | 39,102.7 | all-or-nothing |
+| toolsmithy | 1.13 | planks:0.25,metalParts:0.15,power:0.4 | tools:0.18 | 0 | — | — | — | all-or-nothing |
+
+## Storage
+| id | growth | +capacity |
+| - | - | - |
+| foodStorage | 1.22 | FOOD:225 |
+| largeGranary | 1.15 | FOOD:600 |
+| rawStorage | 1.22 | wood:120,scrap:80,stone:60 |
+| largeWarehouse | 1.15 | wood:400,stone:160,scrap:240 |
+| materialsDepot | 1.22 | planks:100,metalParts:40 |
+| largeMaterialsDepot | 1.15 | planks:180,metalParts:90,bricks:180 |
+| battery | 1.22 | power:40 |
+
+## Outliers
+### Too Slow
+- huntersHut @1: 289.5 sec
+- huntersHut @10: 1,031.39 sec
+- huntersHut @50: 272,816.02 sec
+- loggingCamp @1: 137.5 sec
+- loggingCamp @50: 35,484.17 sec
+- scrapyard @50: 21,995.74 sec
+- quarry @1: 248.4 sec
+- quarry @10: 695.51 sec
+- quarry @50: 64,112.18 sec
+- sawmill @50: 37,862 sec
+- metalWorkshop @50: 39,102.7 sec
+- school @50: 25,530.22 sec
+- woodGenerator @1: 270.67 sec
+- woodGenerator @10: 828.4 sec
+- woodGenerator @50: 107,968.93 sec
+

--- a/reports/economy/20250816230044/winter_after.md
+++ b/reports/economy/20250816230044/winter_after.md
@@ -1,0 +1,68 @@
+# Economy Report
+
+## Summary
+Analyzed **20** buildings. Season mode: **winter**.
+Weights: {"wood":1,"stone":1.3,"scrap":2.2,"planks":4,"metalParts":6,"power":1,"potatoes":0.9,"meat":1.4,"science":2.5}. Targets: 1, 10, 50.
+Outliers – too fast: 0, too slow: 15.
+
+## Buildings
+| id | category | type | growth | PBT@1 | PBT@10 | PBT@50 | out/s (base) | in/s (base) |
+| - | - | - | - | - | - | - | - | - |
+| potatoField | Food | production | 1.12 | — | — | — | potatoes:0.375 | - |
+| huntersHut | Food | production | 1.15 | 289.5 | 1,031.39 | 272,816.02 | meat:0.22 | - |
+| loggingCamp | Raw Materials | production | 1.12 | 137.5 | 385 | 35,484.17 | wood:0.3 | - |
+| scrapyard | Raw Materials | production | 1.12 | 85.23 | 241.48 | 21,995.74 | scrap:0.08 | - |
+| quarry | Raw Materials | production | 1.12 | 248.4 | 695.51 | 64,112.18 | stone:0.12 | - |
+| brickKiln | Construction Materials | processing | 1.13 | — | — | — | bricks:0.4 | stone:0.4,wood:0.3 |
+| sawmill | Construction Materials | processing | 1.13 | 94.92 | 288.5 | 37,862 | planks:0.5 | wood:0.8 |
+| metalWorkshop | Construction Materials | processing | 1.13 | 98.03 | 299.67 | 39,102.7 | metalParts:0.4 | scrap:0.4 |
+| toolsmithy | Construction Materials | processing | 1.13 | — | — | — | tools:0.18 | planks:0.25,metalParts:0.15,power:0.4 |
+| school | Science | production | 1.13 | 64 | 196 | 25,530.22 | science:0.45 | - |
+| woodGenerator | Energy | production | 1.13 | 270.67 | 828.4 | 107,968.93 | power:1 | wood:0.25 |
+| shelter | Settlement | production | 1.8 | — | — | — | - | - |
+| radio | Utilities | production | 1 | — | — | — | - | power:0.1 |
+| foodStorage |  | storage | 1.22 | — | — | — | - | - |
+| largeGranary |  | storage | 1.15 | — | — | — | - | - |
+| rawStorage |  | storage | 1.22 | — | — | — | - | - |
+| largeWarehouse |  | storage | 1.15 | — | — | — | - | - |
+| materialsDepot |  | storage | 1.22 | — | — | — | - | - |
+| largeMaterialsDepot |  | storage | 1.15 | — | — | — | - | - |
+| battery |  | storage | 1.22 | — | — | — | - | - |
+
+## Converters
+| id | growth | in/s | out/s | ratio(out/in) | PBT@1 | PBT@10 | PBT@50 | mode |
+| - | - | - | - | - | - | - | - | - |
+| brickKiln | 1.13 | stone:0.4,wood:0.3 | bricks:0.4 | 0 | — | — | — | all-or-nothing |
+| sawmill | 1.13 | wood:0.8 | planks:0.5 | 2.5 | 94.92 | 288.5 | 37,862 | all-or-nothing |
+| metalWorkshop | 1.13 | scrap:0.4 | metalParts:0.4 | 2.73 | 98.03 | 299.67 | 39,102.7 | all-or-nothing |
+| toolsmithy | 1.13 | planks:0.25,metalParts:0.15,power:0.4 | tools:0.18 | 0 | — | — | — | all-or-nothing |
+
+## Storage
+| id | growth | +capacity |
+| - | - | - |
+| foodStorage | 1.22 | FOOD:225 |
+| largeGranary | 1.15 | FOOD:600 |
+| rawStorage | 1.22 | wood:120,scrap:80,stone:60 |
+| largeWarehouse | 1.15 | wood:400,stone:160,scrap:240 |
+| materialsDepot | 1.22 | planks:100,metalParts:40 |
+| largeMaterialsDepot | 1.15 | planks:180,metalParts:90,bricks:180 |
+| battery | 1.22 | power:40 |
+
+## Outliers
+### Too Slow
+- huntersHut @1: 289.5 sec
+- huntersHut @10: 1,031.39 sec
+- huntersHut @50: 272,816.02 sec
+- loggingCamp @1: 137.5 sec
+- loggingCamp @50: 35,484.17 sec
+- scrapyard @50: 21,995.74 sec
+- quarry @1: 248.4 sec
+- quarry @10: 695.51 sec
+- quarry @50: 64,112.18 sec
+- sawmill @50: 37,862 sec
+- metalWorkshop @50: 39,102.7 sec
+- school @50: 25,530.22 sec
+- woodGenerator @1: 270.67 sec
+- woodGenerator @10: 828.4 sec
+- woodGenerator @50: 107,968.93 sec
+


### PR DESCRIPTION
## Summary
- regenerate economy snapshot and main report
- add JS snapshot export
- update baseline and seasonal economy reports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a10cf899688331968e23ee2ffbf948