### PR TITLE
chore: typecheck power-related tests

### DIFF
--- a/src/engine/__tests__/power.test.ts
+++ b/src/engine/__tests__/power.test.ts
@@ -1,57 +1,84 @@
-// @ts-nocheck
 import { describe, test, expect } from 'vitest';
 import { processTick } from '../production.ts';
 import { defaultState } from '../../state/defaultState.js';
 import { deepClone } from '../../utils/clone.ts';
+import type {
+  GameState,
+  BuildingEntry,
+  ResourceState,
+} from '../../state/useGame.tsx';
+
+function clone(): {
+  state: GameState;
+  buildings: Record<string, BuildingEntry>;
+  resources: Record<string, ResourceState>;
+} {
+  const state = deepClone(defaultState) as GameState;
+  return {
+    state,
+    buildings: state.buildings as Record<string, BuildingEntry>,
+    resources: state.resources as Record<string, ResourceState>,
+  };
+}
 
 describe('power shortages', () => {
   test('buildings go offline when power runs out and recover when restored', () => {
-    const state = deepClone(defaultState);
-    state.buildings.radio = { count: 1 };
-    state.resources.power.amount = 0.15;
-    state.resources.power.discovered = true;
+    const { state, buildings, resources } = clone();
+    buildings.radio = { count: 1 };
+    resources.power.amount = 0.15;
+    resources.power.discovered = true;
 
     let next = processTick(state, 1);
-    expect(next.buildings.radio.offlineReason).toBeUndefined();
-    expect(next.resources.power.amount).toBeCloseTo(0.05, 5);
+    let nextBuildings = next.buildings as Record<string, BuildingEntry>;
+    let nextRes = next.resources as Record<string, ResourceState>;
+    expect(nextBuildings.radio?.offlineReason).toBeUndefined();
+    expect(nextRes.power.amount).toBeCloseTo(0.05, 5);
 
     next = processTick(next, 1);
-    expect(next.buildings.radio.offlineReason).toBe('power');
-    expect(next.resources.power.amount).toBeCloseTo(0.05, 5);
+    nextBuildings = next.buildings as Record<string, BuildingEntry>;
+    nextRes = next.resources as Record<string, ResourceState>;
+    expect(nextBuildings.radio?.offlineReason).toBe('power');
+    expect(nextRes.power.amount).toBeCloseTo(0.05, 5);
 
-    next.resources.power.amount = 1;
+    nextRes.power.amount = 1;
     next = processTick(next, 1);
-    expect(next.buildings.radio.offlineReason).toBeUndefined();
-    expect(next.resources.power.amount).toBeCloseTo(0.9, 5);
+    nextBuildings = next.buildings as Record<string, BuildingEntry>;
+    nextRes = next.resources as Record<string, ResourceState>;
+    expect(nextBuildings.radio?.offlineReason).toBeUndefined();
+    expect(nextRes.power.amount).toBeCloseTo(0.9, 5);
   });
 
   test('power allocated according to priority order', () => {
-    const state = deepClone(defaultState);
-    state.buildings.radio = { count: 1, isDesiredOn: true };
-    state.buildings.toolsmithy = { count: 1, isDesiredOn: true };
+    const { state, buildings, resources } = clone();
+    buildings.radio = { count: 1, isDesiredOn: true };
+    buildings.toolsmithy = { count: 1, isDesiredOn: true };
     state.powerTypeOrder = ['radio', 'toolsmithy'];
-    state.resources.power.amount = 0.1;
-    state.resources.power.discovered = true;
-    state.resources.planks.amount = 10;
-    state.resources.planks.discovered = true;
-    state.resources.metalParts.amount = 10;
-    state.resources.metalParts.discovered = true;
+    resources.power.amount = 0.1;
+    resources.power.discovered = true;
+    resources.planks.amount = 10;
+    resources.planks.discovered = true;
+    resources.metalParts.amount = 10;
+    resources.metalParts.discovered = true;
 
     const next = processTick(state, 1);
-    expect(next.buildings.radio.offlineReason).toBeUndefined();
-    expect(next.buildings.toolsmithy.offlineReason).toBe('power');
-    expect(next.resources.power.amount).toBeCloseTo(0, 5);
+    const nextBuildings = next.buildings as Record<string, BuildingEntry>;
+    const nextRes = next.resources as Record<string, ResourceState>;
+    expect(nextBuildings.radio?.offlineReason).toBeUndefined();
+    expect(nextBuildings.toolsmithy?.offlineReason).toBe('power');
+    expect(nextRes.power.amount).toBeCloseTo(0, 5);
   });
 
   test('buildings stop on resource shortage', () => {
-    const state = deepClone(defaultState);
-    state.buildings.sawmill = { count: 1, isDesiredOn: true };
-    state.buildings.loggingCamp.count = 0;
-    state.resources.wood.amount = 0.5;
-    state.resources.wood.discovered = true;
+    const { state, buildings, resources } = clone();
+    buildings.sawmill = { count: 1, isDesiredOn: true };
+    buildings.loggingCamp.count = 0;
+    resources.wood.amount = 0.5;
+    resources.wood.discovered = true;
 
     const next = processTick(state, 1);
-    expect(next.buildings.sawmill.offlineReason).toBe('resources');
-    expect(next.resources.wood.amount).toBeCloseTo(0.5, 5);
+    const nextBuildings = next.buildings as Record<string, BuildingEntry>;
+    const nextRes = next.resources as Record<string, ResourceState>;
+    expect(nextBuildings.sawmill?.offlineReason).toBe('resources');
+    expect(nextRes.wood.amount).toBeCloseTo(0.5, 5);
   });
 });

--- a/src/engine/__tests__/powerAllocation.test.ts
+++ b/src/engine/__tests__/powerAllocation.test.ts
@@ -1,125 +1,174 @@
-// @ts-nocheck
 import { describe, test, expect } from 'vitest';
 import { processTick } from '../production.ts';
 import { defaultState } from '../../state/defaultState.js';
 import { deepClone } from '../../utils/clone.ts';
+import type {
+  GameState,
+  BuildingEntry,
+  ResourceState,
+} from '../../state/useGame.tsx';
+
+interface PowerStatus {
+  supply: number;
+  demand: number;
+  stored: number;
+  capacity: number;
+}
+
+type GameStateWithPower = GameState & { powerStatus: PowerStatus };
+
+function clone(): {
+  state: GameState;
+  buildings: Record<string, BuildingEntry>;
+  resources: Record<string, ResourceState>;
+} {
+  const state = deepClone(defaultState) as GameState;
+  return {
+    state,
+    buildings: state.buildings as Record<string, BuildingEntry>,
+    resources: state.resources as Record<string, ResourceState>,
+  };
+}
 
 // Test cases described in user instruction
 
 describe('power storage and allocation', () => {
   test('excess supply charges storage up to capacity', () => {
-    const state = deepClone(defaultState);
-    state.buildings.woodGenerator = { count: 1, isDesiredOn: true };
-    state.resources.wood.amount = 50;
-    state.resources.wood.discovered = true;
-    state.resources.power.amount = 10;
-    state.resources.power.discovered = true;
+    const { state, buildings, resources } = clone();
+    buildings.woodGenerator = { count: 1, isDesiredOn: true };
+    resources.wood.amount = 50;
+    resources.wood.discovered = true;
+    resources.power.amount = 10;
+    resources.power.discovered = true;
 
     const next = processTick(state, 15);
-    expect(next.resources.power.amount).toBe(20);
+    const nextResources = next.resources as Record<string, ResourceState>;
+    expect(nextResources.power.amount).toBe(20);
   });
 
   test('deficit drains storage until empty', () => {
-    const state = deepClone(defaultState);
-    state.buildings.radio = { count: 1, isDesiredOn: true };
-    state.resources.power.amount = 1;
-    state.resources.power.discovered = true;
+    const { state, buildings, resources } = clone();
+    buildings.radio = { count: 1, isDesiredOn: true };
+    resources.power.amount = 1;
+    resources.power.discovered = true;
 
     const next = processTick(state, 10);
-    expect(next.resources.power.amount).toBeCloseTo(0, 5);
-    expect(next.buildings.radio.offlineReason).toBeUndefined();
+    const nextResources = next.resources as Record<string, ResourceState>;
+    const nextBuildings = next.buildings as Record<string, BuildingEntry>;
+    expect(nextResources.power.amount).toBeCloseTo(0, 5);
+    expect(nextBuildings.radio?.offlineReason).toBeUndefined();
   });
 
   test('storage sustains ON buildings until depleted', () => {
-    let state = deepClone(defaultState);
-    state.buildings.radio = { count: 1, isDesiredOn: true };
-    state.resources.power.amount = 0.2;
-    state.resources.power.discovered = true;
+    let { state, buildings, resources } = clone();
+    buildings.radio = { count: 1, isDesiredOn: true };
+    resources.power.amount = 0.2;
+    resources.power.discovered = true;
 
     let next = processTick(state, 1);
-    expect(next.buildings.radio.offlineReason).toBeUndefined();
-    expect(next.resources.power.amount).toBeCloseTo(0.1, 5);
+    let nextBuildings = next.buildings as Record<string, BuildingEntry>;
+    let nextResources = next.resources as Record<string, ResourceState>;
+    expect(nextBuildings.radio?.offlineReason).toBeUndefined();
+    expect(nextResources.power.amount).toBeCloseTo(0.1, 5);
 
     next = processTick(next, 1);
-    expect(next.buildings.radio.offlineReason).toBeUndefined();
-    expect(next.resources.power.amount).toBeCloseTo(0, 5);
+    nextBuildings = next.buildings as Record<string, BuildingEntry>;
+    nextResources = next.resources as Record<string, ResourceState>;
+    expect(nextBuildings.radio?.offlineReason).toBeUndefined();
+    expect(nextResources.power.amount).toBeCloseTo(0, 5);
 
     next = processTick(next, 1);
-    expect(next.buildings.radio.offlineReason).toBe('power');
-    expect(next.resources.power.amount).toBeCloseTo(0, 5);
+    nextBuildings = next.buildings as Record<string, BuildingEntry>;
+    nextResources = next.resources as Record<string, ResourceState>;
+    expect(nextBuildings.radio?.offlineReason).toBe('power');
+    expect(nextResources.power.amount).toBeCloseTo(0, 5);
   });
 
   test('allocation honors powerTypeOrder when energy is insufficient', () => {
-    const state = deepClone(defaultState);
-    state.buildings.radio = { count: 1, isDesiredOn: true };
-    state.buildings.toolsmithy = { count: 1, isDesiredOn: true };
-    state.resources.power.amount = 0.4;
-    state.resources.power.discovered = true;
-    state.resources.planks.amount = 10;
-    state.resources.planks.discovered = true;
-    state.resources.metalParts.amount = 10;
-    state.resources.metalParts.discovered = true;
+    const { state, buildings, resources } = clone();
+    buildings.radio = { count: 1, isDesiredOn: true };
+    buildings.toolsmithy = { count: 1, isDesiredOn: true };
+    resources.power.amount = 0.4;
+    resources.power.discovered = true;
+    resources.planks.amount = 10;
+    resources.planks.discovered = true;
+    resources.metalParts.amount = 10;
+    resources.metalParts.discovered = true;
     state.powerTypeOrder = ['radio', 'toolsmithy'];
 
     const next = processTick(state, 1);
-    expect(next.buildings.radio.offlineReason).toBeUndefined();
-    expect(next.buildings.toolsmithy.offlineReason).toBe('power');
-    expect(next.resources.power.amount).toBeCloseTo(0.3, 5);
+    const nextBuildings = next.buildings as Record<string, BuildingEntry>;
+    const nextResources = next.resources as Record<string, ResourceState>;
+    expect(nextBuildings.radio?.offlineReason).toBeUndefined();
+    expect(nextBuildings.toolsmithy?.offlineReason).toBe('power');
+    expect(nextResources.power.amount).toBeCloseTo(0.3, 5);
   });
 
   test('turning ON higher-priority building displaces lower-priority consumers', () => {
-    const base = deepClone(defaultState);
-    base.buildings.toolsmithy = { count: 1, isDesiredOn: true };
-    base.buildings.radio = { count: 1, isDesiredOn: false };
-    base.resources.power.amount = 0.4;
-    base.resources.power.discovered = true;
-    base.resources.planks.amount = 10;
-    base.resources.planks.discovered = true;
-    base.resources.metalParts.amount = 10;
-    base.resources.metalParts.discovered = true;
+    const { state: base, buildings: baseBuildings, resources: baseResources } = clone();
+    baseBuildings.toolsmithy = { count: 1, isDesiredOn: true };
+    baseBuildings.radio = { count: 1, isDesiredOn: false };
+    baseResources.power.amount = 0.4;
+    baseResources.power.discovered = true;
+    baseResources.planks.amount = 10;
+    baseResources.planks.discovered = true;
+    baseResources.metalParts.amount = 10;
+    baseResources.metalParts.discovered = true;
     base.powerTypeOrder = ['radio', 'toolsmithy'];
 
     const powered = processTick(base, 1);
-    expect(powered.buildings.toolsmithy.offlineReason).toBeUndefined();
-    expect(powered.resources.power.amount).toBeCloseTo(0, 5);
+    const poweredBuildings = powered.buildings as Record<string, BuildingEntry>;
+    const poweredResources = powered.resources as Record<string, ResourceState>;
+    expect(poweredBuildings.toolsmithy?.offlineReason).toBeUndefined();
+    expect(poweredResources.power.amount).toBeCloseTo(0, 5);
 
-    const withRadio = deepClone(base);
-    withRadio.buildings.radio.isDesiredOn = true;
-    withRadio.resources.power.amount = 0.4;
+    const withRadio = deepClone(base) as GameState;
+    (withRadio.buildings as Record<string, BuildingEntry>).radio.isDesiredOn = true;
+    (withRadio.resources as Record<string, ResourceState>).power.amount = 0.4;
     const next = processTick(withRadio, 1);
-    expect(next.buildings.radio.offlineReason).toBeUndefined();
-    expect(next.buildings.toolsmithy.offlineReason).toBe('power');
+    const nextBuildings = next.buildings as Record<string, BuildingEntry>;
+    expect(nextBuildings.radio?.offlineReason).toBeUndefined();
+    expect(nextBuildings.toolsmithy?.offlineReason).toBe('power');
   });
 
   test('results are deterministic regardless of building order', () => {
-    const makeState = () => {
-      const s = deepClone(defaultState);
-      s.resources.power.amount = 0.4;
-      s.resources.power.discovered = true;
-      s.resources.planks.amount = 10;
-      s.resources.planks.discovered = true;
-      s.resources.metalParts.amount = 10;
-      s.resources.metalParts.discovered = true;
+    const makeState = (): GameState => {
+      const s = deepClone(defaultState) as GameState;
+      const res = s.resources as Record<string, ResourceState>;
+      res.power.amount = 0.4;
+      res.power.discovered = true;
+      res.planks.amount = 10;
+      res.planks.discovered = true;
+      res.metalParts.amount = 10;
+      res.metalParts.discovered = true;
       s.powerTypeOrder = ['radio', 'toolsmithy'];
       return s;
     };
 
     const stateA = makeState();
-    stateA.buildings.radio = { count: 1, isDesiredOn: true };
-    stateA.buildings.toolsmithy = { count: 1, isDesiredOn: true };
+    const aBuildings = stateA.buildings as Record<string, BuildingEntry>;
+    aBuildings.radio = { count: 1, isDesiredOn: true };
+    aBuildings.toolsmithy = { count: 1, isDesiredOn: true };
 
     const stateB = makeState();
+    const bBuildings = stateB.buildings as Record<string, BuildingEntry>;
     // insert in opposite order
-    stateB.buildings.toolsmithy = { count: 1, isDesiredOn: true };
-    stateB.buildings.radio = { count: 1, isDesiredOn: true };
+    bBuildings.toolsmithy = { count: 1, isDesiredOn: true };
+    bBuildings.radio = { count: 1, isDesiredOn: true };
 
-    const resA = processTick(stateA, 1);
-    const resB = processTick(stateB, 1);
+    const resA = processTick(stateA, 1) as GameStateWithPower;
+    const resB = processTick(stateB, 1) as GameStateWithPower;
+    const resARes = resA.resources as Record<string, ResourceState>;
+    const resBRes = resB.resources as Record<string, ResourceState>;
+    const resABuildings = resA.buildings as Record<string, BuildingEntry>;
+    const resBBuildings = resB.buildings as Record<string, BuildingEntry>;
 
-    expect(resB.resources.power.amount).toBeCloseTo(resA.resources.power.amount, 5);
-    expect(resB.buildings.radio.offlineReason).toBe(resA.buildings.radio.offlineReason);
-    expect(resB.buildings.toolsmithy.offlineReason).toBe(
-      resA.buildings.toolsmithy.offlineReason,
+    expect(resBRes.power.amount).toBeCloseTo(resARes.power.amount, 5);
+    expect(resBBuildings.radio?.offlineReason).toBe(
+      resABuildings.radio?.offlineReason,
+    );
+    expect(resBBuildings.toolsmithy?.offlineReason).toBe(
+      resABuildings.toolsmithy?.offlineReason,
     );
     expect(resB.powerStatus).toEqual(resA.powerStatus);
   });

--- a/src/engine/__tests__/production.test.ts
+++ b/src/engine/__tests__/production.test.ts
@@ -1,137 +1,180 @@
-// @ts-nocheck
 import { describe, test, expect } from 'vitest';
 import { processTick } from '../production.ts';
 import { defaultState } from '../../state/defaultState.js';
 import { deepClone } from '../../utils/clone.ts';
 import { getOutputCapacityFactors } from '../capacity.ts';
 import { ensureCapacityCache } from '../../state/capacityCache.ts';
-import { PRODUCTION_BUILDINGS, BUILDING_MAP } from '../../data/buildings.js';
+import {
+  PRODUCTION_BUILDINGS,
+  BUILDING_MAP,
+} from '../../data/buildings.js';
+import type { Building } from '../../data/buildings.js';
+import type {
+  GameState,
+  BuildingEntry,
+  ResourceState,
+} from '../../state/useGame.tsx';
+
+function clone(): {
+  state: GameState;
+  buildings: Record<string, BuildingEntry>;
+  resources: Record<string, ResourceState>;
+} {
+  const state = deepClone(defaultState) as GameState;
+  return {
+    state,
+    buildings: state.buildings as Record<string, BuildingEntry>,
+    resources: state.resources as Record<string, ResourceState>,
+  };
+}
 
 describe('production building on/off and power allocation', () => {
   test('OFF avoids all consumption and production', () => {
-    const state = deepClone(defaultState);
-    state.buildings.toolsmithy = { count: 1, isDesiredOn: false };
-    state.resources.power.amount = 1;
-    state.resources.power.discovered = true;
-    state.resources.planks.amount = 10;
-    state.resources.planks.discovered = true;
-    state.resources.metalParts.amount = 10;
-    state.resources.metalParts.discovered = true;
-    state.resources.tools.amount = 0;
-    state.resources.tools.discovered = true;
+    const { state, buildings, resources } = clone();
+    buildings.toolsmithy = { count: 1, isDesiredOn: false };
+    resources.power.amount = 1;
+    resources.power.discovered = true;
+    resources.planks.amount = 10;
+    resources.planks.discovered = true;
+    resources.metalParts.amount = 10;
+    resources.metalParts.discovered = true;
+    resources.tools.amount = 0;
+    resources.tools.discovered = true;
 
     const next = processTick(state, 1);
-    expect(next.resources.power.amount).toBeCloseTo(1, 5);
-    expect(next.resources.planks.amount).toBeCloseTo(10, 5);
-    expect(next.resources.metalParts.amount).toBeCloseTo(10, 5);
-    expect(next.resources.tools.amount).toBeCloseTo(0, 5);
-    expect(next.buildings.toolsmithy.offlineReason).toBeUndefined();
+    const nextRes = next.resources as Record<string, ResourceState>;
+    const nextBuildings = next.buildings as Record<string, BuildingEntry>;
+    expect(nextRes.power.amount).toBeCloseTo(1, 5);
+    expect(nextRes.planks.amount).toBeCloseTo(10, 5);
+    expect(nextRes.metalParts.amount).toBeCloseTo(10, 5);
+    expect(nextRes.tools.amount).toBeCloseTo(0, 5);
+    expect(nextBuildings.toolsmithy?.offlineReason).toBeUndefined();
   });
 
   test('ON with no power shows shortage and consumes nothing', () => {
-    const state = deepClone(defaultState);
-    state.buildings.toolsmithy = { count: 1, isDesiredOn: true };
-    state.resources.power.amount = 0;
-    state.resources.power.discovered = true;
-    state.resources.planks.amount = 10;
-    state.resources.planks.discovered = true;
-    state.resources.metalParts.amount = 10;
-    state.resources.metalParts.discovered = true;
-    state.resources.tools.amount = 0;
-    state.resources.tools.discovered = true;
+    const { state, buildings, resources } = clone();
+    buildings.toolsmithy = { count: 1, isDesiredOn: true };
+    resources.power.amount = 0;
+    resources.power.discovered = true;
+    resources.planks.amount = 10;
+    resources.planks.discovered = true;
+    resources.metalParts.amount = 10;
+    resources.metalParts.discovered = true;
+    resources.tools.amount = 0;
+    resources.tools.discovered = true;
 
     const next = processTick(state, 1);
-    expect(next.buildings.toolsmithy.offlineReason).toBe('power');
-    expect(next.resources.power.amount).toBeCloseTo(0, 5);
-    expect(next.resources.planks.amount).toBeCloseTo(10, 5);
-    expect(next.resources.metalParts.amount).toBeCloseTo(10, 5);
-    expect(next.resources.tools.amount).toBeCloseTo(0, 5);
+    const nextRes = next.resources as Record<string, ResourceState>;
+    const nextBuildings = next.buildings as Record<string, BuildingEntry>;
+    expect(nextBuildings.toolsmithy?.offlineReason).toBe('power');
+    expect(nextRes.power.amount).toBeCloseTo(0, 5);
+    expect(nextRes.planks.amount).toBeCloseTo(10, 5);
+    expect(nextRes.metalParts.amount).toBeCloseTo(10, 5);
+    expect(nextRes.tools.amount).toBeCloseTo(0, 5);
   });
 
   test('ON auto-resumes when power and resources return', () => {
-    const state = deepClone(defaultState);
-    state.buildings.toolsmithy = { count: 1, isDesiredOn: true };
-    state.resources.planks.amount = 1;
-    state.resources.planks.discovered = true;
-    state.resources.metalParts.amount = 1;
-    state.resources.metalParts.discovered = true;
-    state.resources.power.amount = 0;
-    state.resources.power.discovered = true;
-    state.resources.tools.amount = 0;
-    state.resources.tools.discovered = true;
+    const { state, buildings, resources } = clone();
+    buildings.toolsmithy = { count: 1, isDesiredOn: true };
+    resources.planks.amount = 1;
+    resources.planks.discovered = true;
+    resources.metalParts.amount = 1;
+    resources.metalParts.discovered = true;
+    resources.power.amount = 0;
+    resources.power.discovered = true;
+    resources.tools.amount = 0;
+    resources.tools.discovered = true;
 
     let next = processTick(state, 1);
-    expect(next.buildings.toolsmithy.offlineReason).toBe('power');
+    let nextBuildings = next.buildings as Record<string, BuildingEntry>;
+    let nextRes = next.resources as Record<string, ResourceState>;
+    expect(nextBuildings.toolsmithy?.offlineReason).toBe('power');
 
-    next.resources.power.amount = 1;
+    nextRes.power.amount = 1;
     next = processTick(next, 1);
-    expect(next.buildings.toolsmithy.offlineReason).toBeUndefined();
-    expect(next.resources.power.amount).toBeCloseTo(0.6, 5);
-    expect(next.resources.planks.amount).toBeCloseTo(0.75, 5);
-    expect(next.resources.metalParts.amount).toBeCloseTo(0.85, 5);
-    expect(next.resources.tools.amount).toBeCloseTo(0.18, 5);
+    nextBuildings = next.buildings as Record<string, BuildingEntry>;
+    nextRes = next.resources as Record<string, ResourceState>;
+    expect(nextBuildings.toolsmithy?.offlineReason).toBeUndefined();
+    expect(nextRes.power.amount).toBeCloseTo(0.6, 5);
+    expect(nextRes.planks.amount).toBeCloseTo(0.75, 5);
+    expect(nextRes.metalParts.amount).toBeCloseTo(0.85, 5);
+    expect(nextRes.tools.amount).toBeCloseTo(0.18, 5);
 
-    next.resources.planks.amount = 0;
-    next.resources.metalParts.amount = 0;
+    nextRes.planks.amount = 0;
+    nextRes.metalParts.amount = 0;
     next = processTick(next, 1);
-    expect(next.buildings.toolsmithy.offlineReason).toBe('resources');
-    expect(next.resources.tools.amount).toBeCloseTo(0.18, 5);
+    nextBuildings = next.buildings as Record<string, BuildingEntry>;
+    nextRes = next.resources as Record<string, ResourceState>;
+    expect(nextBuildings.toolsmithy?.offlineReason).toBe('resources');
+    expect(nextRes.tools.amount).toBeCloseTo(0.18, 5);
 
-    next.resources.planks.amount = 1;
-    next.resources.metalParts.amount = 1;
+    nextRes.planks.amount = 1;
+    nextRes.metalParts.amount = 1;
     next = processTick(next, 1);
-    expect(next.buildings.toolsmithy.offlineReason).toBeUndefined();
-    expect(next.resources.power.amount).toBeCloseTo(0.2, 5);
-    expect(next.resources.planks.amount).toBeCloseTo(0.75, 5);
-    expect(next.resources.metalParts.amount).toBeCloseTo(0.85, 5);
-    expect(next.resources.tools.amount).toBeCloseTo(0.36, 5);
+    nextBuildings = next.buildings as Record<string, BuildingEntry>;
+    nextRes = next.resources as Record<string, ResourceState>;
+    expect(nextBuildings.toolsmithy?.offlineReason).toBeUndefined();
+    expect(nextRes.power.amount).toBeCloseTo(0.2, 5);
+    expect(nextRes.planks.amount).toBeCloseTo(0.75, 5);
+    expect(nextRes.metalParts.amount).toBeCloseTo(0.85, 5);
+    expect(nextRes.tools.amount).toBeCloseTo(0.36, 5);
   });
 
   test('priority allocation: higher-priority building preempts lower-priority', () => {
-    const state = deepClone(defaultState);
-    state.buildings.radio = { count: 1, isDesiredOn: true };
-    state.buildings.toolsmithy = { count: 1, isDesiredOn: true };
+    const { state, buildings, resources } = clone();
+    buildings.radio = { count: 1, isDesiredOn: true };
+    buildings.toolsmithy = { count: 1, isDesiredOn: true };
     state.powerTypeOrder = ['radio', 'toolsmithy'];
-    state.resources.power.amount = 0.1;
-    state.resources.power.discovered = true;
-    state.resources.planks.amount = 10;
-    state.resources.planks.discovered = true;
-    state.resources.metalParts.amount = 10;
-    state.resources.metalParts.discovered = true;
+    resources.power.amount = 0.1;
+    resources.power.discovered = true;
+    resources.planks.amount = 10;
+    resources.planks.discovered = true;
+    resources.metalParts.amount = 10;
+    resources.metalParts.discovered = true;
 
     const next = processTick(state, 1);
-    expect(next.buildings.radio.offlineReason).toBeUndefined();
-    expect(next.buildings.toolsmithy.offlineReason).toBe('power');
-    expect(next.resources.power.amount).toBeCloseTo(0, 5);
+    const nextBuildings = next.buildings as Record<string, BuildingEntry>;
+    const nextRes = next.resources as Record<string, ResourceState>;
+    expect(nextBuildings.radio?.offlineReason).toBeUndefined();
+    expect(nextBuildings.toolsmithy?.offlineReason).toBe('power');
+    expect(nextRes.power.amount).toBeCloseTo(0, 5);
   });
 
   test('capacity factors cap outputs individually', () => {
-    const state = deepClone(defaultState);
+    const { state } = clone();
     ensureCapacityCache(state);
-    const resources = { wood: { amount: 79.8 }, stone: { amount: 0 } };
-    const desired = { wood: 1, stone: 1 };
+    const resources: Record<string, ResourceState> = {
+      wood: { amount: 79.8 },
+      stone: { amount: 0 },
+    };
+    const desired: Record<string, number> = { wood: 1, stone: 1 };
     const factors = getOutputCapacityFactors(state, resources, desired, 0, 0);
     expect(factors.wood).toBeCloseTo(0.2, 5);
     expect(factors.stone).toBeCloseTo(1, 5);
   });
 
   test('multi-output building clamps each resource separately', () => {
-    const state = deepClone(defaultState);
-    const dual = {
+    const { state, buildings, resources } = clone();
+    const dual: Building = {
       id: 'dual',
       outputsPerSecBase: { wood: 1, stone: 1 },
+      costBase: {},
+      costGrowth: 1,
+      type: 'production',
+      name: 'Dual',
     };
     PRODUCTION_BUILDINGS.push(dual);
     BUILDING_MAP[dual.id] = dual;
-    state.buildings[dual.id] = { count: 1 };
+    buildings[dual.id] = { count: 1 };
     state.gameTime.seconds = 270; // ensure summer multipliers = 1
-    state.resources.wood.amount = 79.5;
-    state.resources.wood.discovered = true;
-    state.resources.stone.amount = 0;
-    state.resources.stone.discovered = true;
+    resources.wood.amount = 79.5;
+    resources.wood.discovered = true;
+    resources.stone.amount = 0;
+    resources.stone.discovered = true;
     const next = processTick(state, 1);
-    expect(next.resources.wood.amount).toBeCloseTo(80, 5);
-    expect(next.resources.stone.amount).toBeCloseTo(1, 5);
+    const nextRes = next.resources as Record<string, ResourceState>;
+    expect(nextRes.wood.amount).toBeCloseTo(80, 5);
+    expect(nextRes.stone.amount).toBeCloseTo(1, 5);
     PRODUCTION_BUILDINGS.pop();
     delete BUILDING_MAP[dual.id];
   });


### PR DESCRIPTION
## Summary
- remove ts-nocheck from power-related tests and import GameState types
- use typed state clones instead of any
- make powerStatus assertions type-safe

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a1c90046908331b20a381ae884942a