### PR TITLE
Add knowledge track with library research

### DIFF
--- a/src/data/research.js
+++ b/src/data/research.js
@@ -243,6 +243,20 @@ export const RESEARCH = [
     row: 2,
     track: 1,
   },
+  // Knowledge track
+  {
+    id: 'library',
+    name: 'Library',
+    type: 'unlock',
+    shortDesc: 'Unlocks the library to improve research efforts.',
+    cost: { science: 120 },
+    timeSec: 180,
+    prereqs: [],
+    unlocks: {},
+    row: 0,
+    track: 3,
+    effects: [],
+  },
 ];
 
 export const RESEARCH_MAP = Object.fromEntries(RESEARCH.map((r) => [r.id, r]));

--- a/src/views/research/ResearchTree.jsx
+++ b/src/views/research/ResearchTree.jsx
@@ -12,7 +12,7 @@ const RESEARCH_TRACKS = RESEARCH.reduce((acc, r) => {
 RESEARCH_TRACKS.forEach((track) => track.sort((a, b) => a.row - b.row));
 
 // Column offsets for each track to allow shifting entire tracks horizontally
-const TRACK_OFFSETS = [0, 0, 2];
+const TRACK_OFFSETS = [0, 0, 2, 4];
 const OFFSET_STEP_REM = 22; // width + gap of a research column
 
 function evaluate(node, state) {


### PR DESCRIPTION
## Summary
- Add a new Knowledge track with a Library research node
- Offset the fourth research track in ResearchTree for correct rendering

## Testing
- `npm test`
- `npm run lint`
- `npm run report:economy` *(fails: [Object: null prototype])*

------
https://chatgpt.com/codex/tasks/task_e_68a1e62b6fb4833190b3e9abad023871