### PR TITLE
Adjust research costs for mid-game technologies

### DIFF
--- a/src/data/research.js
+++ b/src/data/research.js
@@ -103,7 +103,7 @@ export const RESEARCH = [
     name: 'Industry Production',
     type: 'efficiency',
     shortDesc: '+5% output for construction materials.',
-    cost: { science: 170 },
+    cost: { science: 220 },
     timeSec: 270,
     prereqs: ['woodworking1', 'salvaging1', 'logistics1'],
     effects: [
@@ -117,7 +117,7 @@ export const RESEARCH = [
     name: 'Masonry II',
     type: 'unlock',
     shortDesc: 'Unlocks larger storage buildings.',
-    cost: { science: 140 },
+    cost: { science: 240 },
     timeSec: 210,
     prereqs: ['masonry1', 'logistics1'],
     unlocks: {
@@ -132,7 +132,7 @@ export const RESEARCH = [
     name: 'Woodworking II',
     type: 'efficiency',
     shortDesc: 'Additional +5% to wood and planks.',
-    cost: { science: 220 },
+    cost: { science: 500 },
     timeSec: 360,
     prereqs: [
       'industry2',
@@ -150,7 +150,7 @@ export const RESEARCH = [
     name: 'Salvaging II',
     type: 'efficiency',
     shortDesc: 'Additional +5% to scrap and metal parts.',
-    cost: { science: 220 },
+    cost: { science: 500 },
     timeSec: 360,
     prereqs: [
       'industry2',
@@ -169,7 +169,7 @@ export const RESEARCH = [
     type: 'efficiency',
     shortDesc:
       'Additional +5% storage capacity for raw materials and construction materials.',
-    cost: { science: 230 },
+    cost: { science: 500 },
     timeSec: 360,
     prereqs: [
       'industry2',
@@ -192,7 +192,7 @@ export const RESEARCH = [
     type: 'unlock',
     shortDesc:
       'Learn the fundamentals of generating and storing electrical power.',
-    cost: { science: 150 },
+    cost: { science: 300 },
     timeSec: 210,
     prereqs: ['industry2'],
     unlocks: {
@@ -209,7 +209,7 @@ export const RESEARCH = [
     name: 'Radio',
     type: 'unlock',
     shortDesc: 'Unlocks radio broadcasts to attract settlers.',
-    cost: { science: 150 },
+    cost: { science: 400 },
     timeSec: 240,
     prereqs: ['basicEnergy'],
     unlocks: { buildings: ['radio'] },

--- a/src/engine/__tests__/research.test.ts
+++ b/src/engine/__tests__/research.test.ts
@@ -76,7 +76,7 @@ describe('research engine', () => {
 
   it('unlocks radio after industry research', () => {
     const state: GameState = deepClone(defaultState);
-    state.resources.science.amount = 1000;
+    state.resources.science.amount = 2000;
     let s = startResearch(state, 'industry1');
     s = processResearchTick(s, RESEARCH_MAP['industry1'].timeSec);
     s = startResearch(s, 'woodworking1');


### PR DESCRIPTION
## Summary
- increase research costs for industrial and energy tech
- update radio unlock test to match new science costs

## Testing
- `npm test`
- `npm run lint`
- `npm run report:economy` *(fails: Object null prototype)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ef0199848331bdcc416cfac2ffa8