### PR TITLE
chore: type safe persistence tests

### DIFF
--- a/src/engine/__tests__/persistence.test.ts
+++ b/src/engine/__tests__/persistence.test.ts
@@ -1,14 +1,22 @@
-// @ts-nocheck
 import { describe, it, expect, vi } from 'vitest';
-import { load, validateSave, CURRENT_SAVE_VERSION, saveGame, restoreBackup } from '../persistence.ts';
+import {
+  load,
+  validateSave,
+  CURRENT_SAVE_VERSION,
+  saveGame,
+  restoreBackup,
+  type SaveFile,
+} from '../persistence.ts';
+import type { GameState } from '../../state/useGame.tsx';
+import { defaultState } from '../../state/defaultState.js';
 
 describe('persistence migrations and validation', () => {
   it('migrates v2 saves to include new fields', () => {
-    const oldSave = {
+    const oldSave: SaveFile = {
       version: 2,
-      resources: {},
-      buildings: {},
-      population: {},
+      resources: {} as unknown as GameState['resources'],
+      buildings: {} as unknown as GameState['buildings'],
+      population: {} as unknown as GameState['population'],
     };
 
     const { state, migratedFrom } = load(JSON.stringify(oldSave));
@@ -29,165 +37,182 @@ describe('persistence migrations and validation', () => {
   });
 
   it('fails validation when essential data is missing', () => {
-    const base = {
+    const base: SaveFile = {
       version: CURRENT_SAVE_VERSION,
-      resources: {},
-      buildings: {},
+      resources: {} as unknown as GameState['resources'],
+      buildings: {} as unknown as GameState['buildings'],
       ui: { activeTab: 'base', drawerOpen: false, offlineProgress: null },
-      log: [],
+      log: [] as unknown as GameState['log'],
       research: { current: null, completed: [], progress: {} },
-      population: { settlers: [] },
+      population: { settlers: [] } as unknown as GameState['population'],
     };
 
-    const missingUi = { ...base };
+    const missingUi: SaveFile = { ...base };
     delete missingUi.ui;
     expect(() => validateSave(missingUi)).toThrow();
 
-    const missingLog = { ...base, log: undefined };
+    const missingLog: SaveFile = { ...base, log: undefined };
     expect(() => validateSave(missingLog)).toThrow();
 
-    const missingResearch = { ...base };
+    const missingResearch: SaveFile = { ...base };
     delete missingResearch.research;
     expect(() => validateSave(missingResearch)).toThrow();
 
-    const missingSettlers = { ...base, population: {} };
+    const missingSettlers: SaveFile = {
+      ...base,
+      population: {} as unknown as GameState['population'],
+    };
     expect(() => validateSave(missingSettlers)).toThrow();
   });
 
   it('rejects malformed resource data', () => {
-    const base = {
+    const base: SaveFile = {
       version: CURRENT_SAVE_VERSION,
-      resources: { wood: { amount: 1, discovered: true, produced: 0 } },
-      buildings: { loggingCamp: { count: 1, isDesiredOn: true } },
+      resources: {
+        wood: { amount: 1, discovered: true, produced: 0 },
+      } as unknown as GameState['resources'],
+      buildings: {
+        loggingCamp: { count: 1, isDesiredOn: true },
+      } as unknown as GameState['buildings'],
       ui: { activeTab: 'base', drawerOpen: false, offlineProgress: null },
-      log: [],
+      log: [] as unknown as GameState['log'],
       research: { current: null, completed: [], progress: {} },
-      population: { settlers: [], candidate: null },
-      colony: { radioTimer: 0 },
+      population: { settlers: [], candidate: null } as unknown as GameState['population'],
+      colony: { radioTimer: 0 } as unknown as GameState['colony'],
     };
 
-    const bad = JSON.parse(JSON.stringify(base));
-    bad.resources.wood.amount = 'oops';
+    const bad: SaveFile = JSON.parse(JSON.stringify(base));
+    (bad.resources as any).wood.amount = 'oops';
     expect(() => validateSave(bad)).toThrow();
 
-    const missing = JSON.parse(JSON.stringify(base));
-    delete missing.resources.wood.amount;
+    const missing: SaveFile = JSON.parse(JSON.stringify(base));
+    delete (missing.resources as any).wood.amount;
     expect(() => validateSave(missing)).toThrow();
   });
 
   it('rejects malformed building data', () => {
-    const base = {
+    const base: SaveFile = {
       version: CURRENT_SAVE_VERSION,
-      resources: { wood: { amount: 1, discovered: true, produced: 0 } },
-      buildings: { loggingCamp: { count: 1, isDesiredOn: true } },
+      resources: {
+        wood: { amount: 1, discovered: true, produced: 0 },
+      } as unknown as GameState['resources'],
+      buildings: {
+        loggingCamp: { count: 1, isDesiredOn: true },
+      } as unknown as GameState['buildings'],
       ui: { activeTab: 'base', drawerOpen: false, offlineProgress: null },
-      log: [],
+      log: [] as unknown as GameState['log'],
       research: { current: null, completed: [], progress: {} },
-      population: { settlers: [], candidate: null },
-      colony: { radioTimer: 0 },
+      population: { settlers: [], candidate: null } as unknown as GameState['population'],
+      colony: { radioTimer: 0 } as unknown as GameState['colony'],
     };
 
-    const bad = JSON.parse(JSON.stringify(base));
-    bad.buildings.loggingCamp.count = 'two';
+    const bad: SaveFile = JSON.parse(JSON.stringify(base));
+    (bad.buildings as any).loggingCamp.count = 'two';
     expect(() => validateSave(bad)).toThrow();
 
-    const missing = JSON.parse(JSON.stringify(base));
-    delete missing.buildings.loggingCamp.count;
+    const missing: SaveFile = JSON.parse(JSON.stringify(base));
+    delete (missing.buildings as any).loggingCamp.count;
     expect(() => validateSave(missing)).toThrow();
   });
 
   it('converts string log entries to objects', () => {
-    const oldSave = {
+    const oldSave: SaveFile = {
       version: 3,
       resources: {},
-      buildings: {},
+      buildings: {} as unknown as GameState['buildings'],
       ui: { activeTab: 'base', drawerOpen: false, offlineProgress: null },
-      log: ['hello world'],
+      log: ['hello world'] as unknown as GameState['log'],
       research: { current: null, completed: [], progress: {} },
-      population: { settlers: [] },
+      population: { settlers: [] } as unknown as GameState['population'],
     };
 
     const { state, migratedFrom } = load(JSON.stringify(oldSave));
+    const log = state.log as unknown as { id: string; text: string; time?: number }[];
     expect(migratedFrom).toBe(3);
     expect(state.version).toBe(CURRENT_SAVE_VERSION);
-    expect(state.log).toHaveLength(1);
-    expect(state.log[0].text).toBe('hello world');
-    expect(typeof state.log[0].id).toBe('string');
-    expect(typeof state.log[0].time).toBe('number');
+    expect(log).toHaveLength(1);
+    expect(log[0].text).toBe('hello world');
+    expect(typeof log[0].id).toBe('string');
+    expect(typeof log[0].time).toBe('number');
   });
 
   it('migrates v4 saves to current version', () => {
-    const oldSave = {
+    const oldSave: SaveFile = {
       version: 4,
       resources: { wood: { amount: 0, discovered: true } },
-      buildings: { loggingCamp: { count: 1 } },
+      buildings: { loggingCamp: { count: 1 } } as unknown as GameState['buildings'],
       ui: { activeTab: 'base', drawerOpen: false, offlineProgress: null },
-      log: [{ id: '1', text: 'hi' }],
+      log: [{ id: '1', text: 'hi' }] as unknown as GameState['log'],
       research: { current: null, completed: [], progress: {} },
-      population: { settlers: [] },
+      population: { settlers: [] } as unknown as GameState['population'],
     };
 
     const { state, migratedFrom } = load(JSON.stringify(oldSave));
+    const log = state.log as unknown as { id: string; text: string; time?: number }[];
     expect(migratedFrom).toBe(4);
     expect(state.version).toBe(CURRENT_SAVE_VERSION);
     expect(state.population).toHaveProperty('candidate', null);
     expect(state.colony).toBeDefined();
     expect(state.buildings.loggingCamp).toHaveProperty('isDesiredOn', true);
-    expect(typeof state.log[0].time).toBe('number');
+    expect(typeof log[0].time).toBe('number');
   });
 
   it('migrates v5 saves to current version', () => {
-    const oldSave = {
+    const oldSave: SaveFile = {
       version: 5,
       resources: { wood: { amount: 0, discovered: true } },
-      buildings: { loggingCamp: { count: 1 } },
+      buildings: { loggingCamp: { count: 1 } } as unknown as GameState['buildings'],
       ui: { activeTab: 'base', drawerOpen: false, offlineProgress: null },
-      log: [{ id: '1', text: 'hi' }],
+      log: [{ id: '1', text: 'hi' }] as unknown as GameState['log'],
       research: { current: null, completed: [], progress: {} },
-      population: { settlers: [], candidate: null },
-      colony: { radioTimer: 0 },
+      population: { settlers: [], candidate: null } as unknown as GameState['population'],
+      colony: { radioTimer: 0 } as unknown as GameState['colony'],
     };
 
     const { state, migratedFrom } = load(JSON.stringify(oldSave));
+    const log = state.log as unknown as { id: string; text: string; time?: number }[];
     expect(migratedFrom).toBe(5);
     expect(state.version).toBe(CURRENT_SAVE_VERSION);
     expect(state.population).toHaveProperty('candidate');
     expect(state.colony).toBeDefined();
-    expect(typeof state.log[0].time).toBe('number');
+    expect(typeof log[0].time).toBe('number');
     expect(state.buildings.loggingCamp).toHaveProperty('isDesiredOn', true);
   });
 
   it('migrates v6 saves to current version', () => {
-    const oldSave = {
+    const oldSave: SaveFile = {
       version: 6,
       resources: { wood: { amount: 0, discovered: true } },
-      buildings: { loggingCamp: { count: 1 } },
+      buildings: { loggingCamp: { count: 1 } } as unknown as GameState['buildings'],
       ui: { activeTab: 'base', drawerOpen: false, offlineProgress: null },
-      log: [{ id: '1', text: 'hi', time: 123 }],
+      log: [{ id: '1', text: 'hi', time: 123 }] as unknown as GameState['log'],
       research: { current: null, completed: [], progress: {} },
-      population: { settlers: [], candidate: null },
-      colony: { radioTimer: 0 },
+      population: { settlers: [], candidate: null } as unknown as GameState['population'],
+      colony: { radioTimer: 0 } as unknown as GameState['colony'],
     };
 
     const { state, migratedFrom } = load(JSON.stringify(oldSave));
+    const log = state.log as unknown as { id: string; text: string; time?: number }[];
     expect(migratedFrom).toBe(6);
     expect(state.version).toBe(CURRENT_SAVE_VERSION);
     expect(state.population).toHaveProperty('candidate');
     expect(state.colony).toBeDefined();
     expect(state.buildings.loggingCamp).toHaveProperty('isDesiredOn', true);
-    expect(state.log[0].time).toBe(123);
+    expect(log[0].time).toBe(123);
   });
 
   it('loads v7 saves without migrating', () => {
-    const oldSave = {
+    const oldSave: SaveFile = {
       version: 7,
       resources: { wood: { amount: 0, discovered: true } },
-      buildings: { loggingCamp: { count: 1, isDesiredOn: false } },
+      buildings: {
+        loggingCamp: { count: 1, isDesiredOn: false },
+      } as unknown as GameState['buildings'],
       ui: { activeTab: 'base', drawerOpen: false, offlineProgress: null },
-      log: [{ id: '1', text: 'hi', time: 123 }],
+      log: [{ id: '1', text: 'hi', time: 123 }] as unknown as GameState['log'],
       research: { current: null, completed: [], progress: {} },
-      population: { settlers: [], candidate: null },
-      colony: { radioTimer: 0 },
+      population: { settlers: [], candidate: null } as unknown as GameState['population'],
+      colony: { radioTimer: 0 } as unknown as GameState['colony'],
     };
 
     const { state, migratedFrom } = load(JSON.stringify(oldSave));
@@ -204,7 +229,7 @@ describe('persistence migrations and validation', () => {
       resources: {},
       buildings: {},
       population: {},
-    };
+    } as unknown as SaveFile;
 
     const { state, migratedFrom } = load(JSON.stringify(oldSave));
     expect(migratedFrom).toBe(2);
@@ -213,7 +238,7 @@ describe('persistence migrations and validation', () => {
 
   it('throws on future save versions', () => {
     const futureVersion = CURRENT_SAVE_VERSION + 1;
-    const futureSave = { version: String(futureVersion) };
+    const futureSave = { version: String(futureVersion) } as unknown as SaveFile;
     expect(() => load(JSON.stringify(futureSave))).toThrow(
       `Save version ${futureVersion} is newer than supported version ${CURRENT_SAVE_VERSION}`,
     );
@@ -232,7 +257,7 @@ describe('save backups', () => {
     let shouldFail = true;
     const spy = vi
       .spyOn(Storage.prototype, 'setItem')
-      .mockImplementation(function (key, value) {
+      .mockImplementation(function (this: Storage, key: string, value: string) {
         if (shouldFail && key === STORAGE_KEY) {
           shouldFail = false;
           throw new Error('fail');
@@ -242,7 +267,7 @@ describe('save backups', () => {
 
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    saveGame({ fresh: true });
+    saveGame(defaultState as unknown as GameState);
 
     expect(localStorage.getItem(STORAGE_KEY)).toBe(JSON.stringify({ old: true }));
     expect(localStorage.getItem(BACKUP_KEY)).toBeNull();

--- a/src/engine/persistence.ts
+++ b/src/engine/persistence.ts
@@ -81,7 +81,10 @@ export const migrations: Migration[] = [
             : {};
       }
       if (!save.population || typeof save.population !== 'object') {
-        save.population = { settlers: [] } as GameState['population'];
+        save.population = {
+          settlers: [],
+          candidate: null,
+        } as unknown as GameState['population'];
       } else if (!Array.isArray(save.population.settlers)) {
         save.population.settlers = [];
       }
@@ -93,7 +96,7 @@ export const migrations: Migration[] = [
     to: 4,
     up(save) {
       if (!Array.isArray(save.log)) {
-        save.log = [];
+        save.log = [] as unknown as GameState['log'];
       } else {
         save.log = save.log.map((entry) => {
           if (typeof entry === 'string') return createLogEntry(entry);
@@ -108,7 +111,7 @@ export const migrations: Migration[] = [
             return { id, text };
           }
           return createLogEntry(String(entry));
-        });
+        }) as unknown as GameState['log'];
       }
       return save;
     },
@@ -118,14 +121,20 @@ export const migrations: Migration[] = [
     to: 5,
     up(save) {
       if (!save.population || typeof save.population !== 'object') {
-        save.population = { settlers: [], candidate: null } as GameState['population'];
+        save.population = {
+          settlers: [],
+          candidate: null,
+        } as unknown as GameState['population'];
       } else {
         if (!Array.isArray(save.population.settlers))
           save.population.settlers = [];
-        if (!('candidate' in save.population)) save.population.candidate = null;
+        if (!('candidate' in (save.population as any)))
+          (save.population as any).candidate = null;
       }
       if (!save.colony || typeof save.colony !== 'object') {
-        save.colony = { radioTimer: RADIO_BASE_SECONDS } as GameState['colony'];
+        save.colony = {
+          radioTimer: RADIO_BASE_SECONDS,
+        } as unknown as GameState['colony'];
       } else if (typeof save.colony.radioTimer !== 'number') {
         save.colony.radioTimer = RADIO_BASE_SECONDS;
       }
@@ -137,16 +146,17 @@ export const migrations: Migration[] = [
     to: 6,
     up(save) {
       if (!Array.isArray(save.log)) {
-        save.log = [];
+        save.log = [] as unknown as GameState['log'];
       } else {
         const now = Date.now();
-        save.log = save.log.map((entry) => ({
-          ...(entry as LogEntry),
-          time:
-            typeof (entry as LogEntry).time === 'number'
-              ? (entry as LogEntry).time
-              : now,
-        }));
+        save.log = save.log
+          .map((entry) => ({
+            ...(entry as LogEntry),
+            time:
+              typeof (entry as LogEntry).time === 'number'
+                ? (entry as LogEntry).time
+                : now,
+          })) as unknown as GameState['log'];
       }
       return save;
     },

--- a/src/state/hooks/useAutosave.tsx
+++ b/src/state/hooks/useAutosave.tsx
@@ -13,7 +13,7 @@ export default function useAutosave(
 
   useEffect(() => {
     const save = () => {
-      setState(() => saveGame(stateRef.current));
+      setState(() => saveGame(stateRef.current) as unknown as GameState);
     };
     const id = setInterval(save, 10000);
     window.addEventListener('beforeunload', save);

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="vite/client" />
+


### PR DESCRIPTION
## Summary
- improve persistence tests with GameState typings
- add vite env types and adjust persistence helpers for TS

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a1c0d67a748331a7de31bd4a68e6e5