### PR TITLE
Add library research and storage building

### DIFF
--- a/docs/ECONOMY_REPORT.md
+++ b/docs/ECONOMY_REPORT.md
@@ -1,7 +1,7 @@
 # Economy Report
 
 ## 1) Overview
-Economy generated from commit **1b5f7109aeab326544a4b683f2c570a0e9933e3d** on 2025-08-17 00:52:21 +0200. Save version: **7**.
+Economy generated from commit **bc91d321760499ffabb3a19f53ad4d61274fa663** on 2025-08-17 16:55:23 +0200. Save version: **7**.
 Each tick represents 1 second. For each building: base production is modified by season multipliers, summed, then clamped to capacity. Offline progress processes in 60-second chunks.
 
 ## 2) Resources
@@ -49,7 +49,8 @@ Each tick represents 1 second. For each building: base production is modified by
 | largeWarehouse | Large Warehouse | storage | {"wood":40,"stone":30,"bricks":20} | 1.15 | 0.5 | {"wood":400,"stone":160,"scrap":240} | - | - | masonry2 | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[16] |
 | materialsDepot | Materials Depot | storage | {"wood":25,"scrap":10,"stone":5} | 1.22 | 0.5 | {"planks":100,"metalParts":40} | - | - | industry1 | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[17] |
 | largeMaterialsDepot | Large Materials Depot | storage | {"wood":35,"bricks":25,"scrap":15} | 1.15 | 0.5 | {"planks":180,"metalParts":90,"bricks":180} | - | - | masonry2 | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[18] |
-| battery | Battery | storage | {"wood":40,"stone":20,"planks":20,"metalParts":10} | 1.22 | 0.5 | {"power":40} | - | - | basicEnergy | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[19] |
+| library | Library | storage | {"wood":40,"stone":20,"scrap":10} | 1.22 | 0.5 | {"science":100} | - | - | library | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[19] |
+| battery | Battery | storage | {"wood":40,"stone":20,"planks":20,"metalParts":10} | 1.22 | 0.5 | {"power":40} | - | - | basicEnergy | {"spring":1,"summer":1,"autumn":1,"winter":1} | buildings.js:BUILDINGS[20] |
 
 ## 5) Research
 | id | name | science cost | time (sec) | prereqs | milestones | unlocks | effects | source |
@@ -59,17 +60,18 @@ Each tick represents 1 second. For each building: base production is modified by
 | salvaging1 | Salvaging I | 60 | 90 | industry1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"SCRAP","percent":0.05,"type":"output"}] | research.js:RESEARCH[2] |
 | logistics1 | Logistics I | 60 | 90 | industry1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"RAW","percent":0.05,"type":"storage"},{"category":"CONSTRUCTION_MATERIALS","percent":0.05,"type":"storage"}] | research.js:RESEARCH[3] |
 | masonry1 | Masonry I | 90 | 150 | industry1 | - | {"resources":["bricks"],"buildings":["brickKiln"],"categories":[]} | - | research.js:RESEARCH[4] |
-| industry2 | Industry II | 200 | 240 | woodworking1, salvaging1, logistics1 | {"produced":{"planks":50,"metalParts":30}} | {"resources":[],"buildings":["toolsmithy"],"categories":[]} | - | research.js:RESEARCH[5] |
-| industryProduction | Industry Production | 170 | 270 | woodworking1, salvaging1, logistics1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"CONSTRUCTION_MATERIALS","percent":0.05,"type":"output"}] | research.js:RESEARCH[6] |
-| masonry2 | Masonry II | 140 | 210 | masonry1, logistics1 | - | {"resources":[],"buildings":["largeWarehouse","largeGranary","largeMaterialsDepot"],"categories":[]} | - | research.js:RESEARCH[7] |
-| woodworking2 | Woodworking II | 220 | 360 | industry2, industryProduction, woodworking1, salvaging1, logistics1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"WOOD","percent":0.05,"type":"output"}] | research.js:RESEARCH[8] |
-| salvaging2 | Salvaging II | 220 | 360 | industry2, industryProduction, woodworking1, salvaging1, logistics1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"SCRAP","percent":0.05,"type":"output"}] | research.js:RESEARCH[9] |
-| logistics2 | Logistics II | 230 | 360 | industry2, industryProduction, woodworking1, salvaging1, logistics1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"RAW","percent":0.05,"type":"storage"},{"category":"CONSTRUCTION_MATERIALS","percent":0.05,"type":"storage"}] | research.js:RESEARCH[10] |
-| basicEnergy | Basic Energy | 150 | 210 | industry2 | - | {"resources":["power"],"buildings":["woodGenerator","battery"],"categories":["Energy"]} | - | research.js:RESEARCH[11] |
-| radio | Radio | 150 | 240 | basicEnergy | - | {"resources":[],"buildings":["radio"],"categories":[]} | - | research.js:RESEARCH[12] |
-| food1 | Food I | 50 | 90 | - | - | {"resources":[],"buildings":[],"categories":[]} | - | research.js:RESEARCH[13] |
-| huntingHut | Hunting Hut | 60 | 90 | food1 | - | {"resources":["meat"],"buildings":["huntersHut"],"categories":[]} | - | research.js:RESEARCH[14] |
-| food2 | Food II | 150 | 240 | huntingHut | - | {"resources":[],"buildings":[],"categories":[]} | [{"resource":"meat","percent":0.04,"type":"output"}] | research.js:RESEARCH[15] |
+| library | Library | 80 | 120 | industry1 | - | {"resources":[],"buildings":["library"],"categories":[]} | - | research.js:RESEARCH[5] |
+| industry2 | Industry II | 200 | 240 | woodworking1, salvaging1, logistics1 | {"produced":{"planks":50,"metalParts":30}} | {"resources":[],"buildings":["toolsmithy"],"categories":[]} | - | research.js:RESEARCH[6] |
+| industryProduction | Industry Production | 170 | 270 | woodworking1, salvaging1, logistics1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"CONSTRUCTION_MATERIALS","percent":0.05,"type":"output"}] | research.js:RESEARCH[7] |
+| masonry2 | Masonry II | 140 | 210 | masonry1, logistics1 | - | {"resources":[],"buildings":["largeWarehouse","largeGranary","largeMaterialsDepot"],"categories":[]} | - | research.js:RESEARCH[8] |
+| woodworking2 | Woodworking II | 220 | 360 | industry2, industryProduction, woodworking1, salvaging1, logistics1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"WOOD","percent":0.05,"type":"output"}] | research.js:RESEARCH[9] |
+| salvaging2 | Salvaging II | 220 | 360 | industry2, industryProduction, woodworking1, salvaging1, logistics1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"SCRAP","percent":0.05,"type":"output"}] | research.js:RESEARCH[10] |
+| logistics2 | Logistics II | 230 | 360 | industry2, industryProduction, woodworking1, salvaging1, logistics1 | - | {"resources":[],"buildings":[],"categories":[]} | [{"category":"RAW","percent":0.05,"type":"storage"},{"category":"CONSTRUCTION_MATERIALS","percent":0.05,"type":"storage"}] | research.js:RESEARCH[11] |
+| basicEnergy | Basic Energy | 150 | 210 | industry2 | - | {"resources":["power"],"buildings":["woodGenerator","battery"],"categories":["Energy"]} | - | research.js:RESEARCH[12] |
+| radio | Radio | 150 | 240 | basicEnergy | - | {"resources":[],"buildings":["radio"],"categories":[]} | - | research.js:RESEARCH[13] |
+| food1 | Food I | 50 | 90 | - | - | {"resources":[],"buildings":[],"categories":[]} | - | research.js:RESEARCH[14] |
+| huntingHut | Hunting Hut | 60 | 90 | food1 | - | {"resources":["meat"],"buildings":["huntersHut"],"categories":[]} | - | research.js:RESEARCH[15] |
+| food2 | Food II | 150 | 240 | huntingHut | - | {"resources":[],"buildings":[],"categories":[]} | [{"resource":"meat","percent":0.04,"type":"output"}] | research.js:RESEARCH[16] |
 
 ## 6) Roles
 | id | name | skill | resources | buildings | source |

--- a/docs/economy-snapshot.json
+++ b/docs/economy-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "version": "1b5f7109aeab326544a4b683f2c570a0e9933e3d",
+  "version": "bc91d321760499ffabb3a19f53ad4d61274fa663",
   "saveVersion": 7,
   "tickSeconds": 1,
   "seasons": {
@@ -768,6 +768,34 @@
       }
     },
     {
+      "id": "library",
+      "name": "Library",
+      "type": "storage",
+      "cost": {
+        "wood": 40,
+        "stone": 20,
+        "scrap": 10
+      },
+      "costGrowth": 1.22,
+      "refund": 0.5,
+      "storage": {
+        "science": 100
+      },
+      "outputsPerSec": {},
+      "inputsPerSec": {},
+      "requiresResearch": "library",
+      "seasonMults": {
+        "spring": 1,
+        "summer": 1,
+        "autumn": 1,
+        "winter": 1
+      },
+      "origin": {
+        "file": "buildings.js",
+        "path": "BUILDINGS[19]"
+      }
+    },
+    {
       "id": "battery",
       "name": "Battery",
       "type": "storage",
@@ -793,7 +821,7 @@
       },
       "origin": {
         "file": "buildings.js",
-        "path": "BUILDINGS[19]"
+        "path": "BUILDINGS[20]"
       }
     }
   ],
@@ -933,6 +961,28 @@
       }
     },
     {
+      "id": "library",
+      "name": "Library",
+      "scienceCost": 80,
+      "timeSec": 120,
+      "prereqs": [
+        "industry1"
+      ],
+      "milestones": null,
+      "unlocks": {
+        "resources": [],
+        "buildings": [
+          "library"
+        ],
+        "categories": []
+      },
+      "effects": [],
+      "origin": {
+        "file": "research.js",
+        "path": "RESEARCH[5]"
+      }
+    },
+    {
       "id": "industry2",
       "name": "Industry II",
       "scienceCost": 200,
@@ -958,7 +1008,7 @@
       "effects": [],
       "origin": {
         "file": "research.js",
-        "path": "RESEARCH[5]"
+        "path": "RESEARCH[6]"
       }
     },
     {
@@ -986,7 +1036,7 @@
       ],
       "origin": {
         "file": "research.js",
-        "path": "RESEARCH[6]"
+        "path": "RESEARCH[7]"
       }
     },
     {
@@ -1011,7 +1061,7 @@
       "effects": [],
       "origin": {
         "file": "research.js",
-        "path": "RESEARCH[7]"
+        "path": "RESEARCH[8]"
       }
     },
     {
@@ -1041,7 +1091,7 @@
       ],
       "origin": {
         "file": "research.js",
-        "path": "RESEARCH[8]"
+        "path": "RESEARCH[9]"
       }
     },
     {
@@ -1071,7 +1121,7 @@
       ],
       "origin": {
         "file": "research.js",
-        "path": "RESEARCH[9]"
+        "path": "RESEARCH[10]"
       }
     },
     {
@@ -1106,7 +1156,7 @@
       ],
       "origin": {
         "file": "research.js",
-        "path": "RESEARCH[10]"
+        "path": "RESEARCH[11]"
       }
     },
     {
@@ -1133,7 +1183,7 @@
       "effects": [],
       "origin": {
         "file": "research.js",
-        "path": "RESEARCH[11]"
+        "path": "RESEARCH[12]"
       }
     },
     {
@@ -1155,7 +1205,7 @@
       "effects": [],
       "origin": {
         "file": "research.js",
-        "path": "RESEARCH[12]"
+        "path": "RESEARCH[13]"
       }
     },
     {
@@ -1173,7 +1223,7 @@
       "effects": [],
       "origin": {
         "file": "research.js",
-        "path": "RESEARCH[13]"
+        "path": "RESEARCH[14]"
       }
     },
     {
@@ -1197,7 +1247,7 @@
       "effects": [],
       "origin": {
         "file": "research.js",
-        "path": "RESEARCH[14]"
+        "path": "RESEARCH[15]"
       }
     },
     {
@@ -1223,7 +1273,7 @@
       ],
       "origin": {
         "file": "research.js",
-        "path": "RESEARCH[15]"
+        "path": "RESEARCH[16]"
       }
     }
   ],

--- a/src/data/buildings.js
+++ b/src/data/buildings.js
@@ -237,6 +237,17 @@ export const BUILDINGS = [
     description: 'Expanded storage for processed construction materials.',
   },
   {
+    id: 'library',
+    name: 'Library',
+    type: 'storage',
+    costBase: { wood: 40, stone: 20, scrap: 10 },
+    costGrowth: 1.22,
+    refund: 0.5,
+    capacityAdd: { science: 100 },
+    requiresResearch: 'library',
+    description: 'Stores scientific knowledge for future breakthroughs.',
+  },
+  {
     id: 'battery',
     name: 'Battery',
     type: 'storage',

--- a/src/data/research.js
+++ b/src/data/research.js
@@ -72,6 +72,19 @@ export const RESEARCH = [
     effects: [],
   },
   {
+    id: 'library',
+    name: 'Library',
+    type: 'unlock',
+    shortDesc: 'Unlocks the library for storing knowledge.',
+    cost: { science: 80 },
+    timeSec: 120,
+    prereqs: ['industry1'],
+    unlocks: { buildings: ['library'] },
+    row: 0,
+    track: 3,
+    effects: [],
+  },
+  {
     id: 'industry2',
     name: 'Industry II',
     type: 'unlock',
@@ -242,20 +255,6 @@ export const RESEARCH = [
     effects: [{ resource: 'meat', percent: 0.04, type: 'output' }],
     row: 2,
     track: 1,
-  },
-  // Knowledge track
-  {
-    id: 'library',
-    name: 'Library',
-    type: 'unlock',
-    shortDesc: 'Unlocks the library to improve research efforts.',
-    cost: { science: 120 },
-    timeSec: 180,
-    prereqs: [],
-    unlocks: {},
-    row: 0,
-    track: 3,
-    effects: [],
   },
 ];
 


### PR DESCRIPTION
## Summary
- add Library research unlocking library building
- add Library storage building for science capacity
- regenerate economy report

## Testing
- `TS_NODE_TRANSPILE_ONLY=1 npm run report:economy`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1ed68bf84833189d18d051891ae39