### PR TITLE
feat: improve popover positioning

### DIFF
--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -13,16 +13,18 @@ const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
 >(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
-  <PopoverPrimitive.Content
-    ref={ref}
-    align={align}
-    sideOffset={sideOffset}
-    className={cn(
-      'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-      className,
-    )}
-    {...props}
-  />
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className,
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
 ));
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 

--- a/src/views/research/ResearchNode.jsx
+++ b/src/views/research/ResearchNode.jsx
@@ -172,7 +172,6 @@ const ResearchNode = forwardRef(({ node, status, onStart }, ref) => {
         </div>
       </PopoverTrigger>
       <PopoverContent
-        side="bottom"
         align="center"
         onMouseLeave={() => !isTouch && setOpen(false)}
       >


### PR DESCRIPTION
## Summary
- Portal popover content outside scroll containers so overlays aren't clipped
- Let research node popovers choose direction automatically instead of hardcoding bottom

## Testing
- `npm test`
- `npm run lint`
- `npm run dev` *(manual check via `curl` for 200 OK response)*

------
https://chatgpt.com/codex/tasks/task_e_68a1fccb24088331a0cabb01fbaa657e