### PR TITLE
Reduce science output and capacity

### DIFF
--- a/docs/ECONOMY_REPORT.md
+++ b/docs/ECONOMY_REPORT.md
@@ -16,7 +16,7 @@ Each tick represents 1 second. For each building: base production is modified by
 | bricks | Bricks | CONSTRUCTION_MATERIALS | 0 | 40 |  | resources.js:RESOURCES.bricks |
 | metalParts | Metal Parts | CONSTRUCTION_MATERIALS | 0 | 24 |  | resources.js:RESOURCES.metalParts |
 | tools | Tools | CONSTRUCTION_MATERIALS | 0 | 24 |  | resources.js:RESOURCES.tools |
-| science | Science | SOCIETY | 0 | 400 |  | resources.js:RESOURCES.science |
+| science | Science | SOCIETY | 0 | 120 |  | resources.js:RESOURCES.science |
 | power | Power | ENERGY | 0 | 20 |  | resources.js:RESOURCES.power |
 
 ## 3) Seasons
@@ -39,7 +39,7 @@ Each tick represents 1 second. For each building: base production is modified by
 | sawmill | Sawmill | processing | {"wood":53,"scrap":20,"stone":13} | 1.13 | 0.5 | - | {"planks":0.5} | {"wood":0.8} | industry1 | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[6] |
 | metalWorkshop | Metal Workshop | processing | {"wood":30,"scrap":30,"stone":10,"planks":10} | 1.13 | 0.5 | - | {"metalParts":0.4} | {"scrap":0.4} | industry1 | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[7] |
 | toolsmithy | Toolsmithy | processing | {"wood":50,"scrap":30,"stone":20,"planks":25,"metalParts":15} | 1.13 | 0.5 | - | {"tools":0.18} | {"planks":0.25,"metalParts":0.15,"power":0.4} | industry2 | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[8] |
-| school | School | production | {"wood":30,"scrap":12,"stone":12} | 1.13 | 0.5 | - | {"science":0.45} | - | - | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[9] |
+| school | School | production | {"wood":30,"scrap":12,"stone":12} | 1.13 | 0.5 | - | {"science":0.2} | - | - | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[9] |
 | woodGenerator | Wood Generator | production | {"wood":50,"stone":10,"planks":20,"metalParts":10} | 1.13 | 0.5 | - | {"power":1} | {"wood":0.25} | basicEnergy | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[10] |
 | shelter | Shelter | production | {"wood":30,"scrap":10} | 1.8 | 0.5 | - | - | - | - | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[11] |
 | radio | Radio | production | {"wood":80,"scrap":40,"stone":20,"planks":20,"metalParts":10} | 1 | 0.5 | - | - | {"power":0.1} | radio | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[12] |
@@ -99,7 +99,7 @@ Starting season: spring, Year: 1.
 | bricks | 0 | 40 | resources.js:RESOURCES.bricks.startingAmount/startingCapacity |
 | metalParts | 0 | 24 | resources.js:RESOURCES.metalParts.startingAmount/startingCapacity |
 | tools | 0 | 24 | resources.js:RESOURCES.tools.startingAmount/startingCapacity |
-| science | 0 | 400 | resources.js:RESOURCES.science.startingAmount/startingCapacity |
+| science | 0 | 120 | resources.js:RESOURCES.science.startingAmount/startingCapacity |
 | power | 0 | 20 | resources.js:RESOURCES.power.startingAmount/startingCapacity |
 
 ### Buildings

--- a/docs/economy-snapshot.js
+++ b/docs/economy-snapshot.js
@@ -198,7 +198,7 @@ export default {
       "displayName": "Science",
       "category": "SOCIETY",
       "startingAmount": 0,
-      "startingCapacity": 400,
+      "startingCapacity": 120,
       "unit": null,
       "origin": {
         "file": "resources.js",
@@ -491,7 +491,7 @@ export default {
       "refund": 0.5,
       "storage": {},
       "outputsPerSec": {
-        "science": 0.45
+        "science": 0.2
       },
       "inputsPerSec": {},
       "requiresResearch": "",
@@ -1462,7 +1462,7 @@ export default {
     },
     "science": {
       "amount": 0,
-      "capacity": 400
+      "capacity": 120
     },
     "power": {
       "amount": 0,

--- a/docs/economy-snapshot.json
+++ b/docs/economy-snapshot.json
@@ -198,7 +198,7 @@
       "displayName": "Science",
       "category": "SOCIETY",
       "startingAmount": 0,
-      "startingCapacity": 400,
+      "startingCapacity": 120,
       "unit": null,
       "origin": {
         "file": "resources.js",
@@ -491,7 +491,7 @@
       "refund": 0.5,
       "storage": {},
       "outputsPerSec": {
-        "science": 0.45
+        "science": 0.2
       },
       "inputsPerSec": {},
       "requiresResearch": "",
@@ -1462,7 +1462,7 @@
     },
     "science": {
       "amount": 0,
-      "capacity": 400
+      "capacity": 120
     },
     "power": {
       "amount": 0,

--- a/src/data/buildings.js
+++ b/src/data/buildings.js
@@ -122,7 +122,7 @@ export const BUILDINGS = [
     name: 'School',
     type: 'production',
     category: 'Science',
-    outputsPerSecBase: { science: 0.45 }, // changed: 0.5→0.45
+    outputsPerSecBase: { science: 0.2 }, // changed: 0.45→0.2
     costBase: { wood: 30, scrap: 12, stone: 12 }, // changed: wood 25→30, scrap 10→12, stone 10→12
     costGrowth: 1.13, // changed: 1.15→1.13
     refund: 0.5,

--- a/src/data/resources.js
+++ b/src/data/resources.js
@@ -79,7 +79,7 @@ export const RESOURCES = {
     icon: '🔬',
     category: 'SOCIETY',
     startingAmount: 0,
-    startingCapacity: 400,
+    startingCapacity: 120, // changed: 400 -> 120
   },
   power: {
     id: 'power',


### PR DESCRIPTION
## Summary
- Lower school base science production to 0.2 per second
- Decrease starting science capacity to 120
- Refresh economy docs to reflect new science balance

## Testing
- `npm test`
- `npm run lint`
- `npm run report:economy` *(fails: Object: null prototype)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ea15a2008331b14dc12e27ba2e93