### PR TITLE
refactor: type offline tests

### DIFF
--- a/src/engine/__tests__/offline.test.ts
+++ b/src/engine/__tests__/offline.test.ts
@@ -1,9 +1,18 @@
-// @ts-nocheck
 import { describe, it, expect, vi } from 'vitest';
+import type { GameState } from '../../state/useGame.tsx';
+import type { OfflineEvent } from '../offline.ts';
+import type { Candidate } from '../candidates.ts';
 
-const fakeCandidate = { id: 'cand1' };
+const fakeCandidate: Candidate = {
+  id: 'cand1',
+  firstName: 'Jane',
+  lastName: 'Doe',
+  sex: 'F',
+  age: 30,
+  skills: {},
+};
 vi.mock('../candidates.ts', () => ({
-  generateCandidate: vi.fn(() => fakeCandidate),
+  generateCandidate: vi.fn<[], Candidate>(() => fakeCandidate),
 }));
 
 import { applyOfflineProgress } from '../offline.ts';
@@ -20,43 +29,48 @@ const createRng =
 
 describe('applyOfflineProgress', () => {
   it('uses post-production state to update radio and emits event', () => {
-    generateCandidate.mockClear();
+    const generateCandidateMock = vi.mocked(generateCandidate);
+    generateCandidateMock.mockClear();
     const rng = createRng();
-    const state = {
+    const state: Partial<GameState> = {
       buildings: { radio: { count: 1 }, woodGenerator: { count: 1 } },
       resources: { power: { amount: 0 }, wood: { amount: 100 } },
       population: { candidate: null },
       colony: { radioTimer: 3 },
     };
-    const { state: next, events } = applyOfflineProgress(state, 5, {}, rng);
-    expect(generateCandidate).toHaveBeenCalledOnce();
+    const { state: next, events }: { state: GameState; events: OfflineEvent[] } =
+      applyOfflineProgress(state as GameState, 5, {}, rng);
+    expect(generateCandidateMock).toHaveBeenCalledOnce();
     expect(next.population.candidate).toEqual(fakeCandidate);
     expect(next.colony.radioTimer).toBe(0);
-    const evt = events.find((e) => e.type === 'candidate');
+    const evt: OfflineEvent | undefined = events.find(
+      (e) => e.type === 'candidate',
+    );
     expect(evt?.text).toBe('Someone responded to the radio');
   });
 
   it('returns resource gains for production while offline', () => {
     const rng = createRng(2);
-    const state = {
+    const state: Partial<GameState> = {
       buildings: { woodGenerator: { count: 1 } },
       resources: { power: { amount: 0 }, wood: { amount: 100 } },
       population: { candidate: null },
       colony: { radioTimer: 0 },
     };
-    const { gains } = applyOfflineProgress(state, 5, {}, rng);
+    const { gains } = applyOfflineProgress(state as GameState, 5, {}, rng);
     expect(gains.power).toBeGreaterThan(0);
   });
 
   it('does not consume or produce when buildings are off', () => {
     const rng = createRng(3);
-    const state = {
+    const state: Partial<GameState> = {
       buildings: { woodGenerator: { count: 1, isDesiredOn: false } },
       resources: { power: { amount: 0 }, wood: { amount: 100 } },
       population: { candidate: null },
       colony: { radioTimer: 0 },
     };
-    const { state: next, gains } = applyOfflineProgress(state, 5, {}, rng);
+    const { state: next, gains }: { state: GameState; gains: Record<string, number> } =
+      applyOfflineProgress(state as GameState, 5, {}, rng);
     expect(next.resources.wood.amount).toBe(100);
     expect(next.resources.power.amount).toBe(0);
     expect(gains).toEqual({});
@@ -64,13 +78,14 @@ describe('applyOfflineProgress', () => {
 
   it('handles shortages the same as online', () => {
     const rng = createRng(4);
-    const state = {
+    const state: Partial<GameState> = {
       buildings: { woodGenerator: { count: 1 } },
       resources: { power: { amount: 0 }, wood: { amount: 0 } },
       population: { candidate: null },
       colony: { radioTimer: 0 },
     };
-    const { state: next, gains } = applyOfflineProgress(state, 5, {}, rng);
+    const { state: next, gains }: { state: GameState; gains: Record<string, number> } =
+      applyOfflineProgress(state as GameState, 5, {}, rng);
     expect(next.resources.wood.amount).toBe(0);
     expect(next.resources.power.amount).toBe(0);
     expect(next.buildings.woodGenerator.offlineReason).toBe('resources');
@@ -78,25 +93,26 @@ describe('applyOfflineProgress', () => {
   });
 
   it('updates power storage like live ticks', () => {
-    const createState = () => ({
-      buildings: {
-        woodGenerator: { count: 1 },
-        toolsmithy: { count: 1 },
-        battery: { count: 1 },
-      },
-      resources: {
-        wood: { amount: 100 },
-        planks: { amount: 100 },
-        metalParts: { amount: 100 },
-        power: { amount: 0 },
-        tools: { amount: 0 },
-      },
-      population: { settlers: [], candidate: null },
-      colony: { radioTimer: 0, starvationTimerSeconds: 0 },
-    });
+    const createState = (): GameState =>
+      ({
+        buildings: {
+          woodGenerator: { count: 1 },
+          toolsmithy: { count: 1 },
+          battery: { count: 1 },
+        },
+        resources: {
+          wood: { amount: 100 },
+          planks: { amount: 100 },
+          metalParts: { amount: 100 },
+          power: { amount: 0 },
+          tools: { amount: 0 },
+        },
+        population: { settlers: [], candidate: null },
+        colony: { radioTimer: 0, starvationTimerSeconds: 0 },
+      } as GameState);
     const seconds = 10;
     const rng = createRng(5);
-    const { state: offline } = applyOfflineProgress(
+    const { state: offline }: { state: GameState } = applyOfflineProgress(
       createState(),
       seconds,
       {},
@@ -112,7 +128,7 @@ describe('applyOfflineProgress', () => {
 
   it('completes research and logs event while offline', () => {
     const id = 'industry1';
-    const state: any = {
+    const state: Partial<GameState> = {
       buildings: {},
       resources: {},
       research: { current: { id }, completed: [], progress: { [id]: 0 } },
@@ -121,10 +137,13 @@ describe('applyOfflineProgress', () => {
       log: [],
     };
     const seconds = RESEARCH_MAP[id].timeSec + 5;
-    const { state: next, events } = applyOfflineProgress(state, seconds, {});
+    const { state: next, events }: { state: GameState; events: OfflineEvent[] } =
+      applyOfflineProgress(state as GameState, seconds, {});
     expect(next.research.current).toBe(null);
     expect(next.research.completed).toContain(id);
-    const evt = events.find((e: any) => e.type === 'research');
+    const evt: OfflineEvent | undefined = events.find(
+      (e) => e.type === 'research',
+    );
     expect(evt?.text).toContain(RESEARCH_MAP[id].name);
   });
 });

--- a/src/engine/__tests__/offlineTicks.test.ts
+++ b/src/engine/__tests__/offlineTicks.test.ts
@@ -1,28 +1,33 @@
-// @ts-nocheck
 import { describe, it, expect, vi } from 'vitest';
 import { getResourceRates } from '../../state/selectors.js';
 import { processSettlersTick } from '../settlers.ts';
 import { RESOURCES } from '../../data/resources.js';
+import type { GameState, ResourceState } from '../../state/useGame.tsx';
 
-const createBaseState = () => ({
-  buildings: { woodGenerator: { count: 1 }, radio: { count: 1 } },
-  resources: {
-    wood: { amount: 50, discovered: true, produced: 0 },
-    power: { amount: 0, discovered: false, produced: 0 },
-    potatoes: { amount: 0, discovered: false, produced: 0 },
-  },
-  population: { settlers: [], candidate: null },
-  colony: { radioTimer: 0, starvationTimerSeconds: 0 },
-});
+type TestGameState = GameState & { resources: Record<string, ResourceState> };
 
-const createRng = (seed = 1) => () => {
+const createBaseState = (): TestGameState =>
+  ({
+    buildings: { woodGenerator: { count: 1 }, radio: { count: 1 } },
+    resources: {
+      wood: { amount: 50, discovered: true, produced: 0 } as ResourceState,
+      power: { amount: 0, discovered: false, produced: 0 } as ResourceState,
+      potatoes: { amount: 0, discovered: false, produced: 0 } as ResourceState,
+    },
+    population: { settlers: [], candidate: null },
+    colony: { radioTimer: 0, starvationTimerSeconds: 0 },
+  } as TestGameState);
+
+const createRng = (seed = 1): (() => number) => () => {
   seed = (seed * 16807) % 2147483647;
   return (seed - 1) / 2147483646;
 };
 
 describe('offline progress', () => {
   it('invokes processTick in larger chunks', async () => {
-    const mock = vi.fn((state: any) => state);
+    const mock = vi.fn<
+      (state: TestGameState, seconds?: number, roleBonuses?: Record<string, number>) => TestGameState
+    >((state) => state);
     vi.doMock('../production.ts', () => ({ processTick: mock }));
     const { applyOfflineProgress } = await import('../offline.ts');
     applyOfflineProgress(createBaseState(), 5, {}, createRng());
@@ -39,7 +44,7 @@ describe('offline progress', () => {
       100,
       {},
       createRng(2),
-    ).state;
+    ).state as TestGameState;
     let online = createBaseState();
     for (let i = 0; i < 100; i += 1) {
       online = processTick(online, 1);
@@ -51,24 +56,31 @@ describe('offline progress', () => {
   it('matches per-second simulation over multiple hours', async () => {
     const { applyOfflineProgress } = await import('../offline.ts');
     const { processTick } = await import('../production.ts');
-    const base = {
+    const base: Partial<TestGameState> = {
       buildings: { potatoField: { count: 2 }, largeGranary: { count: 100 } },
-      resources: { potatoes: { amount: 0, discovered: true, produced: 0 } },
-      population: { settlers: [{ id: 's1', isDead: false, role: null }], candidate: null },
+      resources: { potatoes: { amount: 0, discovered: true, produced: 0 } as ResourceState },
+      population: {
+        settlers: [{ id: 's1', isDead: false, role: null }] as unknown as TestGameState['population']['settlers'],
+        candidate: null,
+      },
       colony: { radioTimer: 0, starvationTimerSeconds: 0 },
     };
     const seconds = 3 * 3600;
     const rngOffline = createRng(3);
-    const offline = applyOfflineProgress(structuredClone(base), seconds, {}, rngOffline)
-      .state;
+    const offline = applyOfflineProgress(
+      structuredClone(base) as TestGameState,
+      seconds,
+      {},
+      rngOffline,
+    ).state as TestGameState;
 
-    let online = structuredClone(base);
+    let online = structuredClone(base) as TestGameState;
     const rngOnline = createRng(3);
     for (let i = 0; i < seconds; i += 1) {
       online = processTick(online, 1);
       const rates = getResourceRates(online);
       let totalFoodProdBase = 0;
-      Object.keys(RESOURCES).forEach((id) => {
+      (Object.keys(RESOURCES) as Array<keyof typeof RESOURCES>).forEach((id) => {
         if (RESOURCES[id].category === 'FOOD') {
           totalFoodProdBase += rates[id]?.perSec || 0;
         }


### PR DESCRIPTION
## Summary
- add proper typings to offline progress tests
- remove `@ts-nocheck` annotations
- use typed mocks and state objects

## Testing
- `npm run typecheck` *(fails: Property 'science' does not exist on type '{}', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a1cf3b7b0483318fc5d4a745d80c9f